### PR TITLE
feat(algo-compendium): add Algorithm Compendium module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
     commit-message:
-      prefix: "chore(deps):"
-      prefix-development: "chore(deps):"
-      include: "scope"
+      prefix: 'chore(deps):'
+      prefix-development: 'chore(deps):'
+      include: 'scope'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           bun run --filter "bilbatez.dev" build
           bun run --filter "kprfordummies" build
+          bun run --filter "algo-compendium" build
       - name: Run Playwright tests
         run: bun run test
       - uses: actions/upload-artifact@v4

--- a/algo-compendium/CLAUDE.md
+++ b/algo-compendium/CLAUDE.md
@@ -1,0 +1,110 @@
+# algo-compendium
+
+Algorithm compendium SPA — complete reference and interactive visualizer for 63 algorithms across 8 categories.
+
+## Stack
+
+- **Runtime/package manager**: Bun (workspace member of monorepo root)
+- **Build tool**: Vite 6 (`@vitejs/plugin-react` + `@tailwindcss/vite`)
+- **Framework**: React 19 SPA via react-router-dom v7 (BrowserRouter, declarative)
+- **Language**: TypeScript 5, strict mode
+- **Styling**: Tailwind CSS v4 — CSS-only config via `@theme {}` in `app/globals.css`, no `tailwind.config.ts`
+- **Unit tests**: Vitest 3 (colocated `.test.ts` files, `environment: node`)
+- **E2E tests**: Playwright (shared root config, POM pattern, tests live in `../tests/algo-compendium/`)
+- **Dev port**: 3003
+
+## Directory Structure
+
+```
+algo-compendium/
+├── src/main.tsx              # Entry: BrowserRouter + all routes + algorithm registrations
+├── app/
+│   ├── globals.css           # @import 'tailwindcss' + @theme turquoise vars
+│   ├── Layout.tsx            # Full-screen layout: collapsible left sidebar + <Outlet />
+│   ├── Home.tsx              # 8 category cards
+│   ├── CategoryList.tsx      # Generic algorithm grid for a category
+│   ├── AlgorithmDetail.tsx   # Two-panel page: MetadataPanel + visualizer + pseudocode
+│   └── NotFound.tsx
+├── _algorithms/              # Pure algorithm logic (no React)
+│   ├── _shared/types.ts      # AlgorithmMeta<C,S>, VisualizerType, AlgorithmCategory
+│   ├── registry.ts           # registerAlgorithm(), getAlgorithm(), getAlgorithmsByCategory()
+│   ├── sorting/              # 13 algorithms + commands.ts + index.ts
+│   ├── searching/            # 7 algorithms + commands.ts + index.ts
+│   ├── graph/                # 10 algorithms + types.ts + commands.ts + index.ts
+│   ├── tree/                 # 8 algorithms + types.ts + commands.ts + index.ts
+│   ├── dynamic-programming/  # 8 algorithms + commands.ts + index.ts
+│   ├── backtracking/         # 5 algorithms + commands.ts + index.ts
+│   ├── string-matching/      # 5 algorithms + commands.ts + index.ts
+│   └── math/                 # 7 algorithms + commands.ts + index.ts
+├── _visualizers/             # React visualizer components (one per visualizer type)
+│   ├── ArrayVisualizer.tsx   # Sorting + Searching (bar chart)
+│   ├── TreeVisualizer.tsx    # Tree algorithms (SVG)
+│   ├── GraphVisualizer.tsx   # Graph algorithms (SVG)
+│   ├── GridVisualizer.tsx    # DP + Backtracking (HTML table)
+│   ├── StringVisualizer.tsx  # String Matching (character rows)
+│   └── MathVisualizer.tsx    # Math algorithms (adaptive display)
+└── _components/
+    ├── hooks/useAlgorithmPlayer.ts  # Generic playback hook (index, play/pause, speed)
+    ├── Controls.tsx          # Universal play/pause/step/speed/input controls
+    ├── MetadataPanel.tsx     # Complexity table + stable/in-place badges
+    ├── Pseudocode.tsx        # Collapsible monospace code block
+    ├── CategoryIcon.tsx      # Inline SVG icon per category
+    └── AlgorithmIcon.tsx     # Inline SVG icon per algorithm
+```
+
+## Commands
+
+```bash
+bun run dev          # dev server at http://localhost:3003
+bun run build        # tsc + vite build → dist/
+bun run preview      # serve dist/ at port 3003
+bun run prod         # build + preview
+bun run test         # Playwright e2e (from monorepo root)
+bun run test:unit    # Vitest unit tests (run once)
+bun run test:unit:watch  # Vitest watch mode
+```
+
+## Architecture: Command Pattern
+
+Every algorithm is a **pure function** → `Command[]`. The visualizer is a **pure reducer** `(state, cmd) => state`. Nothing in `_algorithms/` imports React.
+
+```
+Algorithm file: export function bubbleSortCommands(arr): SortCommand[]
+Registration:   registerAlgorithm({ name, slug, category, run, reduce, ... })
+Visualizer:     useAlgorithmPlayer(initialState, commands, reduce) → { currentState, play, ... }
+```
+
+- `run(input: S): C[]` — produces command sequence
+- `reduce(state: S, cmd: C): S` — pure reducer (no mutation)
+- `defaultInput: S` — initial state shown on page load
+- Step-back/forward: re-reduce commands `0..index` from `initialState`
+
+## Conventions
+
+- `_` prefix = private/internal (`_algorithms/`, `_components/`, `_visualizers/`)
+- Algorithm slugs: kebab-case, match URL segment (`bubble-sort`, `binary-search`)
+- Each algorithm file exports its pure function AND calls `registerAlgorithm()` as a side effect
+- `index.ts` per category imports all algorithm files to trigger registration
+- All algorithm imports happen in `src/main.tsx`
+- Commits follow Conventional Commits (enforced by commitlint at monorepo root)
+
+## Turquoise Theme
+
+```css
+--color-turquoise: #2ec4b6;
+--color-turquoise-dark: #1a9e91;
+--color-turquoise-light: #7ee4dc;
+```
+
+Use as: `bg-[var(--color-turquoise)]`, `text-[var(--color-turquoise-dark)]`
+
+Visualizer bar/node color states: gray (default) → yellow (comparing) → orange (swapping/active) → turquoise (sorted/visited/found) → purple (pivot/special)
+
+## Gotchas
+
+- Tailwind v4: no `tailwind.config.ts`. Custom colors go in `@theme {}` in `globals.css`.
+- `SortState.sorted` is `number[]` not `Set<number>` — `Set` breaks `useMemo` referential equality.
+- `useAlgorithmPlayer` resets index to `-1` when `commands` array reference changes (new input).
+- Algorithm registrations are side effects — missing import in `src/main.tsx` means the category shows 0 algorithms.
+- Vitest uses `environment: node` (not jsdom) — algorithm tests are pure TS with no DOM.
+- E2E tests in `../tests/algo-compendium/` use `@/algo-compendium/*` path alias (resolves via root `tests/tsconfig.json`).

--- a/algo-compendium/_algorithms/_shared/types.ts
+++ b/algo-compendium/_algorithms/_shared/types.ts
@@ -1,0 +1,42 @@
+export type VisualizerType =
+  | 'array' // Sorting, Searching
+  | 'graph' // Graph algorithms
+  | 'tree' // Tree algorithms
+  | 'grid' // DP, Backtracking
+  | 'string' // String Matching
+  | 'math'; // Math algorithms
+
+export type AlgorithmCategory =
+  | 'sorting'
+  | 'searching'
+  | 'graph'
+  | 'tree'
+  | 'dynamic-programming'
+  | 'string-matching'
+  | 'backtracking'
+  | 'math';
+
+export type AlgorithmMeta<C, S> = {
+  name: string;
+  slug: string;
+  category: AlgorithmCategory;
+  description: string;
+  bestCase: string;
+  averageCase: string;
+  worstCase: string;
+  spaceComplexity: string;
+  stable?: boolean;
+  inPlace?: boolean;
+  pseudocode: string;
+  visualizerType: VisualizerType;
+  defaultInput: S;
+  run: (input: S) => C[];
+  reduce: (state: S, cmd: C) => S;
+};
+
+export type CategoryMeta = {
+  slug: AlgorithmCategory;
+  name: string;
+  description: string;
+  algorithmCount: number;
+};

--- a/algo-compendium/_algorithms/backtracking/commands.ts
+++ b/algo-compendium/_algorithms/backtracking/commands.ts
@@ -1,0 +1,79 @@
+import type { GridState } from '../dynamic-programming/commands';
+
+// Re-export shared types and utilities
+export type { GridState, GridCell } from '../dynamic-programming/commands';
+export { makeGridState } from '../dynamic-programming/commands';
+
+// BacktrackCommand extends GridCommand to support string values in 'compute'
+// and adds a 'clear' command to reset a cell during backtracking
+export type BacktrackCommand =
+  | {
+      type: 'compute';
+      row: number;
+      col: number;
+      value: number | string;
+      description: string;
+    }
+  | { type: 'clear'; row: number; col: number; description: string }
+  | { type: 'highlight'; row: number; col: number; description: string }
+  | { type: 'trace'; cells: [number, number][]; description: string }
+  | { type: 'set_result'; result: number | string; description: string }
+  | { type: 'compare'; row: number; col: number; description: string };
+
+export function backtrackReducer(
+  state: GridState,
+  cmd: BacktrackCommand
+): GridState {
+  switch (cmd.type) {
+    case 'compute': {
+      const grid = state.grid.map((row, r) =>
+        row.map((cell, c) =>
+          r === cmd.row && c === cmd.col
+            ? { value: cmd.value, computed: true }
+            : cell
+        )
+      );
+      return {
+        ...state,
+        grid,
+        highlighted: [cmd.row, cmd.col],
+        description: cmd.description,
+      };
+    }
+    case 'clear': {
+      const grid = state.grid.map((row, r) =>
+        row.map((cell, c) =>
+          r === cmd.row && c === cmd.col
+            ? { value: null, computed: false }
+            : cell
+        )
+      );
+      return {
+        ...state,
+        grid,
+        highlighted: [cmd.row, cmd.col],
+        description: cmd.description,
+      };
+    }
+    case 'highlight':
+      return {
+        ...state,
+        highlighted: [cmd.row, cmd.col],
+        description: cmd.description,
+      };
+    case 'compare':
+      return {
+        ...state,
+        highlighted: [cmd.row, cmd.col],
+        description: cmd.description,
+      };
+    case 'trace':
+      return {
+        ...state,
+        tracePath: cmd.cells,
+        description: cmd.description,
+      };
+    case 'set_result':
+      return { ...state, result: cmd.result, description: cmd.description };
+  }
+}

--- a/algo-compendium/_algorithms/backtracking/index.ts
+++ b/algo-compendium/_algorithms/backtracking/index.ts
@@ -1,0 +1,5 @@
+import './n-queens';
+import './sudoku-solver';
+import './permutations';
+import './subsets';
+import './knights-tour';

--- a/algo-compendium/_algorithms/backtracking/knights-tour.test.ts
+++ b/algo-compendium/_algorithms/backtracking/knights-tour.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { knightsTourCommands } from './knights-tour';
+import { makeGridState, backtrackReducer } from './commands';
+
+const BOARD_SIZE = 5;
+
+function makeBoard() {
+  return makeGridState(
+    BOARD_SIZE,
+    BOARD_SIZE,
+    ['0', '1', '2', '3', '4'],
+    ['0', '1', '2', '3', '4']
+  );
+}
+
+describe('knightsTour', () => {
+  it('visits all 25 squares', () => {
+    const initial = makeBoard();
+    const cmds = knightsTourCommands(initial);
+    const result = cmds.reduce(backtrackReducer, initial);
+    // Count filled cells
+    let filled = 0;
+    for (let r = 0; r < BOARD_SIZE; r++) {
+      for (let c = 0; c < BOARD_SIZE; c++) {
+        if (result.grid[r][c].value !== null) filled++;
+      }
+    }
+    expect(filled).toBe(BOARD_SIZE * BOARD_SIZE);
+  });
+
+  it('each cell has a unique move number 1 to 25', () => {
+    const initial = makeBoard();
+    const cmds = knightsTourCommands(initial);
+    const result = cmds.reduce(backtrackReducer, initial);
+    const values = new Set<number>();
+    for (let r = 0; r < BOARD_SIZE; r++) {
+      for (let c = 0; c < BOARD_SIZE; c++) {
+        const v = result.grid[r][c].value;
+        if (typeof v === 'number') values.add(v);
+      }
+    }
+    expect(values.size).toBe(BOARD_SIZE * BOARD_SIZE);
+    expect(Math.min(...values)).toBe(1);
+    expect(Math.max(...values)).toBe(BOARD_SIZE * BOARD_SIZE);
+  });
+
+  it('sets result to Tour complete!', () => {
+    const initial = makeBoard();
+    const cmds = knightsTourCommands(initial);
+    const result = cmds.reduce(backtrackReducer, initial);
+    expect(result.result).toBe('Tour complete!');
+  });
+
+  it('emits compute commands for each move', () => {
+    const initial = makeBoard();
+    const cmds = knightsTourCommands(initial);
+    const computeCmds = cmds.filter((c) => c.type === 'compute');
+    expect(computeCmds.length).toBe(BOARD_SIZE * BOARD_SIZE);
+  });
+
+  it('reducer does not mutate state', () => {
+    const initial = makeBoard();
+    const cmds = knightsTourCommands(initial);
+    if (cmds.length > 0) {
+      const s1 = backtrackReducer(initial, cmds[0]);
+      expect(initial.result).toBeNull();
+      expect(s1).not.toBe(initial);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/backtracking/knights-tour.ts
+++ b/algo-compendium/_algorithms/backtracking/knights-tour.ts
@@ -1,0 +1,160 @@
+import { registerAlgorithm } from '../registry';
+import type { BacktrackCommand } from './commands';
+import { makeGridState, backtrackReducer } from './commands';
+import type { GridState } from './commands';
+
+const BOARD_SIZE = 5;
+
+// All 8 possible knight moves
+const MOVES: [number, number][] = [
+  [2, 1],
+  [1, 2],
+  [-1, 2],
+  [-2, 1],
+  [-2, -1],
+  [-1, -2],
+  [1, -2],
+  [2, -1],
+];
+
+function isValid(row: number, col: number, visited: boolean[][]): boolean {
+  return (
+    row >= 0 &&
+    row < BOARD_SIZE &&
+    col >= 0 &&
+    col < BOARD_SIZE &&
+    !visited[row][col]
+  );
+}
+
+// Warnsdorff's heuristic: pick the move with the fewest onward moves
+function getDegree(row: number, col: number, visited: boolean[][]): number {
+  let count = 0;
+  for (const [dr, dc] of MOVES) {
+    if (isValid(row + dr, col + dc, visited)) count++;
+  }
+  return count;
+}
+
+function findKnightsTour(
+  startRow: number,
+  startCol: number
+): [number, number][] | null {
+  const visited: boolean[][] = Array.from({ length: BOARD_SIZE }, () =>
+    new Array(BOARD_SIZE).fill(false)
+  );
+  const path: [number, number][] = [[startRow, startCol]];
+  visited[startRow][startCol] = true;
+  let row = startRow;
+  let col = startCol;
+
+  for (let move = 1; move < BOARD_SIZE * BOARD_SIZE; move++) {
+    // Get all valid next moves
+    const candidates: { row: number; col: number; degree: number }[] = [];
+    for (const [dr, dc] of MOVES) {
+      const nr = row + dr;
+      const nc = col + dc;
+      if (isValid(nr, nc, visited)) {
+        candidates.push({
+          row: nr,
+          col: nc,
+          degree: getDegree(nr, nc, visited),
+        });
+      }
+    }
+
+    if (candidates.length === 0) return null;
+
+    // Pick move with minimum degree (Warnsdorff's rule)
+    candidates.sort((a, b) => a.degree - b.degree);
+    const next = candidates[0];
+    visited[next.row][next.col] = true;
+    path.push([next.row, next.col]);
+    row = next.row;
+    col = next.col;
+  }
+
+  return path;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function knightsTourCommands(_state: GridState): BacktrackCommand[] {
+  const cmds: BacktrackCommand[] = [];
+
+  const tour = findKnightsTour(0, 0);
+
+  if (!tour) {
+    cmds.push({
+      type: 'set_result',
+      result: 'No tour found',
+      description: 'Warnsdorff heuristic failed to find a tour',
+    });
+    return cmds;
+  }
+
+  // Emit commands for each move in the tour
+  for (let i = 0; i < tour.length; i++) {
+    const [row, col] = tour[i];
+    const moveNumber = i + 1;
+
+    cmds.push({
+      type: 'highlight',
+      row,
+      col,
+      description: `Move ${moveNumber}: knight moves to (${row}, ${col})`,
+    });
+
+    cmds.push({
+      type: 'compute',
+      row,
+      col,
+      value: moveNumber,
+      description: `Place move number ${moveNumber} at (${row}, ${col})`,
+    });
+  }
+
+  // Trace the tour path
+  const traceCells: [number, number][] = tour.map(([r, c]) => [r, c]);
+  cmds.push({
+    type: 'trace',
+    cells: traceCells,
+    description: `Knight's tour complete: all ${BOARD_SIZE * BOARD_SIZE} squares visited`,
+  });
+
+  cmds.push({
+    type: 'set_result',
+    result: 'Tour complete!',
+    description: `Knight visited all ${BOARD_SIZE * BOARD_SIZE} squares`,
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: "Knight's Tour",
+  slug: 'knights-tour',
+  category: 'backtracking',
+  description:
+    "Finds a sequence of knight moves on a 5×5 chessboard such that the knight visits every square exactly once. Uses Warnsdorff's heuristic: always move to the square with the fewest onward moves.",
+  bestCase: 'O(8^n)',
+  averageCase: 'O(8^n)',
+  worstCase: 'O(8^n)',
+  spaceComplexity: 'O(n²)',
+  pseudocode: `function warnsdorff(row, col):
+  visited[row][col] = true
+  for move = 1 to n*n - 1:
+    candidates = valid next squares
+    sort candidates by number of onward moves (ascending)
+    next = candidates[0]  // fewest onward moves
+    visited[next.row][next.col] = true
+    move to next`,
+  visualizerType: 'grid',
+  defaultInput: makeGridState(
+    BOARD_SIZE,
+    BOARD_SIZE,
+    ['0', '1', '2', '3', '4'],
+    ['0', '1', '2', '3', '4']
+  ),
+  run: knightsTourCommands,
+  reduce: backtrackReducer,
+});

--- a/algo-compendium/_algorithms/backtracking/n-queens.test.ts
+++ b/algo-compendium/_algorithms/backtracking/n-queens.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { nQueensCommands } from './n-queens';
+import { makeGridState, backtrackReducer } from './commands';
+import type { BacktrackCommand } from './commands';
+
+function runAlgo(state: ReturnType<typeof makeGridState>) {
+  const cmds = nQueensCommands(state);
+  return cmds.reduce(backtrackReducer, state);
+}
+
+describe('N-Queens (4x4)', () => {
+  it('finds a solution (result === "Solution found!")', () => {
+    const state = makeGridState(
+      4,
+      4,
+      ['Row 0', 'Row 1', 'Row 2', 'Row 3'],
+      ['Col 0', 'Col 1', 'Col 2', 'Col 3']
+    );
+    const result = runAlgo(state);
+    expect(result.result).toBe('Solution found!');
+  });
+
+  it('trace contains exactly 4 queen positions', () => {
+    const state = makeGridState(
+      4,
+      4,
+      ['Row 0', 'Row 1', 'Row 2', 'Row 3'],
+      ['Col 0', 'Col 1', 'Col 2', 'Col 3']
+    );
+    const result = runAlgo(state);
+    expect(result.tracePath).toHaveLength(4);
+  });
+
+  it('places queens so each row has exactly one queen', () => {
+    const state = makeGridState(
+      4,
+      4,
+      ['Row 0', 'Row 1', 'Row 2', 'Row 3'],
+      ['Col 0', 'Col 1', 'Col 2', 'Col 3']
+    );
+    const result = runAlgo(state);
+    const tracedRows = result.tracePath.map(([r]) => r);
+    const uniqueRows = new Set(tracedRows);
+    expect(uniqueRows.size).toBe(4);
+  });
+
+  it('no two queens share a column', () => {
+    const state = makeGridState(
+      4,
+      4,
+      ['Row 0', 'Row 1', 'Row 2', 'Row 3'],
+      ['Col 0', 'Col 1', 'Col 2', 'Col 3']
+    );
+    const result = runAlgo(state);
+    const tracedCols = result.tracePath.map(([, c]) => c);
+    const uniqueCols = new Set(tracedCols);
+    expect(uniqueCols.size).toBe(4);
+  });
+
+  it('no two queens share a diagonal', () => {
+    const state = makeGridState(
+      4,
+      4,
+      ['Row 0', 'Row 1', 'Row 2', 'Row 3'],
+      ['Col 0', 'Col 1', 'Col 2', 'Col 3']
+    );
+    const result = runAlgo(state);
+    const positions = result.tracePath;
+    for (let i = 0; i < positions.length; i++) {
+      for (let j = i + 1; j < positions.length; j++) {
+        const [r1, c1] = positions[i];
+        const [r2, c2] = positions[j];
+        expect(Math.abs(r1 - r2)).not.toBe(Math.abs(c1 - c2));
+      }
+    }
+  });
+
+  it('produces commands (non-empty)', () => {
+    const state = makeGridState(
+      4,
+      4,
+      ['Row 0', 'Row 1', 'Row 2', 'Row 3'],
+      ['Col 0', 'Col 1', 'Col 2', 'Col 3']
+    );
+    const cmds = nQueensCommands(state);
+    expect(cmds.length).toBeGreaterThan(0);
+  });
+
+  it('reducer does not mutate original state', () => {
+    const state = makeGridState(
+      4,
+      4,
+      ['Row 0', 'Row 1', 'Row 2', 'Row 3'],
+      ['Col 0', 'Col 1', 'Col 2', 'Col 3']
+    );
+    const cmds = nQueensCommands(state);
+    const next = backtrackReducer(state, cmds[0] as BacktrackCommand);
+    expect(state.grid[0][0].value).toBeNull();
+    expect(next).not.toBe(state);
+  });
+});

--- a/algo-compendium/_algorithms/backtracking/n-queens.ts
+++ b/algo-compendium/_algorithms/backtracking/n-queens.ts
@@ -1,0 +1,118 @@
+import { registerAlgorithm } from '../registry';
+import type { GridState, BacktrackCommand } from './commands';
+import { makeGridState, backtrackReducer } from './commands';
+
+export function nQueensCommands(state: GridState): BacktrackCommand[] {
+  const cmds: BacktrackCommand[] = [];
+  const n = state.grid.length;
+  const queens: number[] = []; // queens[row] = col
+
+  function isSafe(row: number, col: number): boolean {
+    for (let r = 0; r < row; r++) {
+      const c = queens[r];
+      if (c === col || Math.abs(c - col) === Math.abs(r - row)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  let solved = false;
+
+  function solve(row: number): boolean {
+    if (row === n) {
+      return true;
+    }
+    for (let col = 0; col < n; col++) {
+      cmds.push({
+        type: 'highlight',
+        row,
+        col,
+        description: `Row ${row}: trying column ${col}`,
+      });
+
+      if (isSafe(row, col)) {
+        queens[row] = col;
+        cmds.push({
+          type: 'compute',
+          row,
+          col,
+          value: 'Q',
+          description: `Placed queen at (${row}, ${col})`,
+        });
+
+        if (solve(row + 1)) {
+          return true;
+        }
+
+        // Backtrack
+        queens.splice(row, 1);
+        cmds.push({
+          type: 'clear',
+          row,
+          col,
+          description: `Backtrack: removed queen from (${row}, ${col})`,
+        });
+      }
+    }
+    return false;
+  }
+
+  solved = solve(0);
+
+  if (solved) {
+    const solutionCells: [number, number][] = queens.map((col, row) => [
+      row,
+      col,
+    ]);
+    cmds.push({
+      type: 'trace',
+      cells: solutionCells,
+      description: `Solution found: ${queens.map((col, row) => `(${row},${col})`).join(', ')}`,
+    });
+    cmds.push({
+      type: 'set_result',
+      result: 'Solution found!',
+      description: `N-Queens solved for n=${n}`,
+    });
+  } else {
+    cmds.push({
+      type: 'set_result',
+      result: 'No solution',
+      description: `No solution exists for n=${n}`,
+    });
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'N-Queens',
+  slug: 'n-queens',
+  category: 'backtracking',
+  description:
+    'Place N queens on an N×N chessboard so that no two queens attack each other (no shared row, column, or diagonal). Uses backtracking to find the first valid arrangement.',
+  bestCase: 'O(N!)',
+  averageCase: 'O(N!)',
+  worstCase: 'O(N!)',
+  spaceComplexity: 'O(N)',
+  stable: false,
+  inPlace: true,
+  pseudocode: `function solve(row):
+  if row == N: return true  // solution found
+  for col = 0 to N-1:
+    if isSafe(row, col):
+      place queen at (row, col)
+      if solve(row + 1): return true
+      remove queen from (row, col)  // backtrack
+  return false`,
+  visualizerType: 'grid',
+  defaultInput: makeGridState(
+    4,
+    4,
+    ['Row 0', 'Row 1', 'Row 2', 'Row 3'],
+    ['Col 0', 'Col 1', 'Col 2', 'Col 3']
+  ),
+  run: nQueensCommands,
+  reduce: backtrackReducer,
+});

--- a/algo-compendium/_algorithms/backtracking/permutations.test.ts
+++ b/algo-compendium/_algorithms/backtracking/permutations.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { permutationsCommands } from './permutations';
+import { makeGridState, backtrackReducer } from './commands';
+
+function runAlgo(state: ReturnType<typeof makeGridState>) {
+  const cmds = permutationsCommands(state);
+  return cmds.reduce(backtrackReducer, state);
+}
+
+describe('Permutations of [1, 2, 3]', () => {
+  it('result is 6 (3! permutations)', () => {
+    const state = makeGridState(
+      6,
+      3,
+      ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'],
+      ['[0]', '[1]', '[2]']
+    );
+    const result = runAlgo(state);
+    expect(result.result).toBe(6);
+  });
+
+  it('fills all 6 rows of the grid', () => {
+    const state = makeGridState(
+      6,
+      3,
+      ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'],
+      ['[0]', '[1]', '[2]']
+    );
+    const result = runAlgo(state);
+    // Every row should have all 3 columns filled
+    for (let r = 0; r < 6; r++) {
+      const rowVals = result.grid[r].map((c) => c.value).sort();
+      expect(rowVals).toEqual([1, 2, 3]);
+    }
+  });
+
+  it('all permutations are unique', () => {
+    const state = makeGridState(
+      6,
+      3,
+      ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'],
+      ['[0]', '[1]', '[2]']
+    );
+    const result = runAlgo(state);
+    const perms = result.grid.map((row) => row.map((c) => c.value).join(','));
+    const unique = new Set(perms);
+    expect(unique.size).toBe(6);
+  });
+
+  it('each permutation contains elements 1, 2, 3', () => {
+    const state = makeGridState(
+      6,
+      3,
+      ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'],
+      ['[0]', '[1]', '[2]']
+    );
+    const result = runAlgo(state);
+    for (let r = 0; r < 6; r++) {
+      const vals = result.grid[r].map((c) => Number(c.value)).sort();
+      expect(vals).toEqual([1, 2, 3]);
+    }
+  });
+
+  it('produces commands (non-empty)', () => {
+    const state = makeGridState(
+      6,
+      3,
+      ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'],
+      ['[0]', '[1]', '[2]']
+    );
+    const cmds = permutationsCommands(state);
+    expect(cmds.length).toBeGreaterThan(0);
+  });
+});

--- a/algo-compendium/_algorithms/backtracking/permutations.ts
+++ b/algo-compendium/_algorithms/backtracking/permutations.ts
@@ -1,0 +1,87 @@
+import { registerAlgorithm } from '../registry';
+import type { GridState, BacktrackCommand } from './commands';
+import { makeGridState, backtrackReducer } from './commands';
+
+export function permutationsCommands(state: GridState): BacktrackCommand[] {
+  const cmds: BacktrackCommand[] = [];
+  const n = state.grid[0].length; // number of elements (cols)
+  const elements: number[] = Array.from({ length: n }, (_, i) => i + 1);
+  const arr = [...elements];
+  let resultRow = 0;
+  let permCount = 0;
+
+  function swap(i: number, j: number) {
+    cmds.push({
+      type: 'highlight',
+      row: resultRow,
+      col: i,
+      description: `Swapping positions ${i} and ${j}: [${arr.join(', ')}]`,
+    });
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+
+  function generate(start: number) {
+    if (start === n) {
+      // Record this permutation in the result row
+      for (let c = 0; c < n; c++) {
+        cmds.push({
+          type: 'compute',
+          row: resultRow,
+          col: c,
+          value: arr[c],
+          description: `Permutation ${permCount + 1}: [${arr.join(', ')}] — place ${arr[c]} at position ${c}`,
+        });
+      }
+      permCount++;
+      resultRow++;
+      return;
+    }
+
+    for (let i = start; i < n; i++) {
+      swap(start, i);
+      generate(start + 1);
+      swap(start, i); // restore
+    }
+  }
+
+  generate(0);
+
+  cmds.push({
+    type: 'set_result',
+    result: permCount,
+    description: `Found ${permCount} permutations of [${elements.join(', ')}] (${n}! = ${permCount})`,
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Permutations',
+  slug: 'permutations',
+  category: 'backtracking',
+  description:
+    'Generate all permutations of [1, 2, 3] using backtracking with in-place swapping. Each row in the grid shows one permutation.',
+  bestCase: 'O(n!)',
+  averageCase: 'O(n!)',
+  worstCase: 'O(n!)',
+  spaceComplexity: 'O(n)',
+  stable: false,
+  inPlace: true,
+  pseudocode: `function generate(start):
+  if start == n:
+    record permutation
+    return
+  for i = start to n-1:
+    swap(arr[start], arr[i])
+    generate(start + 1)
+    swap(arr[start], arr[i])  // backtrack`,
+  visualizerType: 'grid',
+  defaultInput: makeGridState(
+    6,
+    3,
+    ['p1', 'p2', 'p3', 'p4', 'p5', 'p6'],
+    ['[0]', '[1]', '[2]']
+  ),
+  run: permutationsCommands,
+  reduce: backtrackReducer,
+});

--- a/algo-compendium/_algorithms/backtracking/subsets.test.ts
+++ b/algo-compendium/_algorithms/backtracking/subsets.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { subsetsCommands } from './subsets';
+import { makeGridState, backtrackReducer } from './commands';
+
+function makeDefaultState() {
+  return makeGridState(
+    8,
+    3,
+    ['∅', '{1}', '{1,2}', '{1,2,3}', '{1,3}', '{2}', '{2,3}', '{3}'],
+    ['1', '2', '3']
+  );
+}
+
+function runAlgo(state: ReturnType<typeof makeGridState>) {
+  const cmds = subsetsCommands(state);
+  return cmds.reduce(backtrackReducer, state);
+}
+
+describe('Subsets of [1, 2, 3]', () => {
+  it('result is 8 (2^3 subsets)', () => {
+    const state = makeDefaultState();
+    const result = runAlgo(state);
+    expect(result.result).toBe(8);
+  });
+
+  it('produces commands (non-empty)', () => {
+    const state = makeDefaultState();
+    const cmds = subsetsCommands(state);
+    expect(cmds.length).toBeGreaterThan(0);
+  });
+
+  it('first row (empty subset) has no computed cells', () => {
+    const state = makeDefaultState();
+    const result = runAlgo(state);
+    // Row 0 = empty subset: no cells should have a computed value
+    const row0Computed = result.grid[0].filter(
+      (c) => c.computed && c.value !== null
+    );
+    expect(row0Computed).toHaveLength(0);
+  });
+
+  it('row 3 (full subset {1,2,3}) has all 3 cells filled', () => {
+    const state = makeDefaultState();
+    const result = runAlgo(state);
+    // Generation order: row 3 = {1,2,3}
+    const row3Vals = result.grid[3].map((c) => Number(c.value)).sort();
+    expect(row3Vals).toEqual([1, 2, 3]);
+  });
+
+  it('row 1 ({1}) has only element 1 filled', () => {
+    const state = makeDefaultState();
+    const result = runAlgo(state);
+    // Row 1 = {1}: only col 0 (element 1) should be computed
+    expect(Number(result.grid[1][0].value)).toBe(1);
+    expect(result.grid[1][1].value).toBeNull();
+    expect(result.grid[1][2].value).toBeNull();
+  });
+
+  it('subsets count matches 2^n formula', () => {
+    const state = makeDefaultState();
+    const cmds = subsetsCommands(state);
+    const result = cmds.reduce(backtrackReducer, state);
+    expect(result.result).toBe(Math.pow(2, 3));
+  });
+});

--- a/algo-compendium/_algorithms/backtracking/subsets.ts
+++ b/algo-compendium/_algorithms/backtracking/subsets.ts
@@ -1,0 +1,81 @@
+import { registerAlgorithm } from '../registry';
+import type { GridState, BacktrackCommand } from './commands';
+import { makeGridState, backtrackReducer } from './commands';
+
+export function subsetsCommands(state: GridState): BacktrackCommand[] {
+  const cmds: BacktrackCommand[] = [];
+  const n = state.grid[0].length; // number of elements
+  const elements: number[] = Array.from({ length: n }, (_, i) => i + 1);
+  const current: number[] = [];
+  let subsetRow = 0;
+  let subsetCount = 0;
+
+  function generate(start: number) {
+    // Record current subset in its row
+    for (let c = 0; c < n; c++) {
+      if (current.includes(elements[c])) {
+        cmds.push({
+          type: 'compute',
+          row: subsetRow,
+          col: c,
+          value: elements[c],
+          description: `Subset ${subsetCount + 1}: {${current.join(', ')}} — include ${elements[c]}`,
+        });
+      } else {
+        cmds.push({
+          type: 'highlight',
+          row: subsetRow,
+          col: c,
+          description: `Subset ${subsetCount + 1}: {${current.join(', ')}} — ${elements[c]} not included`,
+        });
+      }
+    }
+    subsetCount++;
+    subsetRow++;
+
+    for (let i = start; i < n; i++) {
+      current.push(elements[i]);
+      generate(i + 1);
+      current.pop(); // backtrack
+    }
+  }
+
+  generate(0);
+
+  cmds.push({
+    type: 'set_result',
+    result: subsetCount,
+    description: `Found ${subsetCount} subsets of [${elements.join(', ')}] (2^${n} = ${subsetCount})`,
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Subsets',
+  slug: 'subsets',
+  category: 'backtracking',
+  description:
+    'Generate all subsets (power set) of [1, 2, 3] using backtracking. Each row shows one subset, with included elements filled in.',
+  bestCase: 'O(2^n)',
+  averageCase: 'O(2^n)',
+  worstCase: 'O(2^n)',
+  spaceComplexity: 'O(n)',
+  stable: false,
+  inPlace: false,
+  pseudocode: `function generate(start):
+  record current subset
+  for i = start to n-1:
+    include elements[i]
+    generate(i + 1)
+    exclude elements[i]  // backtrack`,
+  visualizerType: 'grid',
+  defaultInput: makeGridState(
+    8,
+    3,
+    ['∅', '{1}', '{1,2}', '{1,2,3}', '{1,3}', '{2}', '{2,3}', '{3}'],
+    ['1', '2', '3']
+  ),
+  run: subsetsCommands,
+  reduce: backtrackReducer,
+});

--- a/algo-compendium/_algorithms/backtracking/sudoku-solver.test.ts
+++ b/algo-compendium/_algorithms/backtracking/sudoku-solver.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { sudokuCommands } from './sudoku-solver';
+import { makeGridState, backtrackReducer } from './commands';
+import type { GridState } from './commands';
+
+// 4x4 puzzle used as defaultInput
+const PUZZLE: number[][] = [
+  [3, 0, 0, 2],
+  [0, 0, 3, 0],
+  [0, 1, 0, 0],
+  [2, 0, 0, 1],
+];
+
+function makeSudokuState(): GridState {
+  const state = makeGridState(
+    4,
+    4,
+    ['Row 0', 'Row 1', 'Row 2', 'Row 3'],
+    ['Col 0', 'Col 1', 'Col 2', 'Col 3']
+  );
+  const grid = state.grid.map((row, r) =>
+    row.map((cell, c) =>
+      PUZZLE[r][c] !== 0 ? { value: PUZZLE[r][c], computed: true } : cell
+    )
+  );
+  return { ...state, grid };
+}
+
+describe('Sudoku Solver (4x4)', () => {
+  it('result is "Puzzle solved!"', () => {
+    const state = makeSudokuState();
+    const cmds = sudokuCommands(state);
+    const result = cmds.reduce(backtrackReducer, state);
+    expect(result.result).toBe('Puzzle solved!');
+  });
+
+  it('each row contains digits 1-4', () => {
+    const state = makeSudokuState();
+    const cmds = sudokuCommands(state);
+    const result = cmds.reduce(backtrackReducer, state);
+    for (let r = 0; r < 4; r++) {
+      const rowVals = result.grid[r].map((c) => Number(c.value)).sort();
+      expect(rowVals).toEqual([1, 2, 3, 4]);
+    }
+  });
+
+  it('each column contains digits 1-4', () => {
+    const state = makeSudokuState();
+    const cmds = sudokuCommands(state);
+    const result = cmds.reduce(backtrackReducer, state);
+    for (let c = 0; c < 4; c++) {
+      const colVals = result.grid.map((row) => Number(row[c].value)).sort();
+      expect(colVals).toEqual([1, 2, 3, 4]);
+    }
+  });
+
+  it('given cells are preserved', () => {
+    const state = makeSudokuState();
+    const cmds = sudokuCommands(state);
+    const result = cmds.reduce(backtrackReducer, state);
+    for (let r = 0; r < 4; r++) {
+      for (let c = 0; c < 4; c++) {
+        if (PUZZLE[r][c] !== 0) {
+          expect(Number(result.grid[r][c].value)).toBe(PUZZLE[r][c]);
+        }
+      }
+    }
+  });
+
+  it('produces commands (non-empty)', () => {
+    const state = makeSudokuState();
+    const cmds = sudokuCommands(state);
+    expect(cmds.length).toBeGreaterThan(0);
+  });
+});

--- a/algo-compendium/_algorithms/backtracking/sudoku-solver.ts
+++ b/algo-compendium/_algorithms/backtracking/sudoku-solver.ts
@@ -1,0 +1,160 @@
+import { registerAlgorithm } from '../registry';
+import type { GridState, BacktrackCommand } from './commands';
+import { makeGridState, backtrackReducer } from './commands';
+
+// 4x4 Sudoku: digits 1-4, 2x2 boxes
+// 0 = empty cell
+const PUZZLE: number[][] = [
+  [3, 0, 0, 2],
+  [0, 0, 3, 0],
+  [0, 1, 0, 0],
+  [2, 0, 0, 1],
+];
+
+export function sudokuCommands(state: GridState): BacktrackCommand[] {
+  const cmds: BacktrackCommand[] = [];
+  const size = state.grid.length; // 4
+  const boxSize = Math.sqrt(size); // 2
+
+  // Build working board from the state grid
+  const board: (number | null)[][] = state.grid.map((row) =>
+    row.map((cell) => (cell.value !== null ? Number(cell.value) : null))
+  );
+
+  function isValid(row: number, col: number, num: number): boolean {
+    // Check row
+    for (let c = 0; c < size; c++) {
+      if (board[row][c] === num) return false;
+    }
+    // Check column
+    for (let r = 0; r < size; r++) {
+      if (board[r][col] === num) return false;
+    }
+    // Check box
+    const boxRow = Math.floor(row / boxSize) * boxSize;
+    const boxCol = Math.floor(col / boxSize) * boxSize;
+    for (let r = boxRow; r < boxRow + boxSize; r++) {
+      for (let c = boxCol; c < boxCol + boxSize; c++) {
+        if (board[r][c] === num) return false;
+      }
+    }
+    return true;
+  }
+
+  function solve(): boolean {
+    for (let row = 0; row < size; row++) {
+      for (let col = 0; col < size; col++) {
+        if (board[row][col] === null) {
+          cmds.push({
+            type: 'highlight',
+            row,
+            col,
+            description: `Finding empty cell at (${row}, ${col})`,
+          });
+          for (let num = 1; num <= size; num++) {
+            cmds.push({
+              type: 'compare',
+              row,
+              col,
+              description: `Trying ${num} at (${row}, ${col})`,
+            });
+            if (isValid(row, col, num)) {
+              board[row][col] = num;
+              cmds.push({
+                type: 'compute',
+                row,
+                col,
+                value: num,
+                description: `Placed ${num} at (${row}, ${col})`,
+              });
+              if (solve()) return true;
+              // Backtrack
+              board[row][col] = null;
+              cmds.push({
+                type: 'clear',
+                row,
+                col,
+                description: `Backtrack: removed ${num} from (${row}, ${col})`,
+              });
+            }
+          }
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  const solved = solve();
+
+  if (solved) {
+    const solvedCells: [number, number][] = [];
+    for (let r = 0; r < size; r++) {
+      for (let c = 0; c < size; c++) {
+        solvedCells.push([r, c]);
+      }
+    }
+    cmds.push({
+      type: 'trace',
+      cells: solvedCells,
+      description: 'Sudoku solved!',
+    });
+    cmds.push({
+      type: 'set_result',
+      result: 'Puzzle solved!',
+      description: 'All cells filled correctly',
+    });
+  } else {
+    cmds.push({
+      type: 'set_result',
+      result: 'No solution',
+      description: 'Puzzle has no solution',
+    });
+  }
+
+  return cmds;
+}
+
+// Build initial state with puzzle pre-filled
+function makeSudokuState(): GridState {
+  const state = makeGridState(
+    4,
+    4,
+    ['Row 0', 'Row 1', 'Row 2', 'Row 3'],
+    ['Col 0', 'Col 1', 'Col 2', 'Col 3']
+  );
+  // Pre-fill given cells
+  const grid = state.grid.map((row, r) =>
+    row.map((cell, c) =>
+      PUZZLE[r][c] !== 0 ? { value: PUZZLE[r][c], computed: true } : cell
+    )
+  );
+  return { ...state, grid };
+}
+
+registerAlgorithm({
+  name: 'Sudoku Solver',
+  slug: 'sudoku-solver',
+  category: 'backtracking',
+  description:
+    'Solve a 4×4 Sudoku puzzle using backtracking. Each row, column, and 2×2 box must contain each digit from 1 to 4 exactly once.',
+  bestCase: 'O(1)',
+  averageCase: 'O(4^k)',
+  worstCase: 'O(4^16)',
+  spaceComplexity: 'O(1)',
+  stable: false,
+  inPlace: true,
+  pseudocode: `function solve():
+  find empty cell (row, col)
+  if none: return true  // solved
+  for num = 1 to 4:
+    if isValid(row, col, num):
+      board[row][col] = num
+      if solve(): return true
+      board[row][col] = 0  // backtrack
+  return false`,
+  visualizerType: 'grid',
+  defaultInput: makeSudokuState(),
+  run: sudokuCommands,
+  reduce: backtrackReducer,
+});

--- a/algo-compendium/_algorithms/dynamic-programming/coin-change.test.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/coin-change.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { coinChangeCommands } from './coin-change';
+import { makeGridState, gridReducer } from './commands';
+
+function runDP(coins: number[], amount: number) {
+  const initialState = {
+    ...makeGridState(
+      1,
+      amount + 1,
+      ['dp'],
+      Array.from({ length: amount + 1 }, (_, i) => String(i))
+    ),
+    coins,
+    amount,
+  };
+  const cmds = coinChangeCommands(initialState);
+  return cmds.reduce(gridReducer, initialState);
+}
+
+describe('Coin Change DP', () => {
+  it('finds min coins for amount 41 with coins [1,5,10,25]', () => {
+    const result = runDP([1, 5, 10, 25], 41);
+    // 25 + 10 + 5 + 1 = 4 coins
+    expect(result.result).toBe(4);
+  });
+
+  it('base case dp[0] = 0', () => {
+    const result = runDP([1, 5], 5);
+    expect(result.grid[0][0].value).toBe(0);
+  });
+
+  it('returns 1 for amount equal to a single coin', () => {
+    const result = runDP([5, 10], 5);
+    expect(result.result).toBe(1);
+  });
+
+  it('returns -1 for impossible amount', () => {
+    const result = runDP([2], 3);
+    expect(result.result).toBe(-1);
+  });
+
+  it('handles amount = 0', () => {
+    const result = runDP([1, 5], 0);
+    expect(result.result).toBe(0);
+  });
+
+  it('handles coins=[1] for various amounts', () => {
+    const result = runDP([1], 7);
+    expect(result.result).toBe(7);
+  });
+
+  it('handles larger amount with classic coins', () => {
+    // coins=[1,5,10,25], amount=30 => 25+5=2 coins
+    const result = runDP([1, 5, 10, 25], 30);
+    expect(result.result).toBe(2);
+  });
+});

--- a/algo-compendium/_algorithms/dynamic-programming/coin-change.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/coin-change.ts
@@ -1,0 +1,103 @@
+import { registerAlgorithm } from '../registry';
+import type { GridCommand, GridState } from './commands';
+import { makeGridState, gridReducer } from './commands';
+
+export function coinChangeCommands(state: GridState): GridCommand[] {
+  const cmds: GridCommand[] = [];
+  const coins = state.coins ?? [];
+  const amount = state.amount ?? 0;
+  const INF = amount + 1;
+
+  const dp: number[] = new Array(amount + 1).fill(INF);
+  dp[0] = 0;
+
+  // Base case
+  cmds.push({
+    type: 'compute',
+    row: 0,
+    col: 0,
+    value: 0,
+    description: 'Base case: dp[0] = 0 (0 coins needed for amount 0)',
+  });
+
+  for (let i = 1; i <= amount; i++) {
+    cmds.push({
+      type: 'highlight',
+      row: 0,
+      col: i,
+      description: `Computing dp[${i}] — min coins for amount ${i}`,
+    });
+
+    let best = INF;
+    for (const coin of coins) {
+      if (coin <= i && dp[i - coin] + 1 < best) {
+        best = dp[i - coin] + 1;
+        cmds.push({
+          type: 'compare',
+          row: 0,
+          col: i,
+          description: `Coin ${coin}: dp[${i - coin}] + 1 = ${dp[i - coin] + 1} (new best)`,
+        });
+      }
+    }
+
+    dp[i] = best;
+    const displayVal = dp[i] >= INF ? -1 : dp[i];
+    cmds.push({
+      type: 'compute',
+      row: 0,
+      col: i,
+      value: displayVal,
+      description:
+        dp[i] >= INF ? `dp[${i}] = -1 (impossible)` : `dp[${i}] = ${dp[i]}`,
+    });
+  }
+
+  const finalResult = dp[amount] >= INF ? -1 : dp[amount];
+  cmds.push({
+    type: 'set_result',
+    result: finalResult,
+    description:
+      finalResult === -1
+        ? `Amount ${amount} cannot be formed`
+        : `Min coins for ${amount} = ${finalResult}`,
+  });
+
+  return cmds;
+}
+
+const defaultCoins = [1, 5, 10, 25];
+const defaultAmount = 41;
+
+registerAlgorithm({
+  name: 'Coin Change',
+  slug: 'coin-change',
+  category: 'dynamic-programming',
+  description:
+    'Finds the minimum number of coins needed to make up a given amount. Uses a 1D DP array where dp[i] is the minimum coins required for amount i.',
+  bestCase: 'O(amount × coins)',
+  averageCase: 'O(amount × coins)',
+  worstCase: 'O(amount × coins)',
+  spaceComplexity: 'O(amount)',
+  stable: false,
+  inPlace: false,
+  pseudocode: `dp[0] = 0
+for i = 1 to amount:
+  for each coin:
+    if coin <= i:
+      dp[i] = min(dp[i], dp[i - coin] + 1)
+return dp[amount]`,
+  visualizerType: 'grid',
+  defaultInput: {
+    ...makeGridState(
+      1,
+      defaultAmount + 1,
+      ['dp'],
+      Array.from({ length: defaultAmount + 1 }, (_, i) => String(i))
+    ),
+    coins: defaultCoins,
+    amount: defaultAmount,
+  },
+  run: coinChangeCommands,
+  reduce: gridReducer,
+});

--- a/algo-compendium/_algorithms/dynamic-programming/commands.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/commands.ts
@@ -1,0 +1,95 @@
+export type GridCommand =
+  | {
+      type: 'compute';
+      row: number;
+      col: number;
+      value: number;
+      description: string;
+    }
+  | { type: 'highlight'; row: number; col: number; description: string }
+  | { type: 'trace'; cells: [number, number][]; description: string }
+  | { type: 'set_result'; result: number | string; description: string }
+  | { type: 'compare'; row: number; col: number; description: string };
+
+export type GridCell = {
+  value: number | string | null;
+  computed: boolean;
+};
+
+export type GridState = {
+  grid: GridCell[][];
+  rowLabels: string[];
+  colLabels: string[];
+  highlighted: [number, number] | null;
+  tracePath: [number, number][];
+  result: number | string | null;
+  description: string;
+  // DP-specific optional fields
+  targetN?: number;
+  s1?: string;
+  s2?: string;
+  items?: { w: number; v: number }[];
+  coins?: number[];
+  amount?: number;
+  arr?: number[];
+};
+
+export function makeGridState(
+  rows: number,
+  cols: number,
+  rowLabels?: string[],
+  colLabels?: string[]
+): GridState {
+  const grid: GridCell[][] = Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => ({ value: null, computed: false }))
+  );
+  return {
+    grid,
+    rowLabels: rowLabels ?? Array.from({ length: rows }, (_, i) => String(i)),
+    colLabels: colLabels ?? Array.from({ length: cols }, (_, i) => String(i)),
+    highlighted: null,
+    tracePath: [],
+    result: null,
+    description: 'Ready',
+  };
+}
+
+export function gridReducer(state: GridState, cmd: GridCommand): GridState {
+  switch (cmd.type) {
+    case 'compute': {
+      const grid = state.grid.map((row, r) =>
+        row.map((cell, c) =>
+          r === cmd.row && c === cmd.col
+            ? { value: cmd.value, computed: true }
+            : cell
+        )
+      );
+      return {
+        ...state,
+        grid,
+        highlighted: [cmd.row, cmd.col],
+        description: cmd.description,
+      };
+    }
+    case 'highlight':
+      return {
+        ...state,
+        highlighted: [cmd.row, cmd.col],
+        description: cmd.description,
+      };
+    case 'compare':
+      return {
+        ...state,
+        highlighted: [cmd.row, cmd.col],
+        description: cmd.description,
+      };
+    case 'trace':
+      return {
+        ...state,
+        tracePath: cmd.cells,
+        description: cmd.description,
+      };
+    case 'set_result':
+      return { ...state, result: cmd.result, description: cmd.description };
+  }
+}

--- a/algo-compendium/_algorithms/dynamic-programming/edit-distance.test.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/edit-distance.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { editDistanceCommands } from './edit-distance';
+import { makeGridState, gridReducer } from './commands';
+
+function runDP(s1: string, s2: string) {
+  const initialState = {
+    ...makeGridState(
+      s1.length + 1,
+      s2.length + 1,
+      ['', ...s1.split('')],
+      ['', ...s2.split('')]
+    ),
+    s1,
+    s2,
+  };
+  const cmds = editDistanceCommands(initialState);
+  return cmds.reduce(gridReducer, initialState);
+}
+
+describe('Edit Distance DP', () => {
+  it('computes edit distance between "kitten" and "sitting"', () => {
+    const result = runDP('kitten', 'sitting');
+    expect(result.result).toBe(3);
+  });
+
+  it('returns 0 for identical strings', () => {
+    const result = runDP('abc', 'abc');
+    expect(result.result).toBe(0);
+  });
+
+  it('returns length of s2 when s1 is empty', () => {
+    const result = runDP('', 'abc');
+    expect(result.result).toBe(3);
+  });
+
+  it('returns length of s1 when s2 is empty', () => {
+    const result = runDP('abc', '');
+    expect(result.result).toBe(3);
+  });
+
+  it('handles single character substitution', () => {
+    const result = runDP('a', 'b');
+    expect(result.result).toBe(1);
+  });
+
+  it('handles single character insertion', () => {
+    const result = runDP('', 'a');
+    expect(result.result).toBe(1);
+  });
+
+  it('fills base case row 0', () => {
+    const result = runDP('ab', 'cd');
+    expect(result.grid[0][0].value).toBe(0);
+    expect(result.grid[0][1].value).toBe(1);
+    expect(result.grid[0][2].value).toBe(2);
+  });
+
+  it('fills base case col 0', () => {
+    const result = runDP('ab', 'cd');
+    expect(result.grid[0][0].value).toBe(0);
+    expect(result.grid[1][0].value).toBe(1);
+    expect(result.grid[2][0].value).toBe(2);
+  });
+
+  it('computes "sunday" to "saturday" = 3', () => {
+    const result = runDP('sunday', 'saturday');
+    expect(result.result).toBe(3);
+  });
+});

--- a/algo-compendium/_algorithms/dynamic-programming/edit-distance.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/edit-distance.ts
@@ -1,0 +1,159 @@
+import { registerAlgorithm } from '../registry';
+import type { GridCommand, GridState } from './commands';
+import { makeGridState, gridReducer } from './commands';
+
+export function editDistanceCommands(state: GridState): GridCommand[] {
+  const cmds: GridCommand[] = [];
+  const s1 = state.s1 ?? '';
+  const s2 = state.s2 ?? '';
+  const m = s1.length;
+  const n = s2.length;
+
+  // dp[i][j] = edit distance between s1[0..i-1] and s2[0..j-1]
+  const dp: number[][] = Array.from({ length: m + 1 }, () =>
+    new Array(n + 1).fill(0)
+  );
+
+  // Base cases: row 0 (deletions from s1)
+  for (let i = 0; i <= m; i++) {
+    dp[i][0] = i;
+    cmds.push({
+      type: 'compute',
+      row: i,
+      col: 0,
+      value: i,
+      description: `Base: dp[${i}][0] = ${i} (delete ${i} chars)`,
+    });
+  }
+
+  // Base cases: col 0 (insertions into s1)
+  for (let j = 1; j <= n; j++) {
+    dp[0][j] = j;
+    cmds.push({
+      type: 'compute',
+      row: 0,
+      col: j,
+      value: j,
+      description: `Base: dp[0][${j}] = ${j} (insert ${j} chars)`,
+    });
+  }
+
+  // Fill DP table
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      cmds.push({
+        type: 'compare',
+        row: i,
+        col: j,
+        description: `Compare s1[${i - 1}]='${s1[i - 1]}' with s2[${j - 1}]='${s2[j - 1]}'`,
+      });
+      if (s1[i - 1] === s2[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1];
+        cmds.push({
+          type: 'compute',
+          row: i,
+          col: j,
+          value: dp[i][j],
+          description: `Match! dp[${i}][${j}] = dp[${i - 1}][${j - 1}] = ${dp[i][j]}`,
+        });
+      } else {
+        const del = dp[i - 1][j] + 1;
+        const ins = dp[i][j - 1] + 1;
+        const rep = dp[i - 1][j - 1] + 1;
+        dp[i][j] = Math.min(del, ins, rep);
+        cmds.push({
+          type: 'compute',
+          row: i,
+          col: j,
+          value: dp[i][j],
+          description: `dp[${i}][${j}] = min(del=${del}, ins=${ins}, rep=${rep}) = ${dp[i][j]}`,
+        });
+      }
+    }
+  }
+
+  // Traceback
+  const tracePath: [number, number][] = [];
+  let i = m;
+  let j = n;
+  while (i > 0 || j > 0) {
+    tracePath.push([i, j]);
+    if (i === 0) {
+      j--;
+    } else if (j === 0) {
+      i--;
+    } else if (s1[i - 1] === s2[j - 1]) {
+      i--;
+      j--;
+    } else {
+      const del = dp[i - 1][j];
+      const ins = dp[i][j - 1];
+      const rep = dp[i - 1][j - 1];
+      const minVal = Math.min(del, ins, rep);
+      if (rep === minVal) {
+        i--;
+        j--;
+      } else if (del === minVal) {
+        i--;
+      } else {
+        j--;
+      }
+    }
+  }
+  tracePath.push([0, 0]);
+
+  cmds.push({
+    type: 'trace',
+    cells: tracePath,
+    description: 'Traceback path highlighted',
+  });
+
+  cmds.push({
+    type: 'set_result',
+    result: dp[m][n],
+    description: `Edit distance between "${s1}" and "${s2}" = ${dp[m][n]}`,
+  });
+
+  return cmds;
+}
+
+const s1 = 'kitten';
+const s2 = 'sitting';
+
+registerAlgorithm({
+  name: 'Edit Distance',
+  slug: 'edit-distance',
+  category: 'dynamic-programming',
+  description:
+    'Computes the minimum number of single-character edits (insertions, deletions, substitutions) required to transform one string into another.',
+  bestCase: 'O(mn)',
+  averageCase: 'O(mn)',
+  worstCase: 'O(mn)',
+  spaceComplexity: 'O(mn)',
+  stable: false,
+  inPlace: false,
+  pseudocode: `for i = 0 to m: dp[i][0] = i
+for j = 0 to n: dp[0][j] = j
+for i = 1 to m:
+  for j = 1 to n:
+    if s1[i] == s2[j]:
+      dp[i][j] = dp[i-1][j-1]
+    else:
+      dp[i][j] = 1 + min(dp[i-1][j],   // delete
+                         dp[i][j-1],   // insert
+                         dp[i-1][j-1]) // replace
+return dp[m][n]`,
+  visualizerType: 'grid',
+  defaultInput: {
+    ...makeGridState(
+      s1.length + 1,
+      s2.length + 1,
+      ['', ...s1.split('')],
+      ['', ...s2.split('')]
+    ),
+    s1,
+    s2,
+  },
+  run: editDistanceCommands,
+  reduce: gridReducer,
+});

--- a/algo-compendium/_algorithms/dynamic-programming/fibonacci.test.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/fibonacci.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { fibonacciCommands } from './fibonacci';
+import { makeGridState, gridReducer } from './commands';
+
+function runDP(initialState: ReturnType<typeof makeGridState>) {
+  const cmds = fibonacciCommands(initialState);
+  return cmds.reduce(gridReducer, initialState);
+}
+
+describe('fibonacci DP', () => {
+  it('computes fib(10) = 55', () => {
+    const state = makeGridState(
+      1,
+      11,
+      ['dp'],
+      ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
+    );
+    const result = runDP(state);
+    expect(result.result).toBe(55);
+  });
+
+  it('fills the grid with correct Fibonacci values', () => {
+    const state = makeGridState(
+      1,
+      11,
+      ['dp'],
+      ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
+    );
+    const result = runDP(state);
+    const expected = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55];
+    expected.forEach((val, i) => {
+      expect(result.grid[0][i].value).toBe(val);
+    });
+  });
+
+  it('computes fib(0) = 0', () => {
+    const state = makeGridState(1, 1, ['dp'], ['0']);
+    const result = runDP(state);
+    expect(result.result).toBe(0);
+  });
+
+  it('computes fib(1) = 1', () => {
+    const state = makeGridState(1, 2, ['dp'], ['0', '1']);
+    const result = runDP(state);
+    expect(result.result).toBe(1);
+  });
+
+  it('computes fib(5) = 5', () => {
+    const state = makeGridState(1, 6, ['dp'], ['0', '1', '2', '3', '4', '5']);
+    const result = runDP(state);
+    expect(result.result).toBe(5);
+  });
+
+  it('reducer does not mutate state', () => {
+    const state = makeGridState(1, 4, ['dp'], ['0', '1', '2', '3']);
+    const cmds = fibonacciCommands(state);
+    const s1 = gridReducer(state, cmds[0]);
+    expect(state.grid[0][0].value).toBeNull();
+    expect(s1).not.toBe(state);
+  });
+});

--- a/algo-compendium/_algorithms/dynamic-programming/fibonacci.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/fibonacci.ts
@@ -1,0 +1,82 @@
+import { registerAlgorithm } from '../registry';
+import type { GridCommand, GridState } from './commands';
+import { makeGridState, gridReducer } from './commands';
+
+export function fibonacciCommands(state: GridState): GridCommand[] {
+  const cmds: GridCommand[] = [];
+  const n = state.grid[0].length - 1; // cols - 1
+  const dp: number[] = new Array(n + 1).fill(0);
+
+  // Base cases
+  dp[0] = 0;
+  cmds.push({
+    type: 'compute',
+    row: 0,
+    col: 0,
+    value: 0,
+    description: 'Base case: dp[0] = 0',
+  });
+
+  if (n >= 1) {
+    dp[1] = 1;
+    cmds.push({
+      type: 'compute',
+      row: 0,
+      col: 1,
+      value: 1,
+      description: 'Base case: dp[1] = 1',
+    });
+  }
+
+  for (let i = 2; i <= n; i++) {
+    cmds.push({
+      type: 'compare',
+      row: 0,
+      col: i,
+      description: `Computing dp[${i}] = dp[${i - 1}] + dp[${i - 2}] = ${dp[i - 1]} + ${dp[i - 2]}`,
+    });
+    dp[i] = dp[i - 1] + dp[i - 2];
+    cmds.push({
+      type: 'compute',
+      row: 0,
+      col: i,
+      value: dp[i],
+      description: `dp[${i}] = ${dp[i]}`,
+    });
+  }
+
+  cmds.push({
+    type: 'set_result',
+    result: dp[n],
+    description: `Fibonacci(${n}) = ${dp[n]}`,
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Fibonacci',
+  slug: 'fibonacci',
+  category: 'dynamic-programming',
+  description:
+    'Computes the nth Fibonacci number using bottom-up dynamic programming, storing all values in a 1D table to avoid redundant computation.',
+  bestCase: 'O(n)',
+  averageCase: 'O(n)',
+  worstCase: 'O(n)',
+  spaceComplexity: 'O(n)',
+  stable: false,
+  inPlace: false,
+  pseudocode: `dp[0] = 0, dp[1] = 1
+for i = 2 to n:
+  dp[i] = dp[i-1] + dp[i-2]
+return dp[n]`,
+  visualizerType: 'grid',
+  defaultInput: makeGridState(
+    1,
+    11,
+    ['dp'],
+    ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
+  ),
+  run: fibonacciCommands,
+  reduce: gridReducer,
+});

--- a/algo-compendium/_algorithms/dynamic-programming/index.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/index.ts
@@ -1,0 +1,8 @@
+import './fibonacci';
+import './lcs';
+import './knapsack';
+import './coin-change';
+import './lis';
+import './edit-distance';
+import './kadane';
+import './matrix-chain';

--- a/algo-compendium/_algorithms/dynamic-programming/kadane.test.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/kadane.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { kadaneCommands } from './kadane';
+import { makeGridState, gridReducer } from './commands';
+
+const ARR = [-2, 1, -3, 4, -1, 2, 1, -5];
+
+function makeKadaneState() {
+  const state = makeGridState(
+    2,
+    ARR.length,
+    ['arr', 'cur'],
+    ARR.map((_, i) => String(i))
+  );
+  const grid = state.grid.map((row, r) =>
+    row.map((cell, c) => (r === 0 ? { value: ARR[c], computed: true } : cell))
+  );
+  return { ...state, grid, arr: ARR };
+}
+
+describe('kadane', () => {
+  it('finds maximum subarray sum of 6', () => {
+    const initial = makeKadaneState();
+    const cmds = kadaneCommands(initial);
+    const result = cmds.reduce(gridReducer, initial);
+    // Max subarray is [4,-1,2,1] = 6
+    expect(result.result).toBe('Max sum: 6');
+  });
+
+  it('computes running values in row 1', () => {
+    const initial = makeKadaneState();
+    const cmds = kadaneCommands(initial);
+    const result = cmds.reduce(gridReducer, initial);
+    // Row 1 col 3 should have maxEndingHere=4
+    expect(result.grid[1][3].value).toBe(4);
+  });
+
+  it('sets a trace path', () => {
+    const initial = makeKadaneState();
+    const cmds = kadaneCommands(initial);
+    const result = cmds.reduce(gridReducer, initial);
+    expect(result.tracePath.length).toBeGreaterThan(0);
+  });
+
+  it('handles all negative array', () => {
+    const arr = [-3, -1, -2];
+    const state = {
+      ...makeGridState(
+        2,
+        arr.length,
+        ['arr', 'cur'],
+        arr.map((_, i) => String(i))
+      ),
+      grid: makeGridState(2, arr.length).grid.map((row, r) =>
+        row.map((cell, c) =>
+          r === 0 ? { value: arr[c], computed: true } : cell
+        )
+      ),
+      arr,
+    };
+    const cmds = kadaneCommands(state);
+    const result = cmds.reduce(gridReducer, state);
+    expect(result.result).toBe('Max sum: -1');
+  });
+
+  it('handles single element', () => {
+    const arr = [5];
+    const state = {
+      ...makeGridState(2, 1, ['arr', 'cur'], ['0']),
+      grid: [
+        [{ value: 5, computed: true }],
+        [{ value: null, computed: false }],
+      ],
+      arr,
+    };
+    const cmds = kadaneCommands(state);
+    const result = cmds.reduce(gridReducer, state);
+    expect(result.result).toBe('Max sum: 5');
+  });
+
+  it('reducer does not mutate state', () => {
+    const initial = makeKadaneState();
+    const cmds = kadaneCommands(initial);
+    if (cmds.length > 0) {
+      const s1 = gridReducer(initial, cmds[0]);
+      expect(initial.result).toBeNull();
+      expect(s1).not.toBe(initial);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/dynamic-programming/kadane.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/kadane.ts
@@ -1,0 +1,134 @@
+import { registerAlgorithm } from '../registry';
+import type { GridCommand, GridState } from './commands';
+import { makeGridState, gridReducer } from './commands';
+
+const ARR = [-2, 1, -3, 4, -1, 2, 1, -5];
+const COLS = ARR.length;
+
+function makeKadaneState(): GridState {
+  const state = makeGridState(
+    2,
+    COLS,
+    ['arr', 'cur'],
+    ARR.map((_, i) => String(i))
+  );
+  // Pre-fill row 0 with array values
+  const grid = state.grid.map((row, r) =>
+    row.map((cell, c) => (r === 0 ? { value: ARR[c], computed: true } : cell))
+  );
+  return { ...state, grid, arr: ARR };
+}
+
+export function kadaneCommands(state: GridState): GridCommand[] {
+  const cmds: GridCommand[] = [];
+  const arr = state.arr ?? ARR;
+  const n = arr.length;
+
+  if (n === 0) {
+    cmds.push({
+      type: 'set_result',
+      result: 'Max sum: 0',
+      description: 'Empty array',
+    });
+    return cmds;
+  }
+
+  let maxEndingHere = arr[0];
+  let maxSoFar = arr[0];
+  let bestStart = 0;
+  let bestEnd = 0;
+  let currentStart = 0;
+
+  cmds.push({
+    type: 'highlight',
+    row: 1,
+    col: 0,
+    description: `Initialize: maxEndingHere=${arr[0]}, maxSoFar=${arr[0]}`,
+  });
+  cmds.push({
+    type: 'compute',
+    row: 1,
+    col: 0,
+    value: arr[0],
+    description: `cur[0] = arr[0] = ${arr[0]}`,
+  });
+
+  for (let i = 1; i < n; i++) {
+    cmds.push({
+      type: 'highlight',
+      row: 0,
+      col: i,
+      description: `Consider arr[${i}]=${arr[i]}: maxEndingHere=${maxEndingHere}`,
+    });
+
+    const prev = maxEndingHere;
+    if (maxEndingHere + arr[i] < arr[i]) {
+      maxEndingHere = arr[i];
+      currentStart = i;
+    } else {
+      maxEndingHere = maxEndingHere + arr[i];
+    }
+
+    cmds.push({
+      type: 'compare',
+      row: 1,
+      col: i,
+      description: `maxEndingHere + arr[${i}] = ${prev} + ${arr[i]} = ${prev + arr[i]} vs arr[${i}]=${arr[i]}`,
+    });
+    cmds.push({
+      type: 'compute',
+      row: 1,
+      col: i,
+      value: maxEndingHere,
+      description: `cur[${i}] = ${maxEndingHere}`,
+    });
+
+    if (maxEndingHere > maxSoFar) {
+      maxSoFar = maxEndingHere;
+      bestStart = currentStart;
+      bestEnd = i;
+    }
+  }
+
+  // Trace the best subarray
+  const traceCells: [number, number][] = [];
+  for (let i = bestStart; i <= bestEnd; i++) {
+    traceCells.push([0, i]);
+    traceCells.push([1, i]);
+  }
+  cmds.push({
+    type: 'trace',
+    cells: traceCells,
+    description: `Best subarray: indices [${bestStart}..${bestEnd}], sum=${maxSoFar}`,
+  });
+
+  cmds.push({
+    type: 'set_result',
+    result: `Max sum: ${maxSoFar}`,
+    description: `Maximum subarray sum = ${maxSoFar}`,
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: "Kadane's Algorithm",
+  slug: 'kadane',
+  category: 'dynamic-programming',
+  description:
+    'Finds the contiguous subarray with the largest sum in O(n) time. At each position, decides whether to extend the current subarray or start fresh, keeping track of the best sum seen so far.',
+  bestCase: 'O(n)',
+  averageCase: 'O(n)',
+  worstCase: 'O(n)',
+  spaceComplexity: 'O(1)',
+  pseudocode: `maxEndingHere = arr[0]
+maxSoFar = arr[0]
+for i = 1 to n-1:
+  maxEndingHere = max(arr[i], maxEndingHere + arr[i])
+  maxSoFar = max(maxSoFar, maxEndingHere)
+return maxSoFar`,
+  visualizerType: 'grid',
+  defaultInput: makeKadaneState(),
+  run: kadaneCommands,
+  reduce: gridReducer,
+});

--- a/algo-compendium/_algorithms/dynamic-programming/knapsack.test.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/knapsack.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { knapsackCommands } from './knapsack';
+import { makeGridState, gridReducer } from './commands';
+
+function runDP(items: { w: number; v: number }[], W: number) {
+  const n = items.length;
+  const initialState = {
+    ...makeGridState(
+      n + 1,
+      W + 1,
+      ['∅', ...items.map((_, i) => `i${i + 1}`)],
+      Array.from({ length: W + 1 }, (_, i) => String(i))
+    ),
+    items,
+  };
+  const cmds = knapsackCommands(initialState);
+  return cmds.reduce(gridReducer, initialState);
+}
+
+describe('0/1 Knapsack DP', () => {
+  it('finds max value for default input', () => {
+    const items = [
+      { w: 2, v: 3 },
+      { w: 3, v: 4 },
+      { w: 4, v: 5 },
+      { w: 5, v: 6 },
+    ];
+    const result = runDP(items, 8);
+    // Optimal: items 1+2+4 => w=2+3+3=no, items 1(2,3)+2(3,4)+4? Let's trust algorithm
+    // w=2(3) + w=3(4) + ... best is items w:2,v:3 + w:3,v:4 + w:3?,
+    // Items: {2,3},{3,4},{4,5},{5,6} W=8
+    // Combinations: {2,3}+{3,4}+{3,4}? No, 0/1 each once
+    // {3,4}+{5,6} = w8 v10
+    // {2,3}+{3,4}+{3,4}? can't repeat — {2,3}+{6,9}? no
+    // {2,3}+{3,4} = w5 v7; remaining 3: item {3,4} = total w8 v11? Wait {2,3}+{3,4}+... item3 is {4,5}, w=2+3+4=9 > 8
+    // {3,4}+{5,6} = w=8 v=10
+    // {2,3}+{3,4} = w=5, v=7, + {3,4}? only 1 of each. remaining=3, item1 {2,3}: total {2,3}+{3,4}=w5,v7+ no more weight
+    // Actually: {2,3}+{6,9}? Not in items. Max is 10
+    expect(result.result).toBe(10);
+  });
+
+  it('initializes base row (no items) to 0', () => {
+    const items = [{ w: 1, v: 2 }];
+    const result = runDP(items, 3);
+    for (let c = 0; c <= 3; c++) {
+      expect(result.grid[0][c].value).toBe(0);
+    }
+  });
+
+  it('handles single item that fits', () => {
+    const items = [{ w: 2, v: 5 }];
+    const result = runDP(items, 3);
+    expect(result.result).toBe(5);
+  });
+
+  it('handles single item that does not fit', () => {
+    const items = [{ w: 5, v: 10 }];
+    const result = runDP(items, 3);
+    expect(result.result).toBe(0);
+  });
+
+  it('handles empty items', () => {
+    const result = runDP([], 5);
+    expect(result.result).toBe(0);
+  });
+
+  it('handles W=0', () => {
+    const items = [{ w: 2, v: 3 }];
+    const result = runDP(items, 0);
+    expect(result.result).toBe(0);
+  });
+});

--- a/algo-compendium/_algorithms/dynamic-programming/knapsack.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/knapsack.ts
@@ -1,0 +1,111 @@
+import { registerAlgorithm } from '../registry';
+import type { GridCommand, GridState } from './commands';
+import { makeGridState, gridReducer } from './commands';
+
+export function knapsackCommands(state: GridState): GridCommand[] {
+  const cmds: GridCommand[] = [];
+  const items = state.items ?? [];
+  const W = state.grid[0].length - 1; // cols - 1 = max capacity
+  const n = items.length;
+
+  // dp[i][w] = max value using first i items with capacity w
+  const dp: number[][] = Array.from({ length: n + 1 }, () =>
+    new Array(W + 1).fill(0)
+  );
+
+  // Initialize row 0 (no items)
+  for (let w = 0; w <= W; w++) {
+    cmds.push({
+      type: 'compute',
+      row: 0,
+      col: w,
+      value: 0,
+      description: `Base case: dp[0][${w}] = 0 (no items)`,
+    });
+  }
+
+  // Fill table
+  for (let i = 1; i <= n; i++) {
+    const item = items[i - 1];
+    for (let w = 0; w <= W; w++) {
+      cmds.push({
+        type: 'compare',
+        row: i,
+        col: w,
+        description: `Item ${i} (w=${item.w}, v=${item.v}), capacity=${w}`,
+      });
+      if (item.w > w) {
+        // Can't include item
+        dp[i][w] = dp[i - 1][w];
+        cmds.push({
+          type: 'compute',
+          row: i,
+          col: w,
+          value: dp[i][w],
+          description: `Item ${i} too heavy (${item.w} > ${w}), dp[${i}][${w}] = dp[${i - 1}][${w}] = ${dp[i][w]}`,
+        });
+      } else {
+        const withItem = dp[i - 1][w - item.w] + item.v;
+        const withoutItem = dp[i - 1][w];
+        dp[i][w] = Math.max(withItem, withoutItem);
+        cmds.push({
+          type: 'compute',
+          row: i,
+          col: w,
+          value: dp[i][w],
+          description: `dp[${i}][${w}] = max(${withoutItem}, ${withItem}) = ${dp[i][w]}`,
+        });
+      }
+    }
+  }
+
+  cmds.push({
+    type: 'set_result',
+    result: dp[n][W],
+    description: `Max value = ${dp[n][W]}`,
+  });
+
+  return cmds;
+}
+
+const defaultItems = [
+  { w: 2, v: 3 },
+  { w: 3, v: 4 },
+  { w: 4, v: 5 },
+  { w: 5, v: 6 },
+];
+const W = 8;
+
+registerAlgorithm({
+  name: '0/1 Knapsack',
+  slug: 'knapsack',
+  category: 'dynamic-programming',
+  description:
+    'Given items with weights and values, find the maximum total value that fits in a knapsack of capacity W. Each item can be taken at most once.',
+  bestCase: 'O(nW)',
+  averageCase: 'O(nW)',
+  worstCase: 'O(nW)',
+  spaceComplexity: 'O(nW)',
+  stable: false,
+  inPlace: false,
+  pseudocode: `for i = 1 to n:
+  for w = 0 to W:
+    if items[i].weight > w:
+      dp[i][w] = dp[i-1][w]
+    else:
+      dp[i][w] = max(dp[i-1][w],
+                     dp[i-1][w - items[i].w] + items[i].v)
+return dp[n][W]`,
+  visualizerType: 'grid',
+  defaultInput: {
+    ...makeGridState(
+      defaultItems.length + 1,
+      W + 1,
+      ['∅', ...defaultItems.map((_, i) => `i${i + 1}`)],
+      Array.from({ length: W + 1 }, (_, i) => String(i))
+    ),
+    items: defaultItems,
+  },
+  run: knapsackCommands,
+  reduce: gridReducer,
+});

--- a/algo-compendium/_algorithms/dynamic-programming/lcs.test.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/lcs.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { lcsCommands } from './lcs';
+import { makeGridState, gridReducer } from './commands';
+
+function runDP(s1: string, s2: string) {
+  const initialState = {
+    ...makeGridState(
+      s1.length + 1,
+      s2.length + 1,
+      ['', ...s1.split('')],
+      ['', ...s2.split('')]
+    ),
+    s1,
+    s2,
+  };
+  const cmds = lcsCommands(initialState);
+  return cmds.reduce(gridReducer, initialState);
+}
+
+describe('LCS DP', () => {
+  it('finds LCS of ABCBDAB and BDCABA', () => {
+    const result = runDP('ABCBDAB', 'BDCABA');
+    // LCS length should be 4 (BDAB or BCAB or BCBA)
+    expect(result.grid[7][6].value).toBe(4);
+  });
+
+  it('sets result to a non-empty string', () => {
+    const result = runDP('ABCBDAB', 'BDCABA');
+    expect(typeof result.result).toBe('string');
+    expect(result.result).not.toBe('(empty)');
+    expect((result.result as string).length).toBe(4);
+  });
+
+  it('handles identical strings', () => {
+    const result = runDP('ABC', 'ABC');
+    expect(result.result).toBe('ABC');
+  });
+
+  it('handles empty s1', () => {
+    const result = runDP('', 'ABC');
+    expect(result.result).toBe('(empty)');
+  });
+
+  it('handles empty s2', () => {
+    const result = runDP('ABC', '');
+    expect(result.result).toBe('(empty)');
+  });
+
+  it('handles no common characters', () => {
+    const result = runDP('ABC', 'DEF');
+    expect(result.result).toBe('(empty)');
+  });
+
+  it('fills base case row 0 with zeros', () => {
+    const result = runDP('AB', 'CD');
+    expect(result.grid[0][0].value).toBe(0);
+    expect(result.grid[0][1].value).toBe(0);
+    expect(result.grid[0][2].value).toBe(0);
+  });
+
+  it('fills base case col 0 with zeros', () => {
+    const result = runDP('AB', 'CD');
+    expect(result.grid[0][0].value).toBe(0);
+    expect(result.grid[1][0].value).toBe(0);
+    expect(result.grid[2][0].value).toBe(0);
+  });
+});

--- a/algo-compendium/_algorithms/dynamic-programming/lcs.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/lcs.ts
@@ -1,0 +1,136 @@
+import { registerAlgorithm } from '../registry';
+import type { GridCommand, GridState } from './commands';
+import { makeGridState, gridReducer } from './commands';
+
+export function lcsCommands(state: GridState): GridCommand[] {
+  const cmds: GridCommand[] = [];
+  const s1 = state.s1 ?? '';
+  const s2 = state.s2 ?? '';
+  const m = s1.length;
+  const n = s2.length;
+
+  // dp[i][j] = LCS length of s1[0..i-1] and s2[0..j-1]
+  const dp: number[][] = Array.from({ length: m + 1 }, () =>
+    new Array(n + 1).fill(0)
+  );
+
+  // Initialize row 0 and col 0 to 0
+  for (let j = 0; j <= n; j++) {
+    cmds.push({
+      type: 'compute',
+      row: 0,
+      col: j,
+      value: 0,
+      description: `Base case: dp[0][${j}] = 0`,
+    });
+  }
+  for (let i = 1; i <= m; i++) {
+    cmds.push({
+      type: 'compute',
+      row: i,
+      col: 0,
+      value: 0,
+      description: `Base case: dp[${i}][0] = 0`,
+    });
+  }
+
+  // Fill DP table
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      cmds.push({
+        type: 'compare',
+        row: i,
+        col: j,
+        description: `Compare s1[${i - 1}]='${s1[i - 1]}' with s2[${j - 1}]='${s2[j - 1]}'`,
+      });
+      if (s1[i - 1] === s2[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+        cmds.push({
+          type: 'compute',
+          row: i,
+          col: j,
+          value: dp[i][j],
+          description: `Match! dp[${i}][${j}] = dp[${i - 1}][${j - 1}] + 1 = ${dp[i][j]}`,
+        });
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+        cmds.push({
+          type: 'compute',
+          row: i,
+          col: j,
+          value: dp[i][j],
+          description: `No match. dp[${i}][${j}] = max(${dp[i - 1][j]}, ${dp[i][j - 1]}) = ${dp[i][j]}`,
+        });
+      }
+    }
+  }
+
+  // Traceback to find LCS string
+  const tracePath: [number, number][] = [];
+  let lcsStr = '';
+  let i = m;
+  let j = n;
+  while (i > 0 && j > 0) {
+    tracePath.push([i, j]);
+    if (s1[i - 1] === s2[j - 1]) {
+      lcsStr = s1[i - 1] + lcsStr;
+      i--;
+      j--;
+    } else if (dp[i - 1][j] > dp[i][j - 1]) {
+      i--;
+    } else {
+      j--;
+    }
+  }
+
+  cmds.push({
+    type: 'trace',
+    cells: tracePath,
+    description: `Traceback path highlighted`,
+  });
+
+  cmds.push({
+    type: 'set_result',
+    result: lcsStr || '(empty)',
+    description: `LCS = "${lcsStr}" (length ${dp[m][n]})`,
+  });
+
+  return cmds;
+}
+
+const s1 = 'ABCBDAB';
+const s2 = 'BDCABA';
+
+registerAlgorithm({
+  name: 'Longest Common Subsequence',
+  slug: 'lcs',
+  category: 'dynamic-programming',
+  description:
+    'Finds the longest subsequence common to two strings. Uses a 2D DP table where dp[i][j] is the LCS length of the first i characters of s1 and first j characters of s2.',
+  bestCase: 'O(mn)',
+  averageCase: 'O(mn)',
+  worstCase: 'O(mn)',
+  spaceComplexity: 'O(mn)',
+  stable: false,
+  inPlace: false,
+  pseudocode: `for i = 0 to m:
+  for j = 0 to n:
+    if s1[i] == s2[j]:
+      dp[i][j] = dp[i-1][j-1] + 1
+    else:
+      dp[i][j] = max(dp[i-1][j], dp[i][j-1])
+// traceback from dp[m][n]`,
+  visualizerType: 'grid',
+  defaultInput: {
+    ...makeGridState(
+      s1.length + 1,
+      s2.length + 1,
+      ['', ...s1.split('')],
+      ['', ...s2.split('')]
+    ),
+    s1,
+    s2,
+  },
+  run: lcsCommands,
+  reduce: gridReducer,
+});

--- a/algo-compendium/_algorithms/dynamic-programming/lis.test.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/lis.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { lisCommands } from './lis';
+import { makeGridState, gridReducer } from './commands';
+
+function runDP(arr: number[]) {
+  const initialState = {
+    ...makeGridState(1, arr.length || 1, ['dp'], arr.map(String)),
+    arr,
+  };
+  const cmds = lisCommands(initialState);
+  return cmds.reduce(gridReducer, initialState);
+}
+
+describe('LIS DP', () => {
+  it('finds LIS length for [10,9,2,5,3,7,101,18]', () => {
+    const result = runDP([10, 9, 2, 5, 3, 7, 101, 18]);
+    // LIS is [2,3,7,101] or [2,5,7,101] = length 4
+    expect(result.result).toBe(4);
+  });
+
+  it('handles already sorted array', () => {
+    const result = runDP([1, 2, 3, 4, 5]);
+    expect(result.result).toBe(5);
+  });
+
+  it('handles reverse sorted array', () => {
+    const result = runDP([5, 4, 3, 2, 1]);
+    expect(result.result).toBe(1);
+  });
+
+  it('handles single element', () => {
+    const result = runDP([42]);
+    expect(result.result).toBe(1);
+  });
+
+  it('handles empty array', () => {
+    const result = runDP([]);
+    expect(result.result).toBe(0);
+  });
+
+  it('handles all equal elements', () => {
+    const result = runDP([3, 3, 3]);
+    expect(result.result).toBe(1);
+  });
+
+  it('computes dp[i] values correctly for [3,1,2]', () => {
+    const result = runDP([3, 1, 2]);
+    // dp[0]=1 (3 alone), dp[1]=1 (1 alone), dp[2]=2 ([1,2])
+    expect(result.grid[0][0].value).toBe(1);
+    expect(result.grid[0][1].value).toBe(1);
+    expect(result.grid[0][2].value).toBe(2);
+    expect(result.result).toBe(2);
+  });
+});

--- a/algo-compendium/_algorithms/dynamic-programming/lis.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/lis.ts
@@ -1,0 +1,99 @@
+import { registerAlgorithm } from '../registry';
+import type { GridCommand, GridState } from './commands';
+import { makeGridState, gridReducer } from './commands';
+
+export function lisCommands(state: GridState): GridCommand[] {
+  const cmds: GridCommand[] = [];
+  const arr = state.arr ?? [];
+  const n = arr.length;
+
+  if (n === 0) {
+    cmds.push({
+      type: 'set_result',
+      result: 0,
+      description: 'Empty array — LIS length = 0',
+    });
+    return cmds;
+  }
+
+  // dp[i] = length of LIS ending at index i
+  const dp: number[] = new Array(n).fill(1);
+
+  // Initialize all cells to 1 (each element is a LIS of length 1)
+  for (let i = 0; i < n; i++) {
+    cmds.push({
+      type: 'compute',
+      row: 0,
+      col: i,
+      value: 1,
+      description: `dp[${i}] = 1 (LIS ending at arr[${i}]=${arr[i]} starts at 1)`,
+    });
+  }
+
+  // Fill DP table O(n²)
+  for (let i = 1; i < n; i++) {
+    for (let j = 0; j < i; j++) {
+      cmds.push({
+        type: 'compare',
+        row: 0,
+        col: j,
+        description: `Compare arr[${j}]=${arr[j]} with arr[${i}]=${arr[i]}`,
+      });
+      if (arr[j] < arr[i] && dp[j] + 1 > dp[i]) {
+        dp[i] = dp[j] + 1;
+        cmds.push({
+          type: 'compute',
+          row: 0,
+          col: i,
+          value: dp[i],
+          description: `arr[${j}]=${arr[j]} < arr[${i}]=${arr[i]}, update dp[${i}] = ${dp[i]}`,
+        });
+      }
+    }
+    cmds.push({
+      type: 'highlight',
+      row: 0,
+      col: i,
+      description: `dp[${i}] = ${dp[i]} (LIS ending at arr[${i}]=${arr[i]})`,
+    });
+  }
+
+  const lisLength = Math.max(...dp);
+  cmds.push({
+    type: 'set_result',
+    result: lisLength,
+    description: `Longest Increasing Subsequence length = ${lisLength}`,
+  });
+
+  return cmds;
+}
+
+const defaultArr = [10, 9, 2, 5, 3, 7, 101, 18];
+
+registerAlgorithm({
+  name: 'Longest Increasing Subsequence',
+  slug: 'lis',
+  category: 'dynamic-programming',
+  description:
+    'Finds the length of the longest strictly increasing subsequence in an array. Uses O(n²) DP where dp[i] is the LIS length ending at index i.',
+  bestCase: 'O(n²)',
+  averageCase: 'O(n²)',
+  worstCase: 'O(n²)',
+  spaceComplexity: 'O(n)',
+  stable: false,
+  inPlace: false,
+  pseudocode: `for i = 0 to n-1:
+  dp[i] = 1
+for i = 1 to n-1:
+  for j = 0 to i-1:
+    if arr[j] < arr[i]:
+      dp[i] = max(dp[i], dp[j] + 1)
+return max(dp)`,
+  visualizerType: 'grid',
+  defaultInput: {
+    ...makeGridState(1, defaultArr.length, ['dp'], defaultArr.map(String)),
+    arr: defaultArr,
+  },
+  run: lisCommands,
+  reduce: gridReducer,
+});

--- a/algo-compendium/_algorithms/dynamic-programming/matrix-chain.test.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/matrix-chain.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { matrixChainCommands } from './matrix-chain';
+import { makeGridState, gridReducer } from './commands';
+
+function makeMatrixChainState() {
+  return makeGridState(3, 3, ['A', 'B', 'C'], ['A', 'B', 'C']);
+}
+
+describe('matrixChain', () => {
+  it('computes correct minimum cost for dims [10,30,5,60]', () => {
+    // A(10x30), B(30x5), C(5x60)
+    // (AB)C: 10*30*5 + 10*5*60 = 1500 + 3000 = 4500
+    // A(BC): 30*5*60 + 10*30*60 = 9000 + 18000 = 27000
+    // Min = 4500
+    const initial = makeMatrixChainState();
+    const cmds = matrixChainCommands(initial);
+    const result = cmds.reduce(gridReducer, initial);
+    expect(result.result).toBe('Min cost: 4500');
+  });
+
+  it('sets dp[0][0] to 0 (base case)', () => {
+    const initial = makeMatrixChainState();
+    const cmds = matrixChainCommands(initial);
+    const result = cmds.reduce(gridReducer, initial);
+    expect(result.grid[0][0].value).toBe(0);
+  });
+
+  it('sets dp[1][1] to 0 (base case)', () => {
+    const initial = makeMatrixChainState();
+    const cmds = matrixChainCommands(initial);
+    const result = cmds.reduce(gridReducer, initial);
+    expect(result.grid[1][1].value).toBe(0);
+  });
+
+  it('sets dp[0][2] to optimal overall cost', () => {
+    const initial = makeMatrixChainState();
+    const cmds = matrixChainCommands(initial);
+    const result = cmds.reduce(gridReducer, initial);
+    expect(result.grid[0][2].value).toBe(4500);
+  });
+
+  it('sets trace path', () => {
+    const initial = makeMatrixChainState();
+    const cmds = matrixChainCommands(initial);
+    const result = cmds.reduce(gridReducer, initial);
+    expect(result.tracePath.length).toBeGreaterThan(0);
+  });
+
+  it('reducer does not mutate state', () => {
+    const initial = makeMatrixChainState();
+    const cmds = matrixChainCommands(initial);
+    if (cmds.length > 0) {
+      const s1 = gridReducer(initial, cmds[0]);
+      expect(initial.result).toBeNull();
+      expect(s1).not.toBe(initial);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/dynamic-programming/matrix-chain.ts
+++ b/algo-compendium/_algorithms/dynamic-programming/matrix-chain.ts
@@ -1,0 +1,110 @@
+import { registerAlgorithm } from '../registry';
+import type { GridCommand, GridState } from './commands';
+import { makeGridState, gridReducer } from './commands';
+
+// dims = [10, 30, 5, 60] means 3 matrices: A(10x30), B(30x5), C(5x60)
+const DIMS = [10, 30, 5, 60];
+const N = DIMS.length - 1; // 3 matrices
+
+function makeMatrixChainState(): GridState {
+  return makeGridState(N, N, ['A', 'B', 'C'], ['A', 'B', 'C']);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function matrixChainCommands(_state: GridState): GridCommand[] {
+  const cmds: GridCommand[] = [];
+  const dims = DIMS;
+  const n = dims.length - 1;
+
+  // dp[i][j] = min cost to multiply matrices i..j (0-indexed)
+  const dp: number[][] = Array.from({ length: n }, () => new Array(n).fill(0));
+
+  // Base case: single matrices cost 0
+  for (let i = 0; i < n; i++) {
+    cmds.push({
+      type: 'compute',
+      row: i,
+      col: i,
+      value: 0,
+      description: `Base case: dp[${i}][${i}] = 0 (single matrix)`,
+    });
+  }
+
+  // Fill for chain lengths 2, 3, ...
+  for (let len = 2; len <= n; len++) {
+    for (let i = 0; i <= n - len; i++) {
+      const j = i + len - 1;
+      dp[i][j] = Infinity;
+
+      cmds.push({
+        type: 'highlight',
+        row: i,
+        col: j,
+        description: `Compute dp[${i}][${j}]: min cost for matrices ${i}..${j}`,
+      });
+
+      for (let k = i; k < j; k++) {
+        cmds.push({
+          type: 'compare',
+          row: i,
+          col: j,
+          description: `Try split at k=${k}: cost = dp[${i}][${k}] + dp[${k + 1}][${j}] + ${dims[i]}×${dims[k + 1]}×${dims[j + 1]}`,
+        });
+
+        const cost =
+          dp[i][k] + dp[k + 1][j] + dims[i] * dims[k + 1] * dims[j + 1];
+
+        if (cost < dp[i][j]) {
+          dp[i][j] = cost;
+        }
+      }
+
+      cmds.push({
+        type: 'compute',
+        row: i,
+        col: j,
+        value: dp[i][j],
+        description: `dp[${i}][${j}] = ${dp[i][j]} (min multiplications)`,
+      });
+    }
+  }
+
+  // Trace optimal path
+  cmds.push({
+    type: 'trace',
+    cells: [[0, n - 1]],
+    description: `Optimal total cost at dp[0][${n - 1}] = ${dp[0][n - 1]}`,
+  });
+
+  cmds.push({
+    type: 'set_result',
+    result: `Min cost: ${dp[0][n - 1]}`,
+    description: `Minimum multiplications: ${dp[0][n - 1]}`,
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Matrix Chain Multiplication',
+  slug: 'matrix-chain',
+  category: 'dynamic-programming',
+  description:
+    'Finds the optimal order to multiply a chain of matrices to minimize the total number of scalar multiplications. Uses a DP table where dp[i][j] = min cost to multiply matrices i through j.',
+  bestCase: 'O(n³)',
+  averageCase: 'O(n³)',
+  worstCase: 'O(n³)',
+  spaceComplexity: 'O(n²)',
+  pseudocode: `for i = 0 to n-1: dp[i][i] = 0
+for len = 2 to n:
+  for i = 0 to n-len:
+    j = i + len - 1
+    dp[i][j] = ∞
+    for k = i to j-1:
+      cost = dp[i][k] + dp[k+1][j] + dims[i]*dims[k+1]*dims[j+1]
+      dp[i][j] = min(dp[i][j], cost)`,
+  visualizerType: 'grid',
+  defaultInput: makeMatrixChainState(),
+  run: matrixChainCommands,
+  reduce: gridReducer,
+});

--- a/algo-compendium/_algorithms/graph/a-star.test.ts
+++ b/algo-compendium/_algorithms/graph/a-star.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { aStarCommands } from './a-star';
+import { makeGraphState, graphReducer } from './commands';
+import type { Graph } from './types';
+
+const testGraph: Graph = {
+  nodes: [
+    { id: 's', label: 'S', x: 80, y: 200 },
+    { id: 'a', label: 'A', x: 220, y: 80 },
+    { id: 'b', label: 'B', x: 220, y: 320 },
+    { id: 'c', label: 'C', x: 380, y: 80 },
+    { id: 'd', label: 'D', x: 380, y: 320 },
+    { id: 'g', label: 'G', x: 520, y: 200 },
+  ],
+  edges: [
+    { from: 's', to: 'a', weight: 3 },
+    { from: 's', to: 'b', weight: 4 },
+    { from: 'a', to: 'c', weight: 3 },
+    { from: 'b', to: 'd', weight: 3 },
+    { from: 'c', to: 'g', weight: 2 },
+    { from: 'd', to: 'g', weight: 4 },
+    { from: 'a', to: 'b', weight: 2 },
+  ],
+  directed: false,
+  weighted: true,
+};
+
+describe('aStar', () => {
+  it('finds a path from s to g', () => {
+    const initial = makeGraphState(testGraph);
+    const cmds = aStarCommands(initial);
+    const result = cmds.reduce(graphReducer, initial);
+    expect(result.path.length).toBeGreaterThan(0);
+    expect(result.path[0]).toBe('s');
+    expect(result.path[result.path.length - 1]).toBe('g');
+  });
+
+  it('finds the optimal path cost (s→a→c→g = 3+3+2 = 8)', () => {
+    const initial = makeGraphState(testGraph);
+    const cmds = aStarCommands(initial);
+    const result = cmds.reduce(graphReducer, initial);
+    // Optimal path: s→a→c→g with cost 8
+    expect(result.distances['g']).toBe(8);
+  });
+
+  it('visits the source node', () => {
+    const initial = makeGraphState(testGraph);
+    const cmds = aStarCommands(initial);
+    const result = cmds.reduce(graphReducer, initial);
+    expect(result.visited).toContain('s');
+  });
+
+  it('handles empty graph', () => {
+    const emptyGraph: Graph = {
+      nodes: [],
+      edges: [],
+      directed: false,
+      weighted: true,
+    };
+    const initial = makeGraphState(emptyGraph);
+    const cmds = aStarCommands(initial);
+    expect(cmds).toHaveLength(0);
+  });
+
+  it('reducer does not mutate state', () => {
+    const initial = makeGraphState(testGraph);
+    const cmds = aStarCommands(initial);
+    if (cmds.length > 0) {
+      const s1 = graphReducer(initial, cmds[0]);
+      expect(initial.visited).toEqual([]);
+      expect(s1).not.toBe(initial);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/graph/a-star.ts
+++ b/algo-compendium/_algorithms/graph/a-star.ts
@@ -1,0 +1,194 @@
+import { registerAlgorithm } from '../registry';
+import type { GraphCommand, GraphState } from './commands';
+import { makeGraphState, graphReducer } from './commands';
+import type { Graph } from './types';
+
+const graph: Graph = {
+  nodes: [
+    { id: 's', label: 'S', x: 80, y: 200 },
+    { id: 'a', label: 'A', x: 220, y: 80 },
+    { id: 'b', label: 'B', x: 220, y: 320 },
+    { id: 'c', label: 'C', x: 380, y: 80 },
+    { id: 'd', label: 'D', x: 380, y: 320 },
+    { id: 'g', label: 'G', x: 520, y: 200 },
+  ],
+  edges: [
+    { from: 's', to: 'a', weight: 3 },
+    { from: 's', to: 'b', weight: 4 },
+    { from: 'a', to: 'c', weight: 3 },
+    { from: 'b', to: 'd', weight: 3 },
+    { from: 'c', to: 'g', weight: 2 },
+    { from: 'd', to: 'g', weight: 4 },
+    { from: 'a', to: 'b', weight: 2 },
+  ],
+  directed: false,
+  weighted: true,
+};
+
+export function aStarCommands(state: GraphState): GraphCommand[] {
+  const cmds: GraphCommand[] = [];
+  const { graph: g } = state;
+
+  if (g.nodes.length === 0) return cmds;
+
+  const sourceId = g.nodes[0].id;
+  const targetId = g.nodes[g.nodes.length - 1].id;
+
+  // Build node position map for heuristic
+  const pos: Record<string, { x: number; y: number }> = {};
+  for (const node of g.nodes) {
+    pos[node.id] = { x: node.x, y: node.y };
+  }
+
+  function heuristic(nodeId: string): number {
+    const a = pos[nodeId];
+    const b = pos[targetId];
+    return Math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2);
+  }
+
+  // Build adjacency list (undirected)
+  const adj: Record<string, { to: string; weight: number }[]> = {};
+  for (const node of g.nodes) adj[node.id] = [];
+  for (const edge of g.edges) {
+    adj[edge.from].push({ to: edge.to, weight: edge.weight ?? 1 });
+    if (!g.directed) {
+      adj[edge.to].push({ to: edge.from, weight: edge.weight ?? 1 });
+    }
+  }
+
+  const gScore: Record<string, number> = {};
+  const fScore: Record<string, number> = {};
+  const prev: Record<string, string | null> = {};
+
+  for (const node of g.nodes) {
+    gScore[node.id] = Infinity;
+    fScore[node.id] = Infinity;
+    prev[node.id] = null;
+  }
+
+  gScore[sourceId] = 0;
+  fScore[sourceId] = heuristic(sourceId);
+
+  cmds.push({
+    type: 'update_distance',
+    nodeId: sourceId,
+    distance: 0,
+    description: `Initialize: g[${sourceId}]=0, f[${sourceId}]=${fScore[sourceId].toFixed(1)}`,
+  });
+
+  const openSet = new Set<string>([sourceId]);
+  const closedSet = new Set<string>();
+
+  while (openSet.size > 0) {
+    // Find node in openSet with lowest fScore
+    let current: string | null = null;
+    let minF = Infinity;
+    for (const nodeId of openSet) {
+      if (fScore[nodeId] < minF) {
+        minF = fScore[nodeId];
+        current = nodeId;
+      }
+    }
+
+    if (!current) break;
+
+    if (current === targetId) {
+      cmds.push({
+        type: 'visit_node',
+        nodeId: current,
+        description: `Reached target ${current}! g=${gScore[current].toFixed(1)}`,
+      });
+      break;
+    }
+
+    openSet.delete(current);
+    closedSet.add(current);
+
+    cmds.push({
+      type: 'visit_node',
+      nodeId: current,
+      description: `Process ${current}: g=${gScore[current].toFixed(1)}, f=${fScore[current].toFixed(1)}`,
+    });
+    cmds.push({
+      type: 'finalize_node',
+      nodeId: current,
+      description: `Close ${current}`,
+    });
+
+    for (const { to: neighbor, weight } of adj[current] ?? []) {
+      if (closedSet.has(neighbor)) continue;
+
+      cmds.push({
+        type: 'visit_edge',
+        from: current,
+        to: neighbor,
+        description: `Explore edge ${current} → ${neighbor} (weight=${weight})`,
+      });
+
+      const tentativeG = gScore[current] + weight;
+
+      if (tentativeG < gScore[neighbor]) {
+        prev[neighbor] = current;
+        gScore[neighbor] = tentativeG;
+        fScore[neighbor] = tentativeG + heuristic(neighbor);
+
+        cmds.push({
+          type: 'update_distance',
+          nodeId: neighbor,
+          distance: tentativeG,
+          description: `Update ${neighbor}: g=${tentativeG.toFixed(1)}, h=${heuristic(neighbor).toFixed(1)}, f=${fScore[neighbor].toFixed(1)}`,
+        });
+
+        openSet.add(neighbor);
+      }
+    }
+  }
+
+  // Reconstruct path
+  const path: string[] = [];
+  let cur: string | null = targetId;
+  while (cur !== null) {
+    path.unshift(cur);
+    cur = prev[cur];
+  }
+
+  if (path[0] === sourceId) {
+    cmds.push({
+      type: 'mark_path',
+      nodes: path,
+      description: `Path: ${path.join(' → ')} (cost=${gScore[targetId].toFixed(1)})`,
+    });
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'A* Search',
+  slug: 'a-star',
+  category: 'graph',
+  description:
+    'A heuristic-guided pathfinding algorithm that finds the shortest path from source to target. Uses f(n) = g(n) + h(n) where g is the actual cost and h is a Euclidean distance heuristic.',
+  bestCase: 'O(b^d)',
+  averageCase: 'O(b^d)',
+  worstCase: 'O(b^d)',
+  spaceComplexity: 'O(b^d)',
+  pseudocode: `openSet = {start}
+g[start] = 0; f[start] = h(start)
+while openSet not empty:
+  current = node in openSet with lowest f
+  if current == goal: reconstruct path
+  move current to closedSet
+  for each neighbor of current:
+    if neighbor in closedSet: skip
+    tentative_g = g[current] + cost(current, neighbor)
+    if tentative_g < g[neighbor]:
+      prev[neighbor] = current
+      g[neighbor] = tentative_g
+      f[neighbor] = g[neighbor] + h(neighbor)
+      add neighbor to openSet`,
+  visualizerType: 'graph',
+  defaultInput: makeGraphState(graph),
+  run: aStarCommands,
+  reduce: graphReducer,
+});

--- a/algo-compendium/_algorithms/graph/bellman-ford.test.ts
+++ b/algo-compendium/_algorithms/graph/bellman-ford.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { bellmanFordCommands } from './bellman-ford';
+import { makeGraphState, graphReducer } from './commands';
+import type { GraphCommand, GraphState } from './commands';
+import { DIRECTED_WEIGHTED } from './types';
+
+function runGraph(commands: GraphCommand[], initial: GraphState): GraphState {
+  return commands.reduce(graphReducer, initial);
+}
+
+describe('Bellman-Ford', () => {
+  it('computes correct shortest distances from A', () => {
+    const initial = makeGraphState(DIRECTED_WEIGHTED);
+    const cmds = bellmanFordCommands(initial);
+    const result = runGraph(cmds, initial);
+
+    // Same expected distances as Dijkstra: A=0, B=4, C=2, D=7, E=7, F=9
+    expect(result.distances['A']).toBe(0);
+    expect(result.distances['B']).toBe(4);
+    expect(result.distances['C']).toBe(2);
+    expect(result.distances['D']).toBe(7);
+    expect(result.distances['E']).toBe(7);
+    expect(result.distances['F']).toBe(9);
+  });
+
+  it('finalizes all reachable nodes', () => {
+    const initial = makeGraphState(DIRECTED_WEIGHTED);
+    const cmds = bellmanFordCommands(initial);
+    const result = runGraph(cmds, initial);
+    expect(result.finalized.length).toBeGreaterThan(0);
+  });
+
+  it('handles empty graph', () => {
+    const emptyGraph = { directed: true, weighted: true, nodes: [], edges: [] };
+    const initial = makeGraphState(emptyGraph);
+    const cmds = bellmanFordCommands(initial);
+    expect(cmds).toHaveLength(0);
+  });
+});

--- a/algo-compendium/_algorithms/graph/bellman-ford.ts
+++ b/algo-compendium/_algorithms/graph/bellman-ford.ts
@@ -1,0 +1,99 @@
+import { registerAlgorithm } from '../registry';
+import type { GraphCommand, GraphState } from './commands';
+import { makeGraphState, graphReducer } from './commands';
+import { DIRECTED_WEIGHTED } from './types';
+
+export function bellmanFordCommands(state: GraphState): GraphCommand[] {
+  const cmds: GraphCommand[] = [];
+  const { graph } = state;
+
+  if (graph.nodes.length === 0) return cmds;
+
+  const sourceId = graph.nodes[0].id;
+  const V = graph.nodes.length;
+
+  // Initialize distances
+  const dist: Record<string, number> = {};
+  for (const node of graph.nodes) {
+    dist[node.id] = Infinity;
+  }
+  dist[sourceId] = 0;
+
+  cmds.push({
+    type: 'update_distance',
+    nodeId: sourceId,
+    distance: 0,
+    description: `Initialize: dist[${sourceId}] = 0, all others = ∞`,
+  });
+
+  // Relax all edges V-1 times
+  for (let i = 0; i < V - 1; i++) {
+    let updated = false;
+    for (const edge of graph.edges) {
+      const u = edge.from;
+      const v = edge.to;
+      const w = edge.weight ?? 1;
+
+      if (dist[u] !== Infinity) {
+        cmds.push({
+          type: 'visit_edge',
+          from: u,
+          to: v,
+          description: `Iteration ${i + 1}: Relax edge ${u} → ${v} (weight=${w})`,
+        });
+
+        if (dist[u] + w < dist[v]) {
+          dist[v] = dist[u] + w;
+          updated = true;
+          cmds.push({
+            type: 'update_distance',
+            nodeId: v,
+            distance: dist[v],
+            description: `Update dist[${v}] = ${dist[v]}`,
+          });
+        }
+      }
+    }
+
+    if (!updated) break; // Early exit if no updates
+  }
+
+  // Finalize all reachable nodes
+  for (const node of graph.nodes) {
+    if (dist[node.id] !== Infinity) {
+      cmds.push({
+        type: 'finalize_node',
+        nodeId: node.id,
+        description: `Node ${node.id}: final dist = ${dist[node.id]}`,
+      });
+    }
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Bellman-Ford',
+  slug: 'bellman-ford',
+  category: 'graph',
+  description:
+    'Finds shortest paths from a source to all vertices, handling negative edge weights. Detects negative cycles. Slower than Dijkstra but more versatile.',
+  bestCase: 'O(V)',
+  averageCase: 'O(VE)',
+  worstCase: 'O(VE)',
+  spaceComplexity: 'O(V)',
+  pseudocode: `BellmanFord(graph, source):
+  dist[source] = 0, dist[v] = ∞ for all others
+  repeat V-1 times:
+    for each edge (u, v, w):
+      if dist[u] + w < dist[v]:
+        dist[v] = dist[u] + w
+  // Check for negative cycles:
+  for each edge (u, v, w):
+    if dist[u] + w < dist[v]:
+      report negative cycle`,
+  visualizerType: 'graph',
+  defaultInput: makeGraphState(DIRECTED_WEIGHTED),
+  run: bellmanFordCommands,
+  reduce: graphReducer,
+});

--- a/algo-compendium/_algorithms/graph/bfs.test.ts
+++ b/algo-compendium/_algorithms/graph/bfs.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { bfsCommands } from './bfs';
+import { makeGraphState, graphReducer } from './commands';
+import type { GraphCommand, GraphState } from './commands';
+import { UNDIRECTED_UNWEIGHTED } from './types';
+
+function runGraph(commands: GraphCommand[], initial: GraphState): GraphState {
+  return commands.reduce(graphReducer, initial);
+}
+
+describe('BFS', () => {
+  it('visits all nodes in an undirected graph', () => {
+    const initial = makeGraphState(UNDIRECTED_UNWEIGHTED);
+    const cmds = bfsCommands(initial);
+    const result = runGraph(cmds, initial);
+    expect(result.visited).toHaveLength(UNDIRECTED_UNWEIGHTED.nodes.length);
+  });
+
+  it('visits nodes in BFS order starting from first node', () => {
+    const initial = makeGraphState(UNDIRECTED_UNWEIGHTED);
+    const cmds = bfsCommands(initial);
+    const result = runGraph(cmds, initial);
+    expect(result.visited[0]).toBe('A');
+  });
+
+  it('handles empty graph', () => {
+    const emptyGraph = {
+      directed: false,
+      weighted: false,
+      nodes: [],
+      edges: [],
+    };
+    const initial = makeGraphState(emptyGraph);
+    const cmds = bfsCommands(initial);
+    expect(cmds).toHaveLength(0);
+  });
+
+  it('generates visit_edge commands', () => {
+    const initial = makeGraphState(UNDIRECTED_UNWEIGHTED);
+    const cmds = bfsCommands(initial);
+    const edgeCmds = cmds.filter((c) => c.type === 'visit_edge');
+    expect(edgeCmds.length).toBeGreaterThan(0);
+  });
+});

--- a/algo-compendium/_algorithms/graph/bfs.ts
+++ b/algo-compendium/_algorithms/graph/bfs.ts
@@ -1,0 +1,81 @@
+import { registerAlgorithm } from '../registry';
+import type { GraphCommand, GraphState } from './commands';
+import { makeGraphState, graphReducer } from './commands';
+import { UNDIRECTED_UNWEIGHTED } from './types';
+
+export function bfsCommands(state: GraphState): GraphCommand[] {
+  const cmds: GraphCommand[] = [];
+  const { graph } = state;
+
+  if (graph.nodes.length === 0) return cmds;
+
+  const startId = graph.nodes[0].id;
+  const visited = new Set<string>();
+  const queue: string[] = [startId];
+  visited.add(startId);
+
+  // Build adjacency list
+  const adj: Record<string, string[]> = {};
+  for (const node of graph.nodes) adj[node.id] = [];
+  for (const edge of graph.edges) {
+    adj[edge.from].push(edge.to);
+    if (!graph.directed) adj[edge.to].push(edge.from);
+  }
+
+  cmds.push({
+    type: 'visit_node',
+    nodeId: startId,
+    description: `BFS: Start at node ${startId}`,
+  });
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const neighbors = adj[current] ?? [];
+
+    for (const neighbor of neighbors) {
+      cmds.push({
+        type: 'visit_edge',
+        from: current,
+        to: neighbor,
+        description: `Explore edge ${current} → ${neighbor}`,
+      });
+
+      if (!visited.has(neighbor)) {
+        visited.add(neighbor);
+        queue.push(neighbor);
+        cmds.push({
+          type: 'visit_node',
+          nodeId: neighbor,
+          description: `BFS: Visit node ${neighbor} (from ${current})`,
+        });
+      }
+    }
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Breadth-First Search',
+  slug: 'bfs',
+  category: 'graph',
+  description:
+    'Explores a graph level by level from the start node, visiting all neighbors before moving deeper. Finds shortest path in unweighted graphs.',
+  bestCase: 'O(V+E)',
+  averageCase: 'O(V+E)',
+  worstCase: 'O(V+E)',
+  spaceComplexity: 'O(V)',
+  pseudocode: `BFS(graph, start):
+  queue = [start]
+  visited = {start}
+  while queue not empty:
+    node = queue.dequeue()
+    for each neighbor of node:
+      if neighbor not in visited:
+        visited.add(neighbor)
+        queue.enqueue(neighbor)`,
+  visualizerType: 'graph',
+  defaultInput: makeGraphState(UNDIRECTED_UNWEIGHTED),
+  run: bfsCommands,
+  reduce: graphReducer,
+});

--- a/algo-compendium/_algorithms/graph/commands.ts
+++ b/algo-compendium/_algorithms/graph/commands.ts
@@ -1,0 +1,85 @@
+import type { Graph } from './types';
+
+export type GraphCommand =
+  | { type: 'visit_node'; nodeId: string; description: string }
+  | { type: 'visit_edge'; from: string; to: string; description: string }
+  | {
+      type: 'update_distance';
+      nodeId: string;
+      distance: number;
+      description: string;
+    }
+  | { type: 'mark_path'; nodes: string[]; description: string }
+  | { type: 'mark_mst_edge'; from: string; to: string; description: string }
+  | { type: 'finalize_node'; nodeId: string; description: string }
+  | { type: 'set_result'; result: string[]; description: string };
+
+export type GraphState = {
+  graph: Graph;
+  visited: string[]; // visited node IDs
+  visitedEdges: [string, string][]; // [from, to] pairs
+  current: string | null; // current node
+  distances: Record<string, number>; // for Dijkstra/Bellman-Ford
+  path: string[]; // highlighted path
+  mstEdges: [string, string][]; // MST edges
+  finalized: string[]; // finalized/done nodes
+  result: string[]; // topological order or other ordered result
+  description: string;
+};
+
+export function makeGraphState(graph: Graph): GraphState {
+  const distances: Record<string, number> = {};
+  graph.nodes.forEach((n) => {
+    distances[n.id] = Infinity;
+  });
+  return {
+    graph,
+    visited: [],
+    visitedEdges: [],
+    current: null,
+    distances,
+    path: [],
+    mstEdges: [],
+    finalized: [],
+    result: [],
+    description: 'Ready',
+  };
+}
+
+export function graphReducer(state: GraphState, cmd: GraphCommand): GraphState {
+  switch (cmd.type) {
+    case 'visit_node':
+      return {
+        ...state,
+        visited: [...new Set([...state.visited, cmd.nodeId])],
+        current: cmd.nodeId,
+        description: cmd.description,
+      };
+    case 'visit_edge':
+      return {
+        ...state,
+        visitedEdges: [...state.visitedEdges, [cmd.from, cmd.to]],
+        description: cmd.description,
+      };
+    case 'update_distance': {
+      const distances = { ...state.distances, [cmd.nodeId]: cmd.distance };
+      return { ...state, distances, description: cmd.description };
+    }
+    case 'mark_path':
+      return { ...state, path: cmd.nodes, description: cmd.description };
+    case 'mark_mst_edge':
+      return {
+        ...state,
+        mstEdges: [...state.mstEdges, [cmd.from, cmd.to]],
+        description: cmd.description,
+      };
+    case 'finalize_node':
+      return {
+        ...state,
+        finalized: [...state.finalized, cmd.nodeId],
+        description: cmd.description,
+      };
+    case 'set_result':
+      return { ...state, result: cmd.result, description: cmd.description };
+  }
+}

--- a/algo-compendium/_algorithms/graph/dfs.test.ts
+++ b/algo-compendium/_algorithms/graph/dfs.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { dfsCommands } from './dfs';
+import { makeGraphState, graphReducer } from './commands';
+import type { GraphCommand, GraphState } from './commands';
+import { UNDIRECTED_UNWEIGHTED } from './types';
+
+function runGraph(commands: GraphCommand[], initial: GraphState): GraphState {
+  return commands.reduce(graphReducer, initial);
+}
+
+describe('DFS', () => {
+  it('visits all nodes in an undirected graph', () => {
+    const initial = makeGraphState(UNDIRECTED_UNWEIGHTED);
+    const cmds = dfsCommands(initial);
+    const result = runGraph(cmds, initial);
+    expect(result.visited).toHaveLength(UNDIRECTED_UNWEIGHTED.nodes.length);
+  });
+
+  it('starts from the first node', () => {
+    const initial = makeGraphState(UNDIRECTED_UNWEIGHTED);
+    const cmds = dfsCommands(initial);
+    const result = runGraph(cmds, initial);
+    expect(result.visited[0]).toBe('A');
+  });
+
+  it('handles empty graph', () => {
+    const emptyGraph = {
+      directed: false,
+      weighted: false,
+      nodes: [],
+      edges: [],
+    };
+    const initial = makeGraphState(emptyGraph);
+    const cmds = dfsCommands(initial);
+    expect(cmds).toHaveLength(0);
+  });
+
+  it('generates visit_edge commands', () => {
+    const initial = makeGraphState(UNDIRECTED_UNWEIGHTED);
+    const cmds = dfsCommands(initial);
+    const edgeCmds = cmds.filter((c) => c.type === 'visit_edge');
+    expect(edgeCmds.length).toBeGreaterThan(0);
+  });
+});

--- a/algo-compendium/_algorithms/graph/dfs.ts
+++ b/algo-compendium/_algorithms/graph/dfs.ts
@@ -1,0 +1,73 @@
+import { registerAlgorithm } from '../registry';
+import type { GraphCommand, GraphState } from './commands';
+import { makeGraphState, graphReducer } from './commands';
+import { UNDIRECTED_UNWEIGHTED } from './types';
+
+export function dfsCommands(state: GraphState): GraphCommand[] {
+  const cmds: GraphCommand[] = [];
+  const { graph } = state;
+
+  if (graph.nodes.length === 0) return cmds;
+
+  const startId = graph.nodes[0].id;
+  const visited = new Set<string>();
+
+  // Build adjacency list
+  const adj: Record<string, string[]> = {};
+  for (const node of graph.nodes) adj[node.id] = [];
+  for (const edge of graph.edges) {
+    adj[edge.from].push(edge.to);
+    if (!graph.directed) adj[edge.to].push(edge.from);
+  }
+
+  function dfs(nodeId: string) {
+    visited.add(nodeId);
+    cmds.push({
+      type: 'visit_node',
+      nodeId,
+      description: `DFS: Visit node ${nodeId}`,
+    });
+
+    const neighbors = adj[nodeId] ?? [];
+    for (const neighbor of neighbors) {
+      cmds.push({
+        type: 'visit_edge',
+        from: nodeId,
+        to: neighbor,
+        description: `Explore edge ${nodeId} → ${neighbor}`,
+      });
+
+      if (!visited.has(neighbor)) {
+        dfs(neighbor);
+      }
+    }
+  }
+
+  dfs(startId);
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Depth-First Search',
+  slug: 'dfs',
+  category: 'graph',
+  description:
+    'Explores as far as possible along each branch before backtracking. Useful for topological sorting, cycle detection, and finding connected components.',
+  bestCase: 'O(V+E)',
+  averageCase: 'O(V+E)',
+  worstCase: 'O(V+E)',
+  spaceComplexity: 'O(V)',
+  pseudocode: `DFS(graph, start):
+  visited = {}
+  function explore(node):
+    visited.add(node)
+    for each neighbor of node:
+      if neighbor not in visited:
+        explore(neighbor)
+  explore(start)`,
+  visualizerType: 'graph',
+  defaultInput: makeGraphState(UNDIRECTED_UNWEIGHTED),
+  run: dfsCommands,
+  reduce: graphReducer,
+});

--- a/algo-compendium/_algorithms/graph/dijkstra.test.ts
+++ b/algo-compendium/_algorithms/graph/dijkstra.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { dijkstraCommands } from './dijkstra';
+import { makeGraphState, graphReducer } from './commands';
+import type { GraphCommand, GraphState } from './commands';
+import { DIRECTED_WEIGHTED } from './types';
+
+function runGraph(commands: GraphCommand[], initial: GraphState): GraphState {
+  return commands.reduce(graphReducer, initial);
+}
+
+describe('Dijkstra', () => {
+  it('computes correct shortest distances from A', () => {
+    const initial = makeGraphState(DIRECTED_WEIGHTED);
+    const cmds = dijkstraCommands(initial);
+    const result = runGraph(cmds, initial);
+
+    // From A: A=0, B=3 (A→B→C: 4+1=5, but A→B=4 direct),
+    // Let's verify known distances:
+    // A=0, B=4 (direct), C=2 (A→C direct), D=6 (A→C→E→D=2+5+1=8, or A→B→D=4+3=7), E=7 (A→C→E=2+5), F=8 (min of D→F=7+2=9 or E→F=7+3=10... wait)
+    // A→B=4, A→C=2, B→D=7 (4+3), B→C=5(4+1 but A→C=2 shorter), C→E=7(2+5), E→D=8(7+1), D→F=9(7+2 or 8+2=10), E→F=10(7+3)
+    // So: A=0, B=4, C=2, D=7, E=7, F=9
+    expect(result.distances['A']).toBe(0);
+    expect(result.distances['B']).toBe(4);
+    expect(result.distances['C']).toBe(2);
+    expect(result.distances['D']).toBe(7);
+    expect(result.distances['E']).toBe(7);
+    expect(result.distances['F']).toBe(9);
+  });
+
+  it('finalizes all reachable nodes', () => {
+    const initial = makeGraphState(DIRECTED_WEIGHTED);
+    const cmds = dijkstraCommands(initial);
+    const result = runGraph(cmds, initial);
+    expect(result.finalized).toHaveLength(DIRECTED_WEIGHTED.nodes.length);
+  });
+
+  it('marks a path from source to destination', () => {
+    const initial = makeGraphState(DIRECTED_WEIGHTED);
+    const cmds = dijkstraCommands(initial);
+    const result = runGraph(cmds, initial);
+    expect(result.path.length).toBeGreaterThan(0);
+    expect(result.path[0]).toBe('A');
+  });
+});

--- a/algo-compendium/_algorithms/graph/dijkstra.ts
+++ b/algo-compendium/_algorithms/graph/dijkstra.ts
@@ -1,0 +1,129 @@
+import { registerAlgorithm } from '../registry';
+import type { GraphCommand, GraphState } from './commands';
+import { makeGraphState, graphReducer } from './commands';
+import { DIRECTED_WEIGHTED } from './types';
+
+export function dijkstraCommands(state: GraphState): GraphCommand[] {
+  const cmds: GraphCommand[] = [];
+  const { graph } = state;
+
+  if (graph.nodes.length === 0) return cmds;
+
+  const sourceId = graph.nodes[0].id;
+
+  // Initialize distances
+  const dist: Record<string, number> = {};
+  const prev: Record<string, string | null> = {};
+  for (const node of graph.nodes) {
+    dist[node.id] = Infinity;
+    prev[node.id] = null;
+  }
+  dist[sourceId] = 0;
+
+  cmds.push({
+    type: 'update_distance',
+    nodeId: sourceId,
+    distance: 0,
+    description: `Initialize: dist[${sourceId}] = 0, all others = ∞`,
+  });
+
+  const unvisited = new Set<string>(graph.nodes.map((n) => n.id));
+
+  while (unvisited.size > 0) {
+    // Pick node with minimum distance
+    let u: string | null = null;
+    let minDist = Infinity;
+    for (const nodeId of unvisited) {
+      if (dist[nodeId] < minDist) {
+        minDist = dist[nodeId];
+        u = nodeId;
+      }
+    }
+
+    if (u === null || dist[u] === Infinity) break;
+
+    unvisited.delete(u);
+
+    cmds.push({
+      type: 'visit_node',
+      nodeId: u,
+      description: `Process node ${u} (dist=${dist[u]})`,
+    });
+
+    // Relax edges
+    const edges = graph.edges.filter((e) => e.from === u);
+    for (const edge of edges) {
+      const v = edge.to;
+      const w = edge.weight ?? 1;
+      const newDist = dist[u] + w;
+
+      cmds.push({
+        type: 'visit_edge',
+        from: u,
+        to: v,
+        description: `Relax edge ${u} → ${v} (weight=${w})`,
+      });
+
+      if (newDist < dist[v]) {
+        dist[v] = newDist;
+        prev[v] = u;
+        cmds.push({
+          type: 'update_distance',
+          nodeId: v,
+          distance: newDist,
+          description: `Update dist[${v}] = ${newDist}`,
+        });
+      }
+    }
+
+    cmds.push({
+      type: 'finalize_node',
+      nodeId: u,
+      description: `Finalize node ${u} (shortest dist=${dist[u]})`,
+    });
+  }
+
+  // Reconstruct path from source to last node
+  const lastNode = graph.nodes[graph.nodes.length - 1].id;
+  const path: string[] = [];
+  let cur: string | null = lastNode;
+  while (cur !== null) {
+    path.unshift(cur);
+    cur = prev[cur];
+  }
+  if (path[0] === sourceId) {
+    cmds.push({
+      type: 'mark_path',
+      nodes: path,
+      description: `Shortest path: ${path.join(' → ')} (dist=${dist[lastNode]})`,
+    });
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: "Dijkstra's Algorithm",
+  slug: 'dijkstra',
+  category: 'graph',
+  description:
+    'Finds the shortest path from a source node to all other nodes in a weighted graph with non-negative edge weights. Uses a greedy approach with a priority queue.',
+  bestCase: 'O(1)',
+  averageCase: 'O((V+E) log V)',
+  worstCase: 'O(V²)',
+  spaceComplexity: 'O(V)',
+  pseudocode: `Dijkstra(graph, source):
+  dist[source] = 0, dist[v] = ∞ for all others
+  unvisited = all nodes
+  while unvisited not empty:
+    u = node in unvisited with min dist
+    remove u from unvisited
+    for each neighbor v of u:
+      alt = dist[u] + weight(u,v)
+      if alt < dist[v]:
+        dist[v] = alt`,
+  visualizerType: 'graph',
+  defaultInput: makeGraphState(DIRECTED_WEIGHTED),
+  run: dijkstraCommands,
+  reduce: graphReducer,
+});

--- a/algo-compendium/_algorithms/graph/floyd-warshall.test.ts
+++ b/algo-compendium/_algorithms/graph/floyd-warshall.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { floydWarshallCommands } from './floyd-warshall';
+import { makeGraphState, graphReducer } from './commands';
+import type { GraphCommand, GraphState } from './commands';
+import { DIRECTED_WEIGHTED } from './types';
+
+function runGraph(commands: GraphCommand[], initial: GraphState): GraphState {
+  return commands.reduce(graphReducer, initial);
+}
+
+describe('Floyd-Warshall', () => {
+  it('finalizes all nodes', () => {
+    const initial = makeGraphState(DIRECTED_WEIGHTED);
+    const cmds = floydWarshallCommands(initial);
+    const result = runGraph(cmds, initial);
+    // All nodes should be finalized
+    expect(result.finalized).toHaveLength(DIRECTED_WEIGHTED.nodes.length);
+  });
+
+  it('generates update_distance commands during relaxation', () => {
+    const initial = makeGraphState(DIRECTED_WEIGHTED);
+    const cmds = floydWarshallCommands(initial);
+    const distCmds = cmds.filter((c) => c.type === 'update_distance');
+    expect(distCmds.length).toBeGreaterThan(0);
+  });
+
+  it('handles empty graph', () => {
+    const emptyGraph = { directed: true, weighted: true, nodes: [], edges: [] };
+    const initial = makeGraphState(emptyGraph);
+    const cmds = floydWarshallCommands(initial);
+    expect(cmds).toHaveLength(0);
+  });
+
+  it('distance from A to F is 9 (optimal all-pairs path)', () => {
+    const initial = makeGraphState(DIRECTED_WEIGHTED);
+    const cmds = floydWarshallCommands(initial);
+    const result = runGraph(cmds, initial);
+    // Floyd-Warshall updates distances via update_distance commands
+    // The last update_distance for node F should reflect dist 9
+    const fDistCmds = cmds.filter(
+      (c) =>
+        c.type === 'update_distance' && (c as { nodeId: string }).nodeId === 'F'
+    );
+    if (fDistCmds.length > 0) {
+      const lastF = fDistCmds[fDistCmds.length - 1] as { distance: number };
+      expect(lastF.distance).toBeLessThanOrEqual(9);
+    }
+    // finalized state should contain all nodes
+    expect(result.finalized).toContain('F');
+  });
+});

--- a/algo-compendium/_algorithms/graph/floyd-warshall.ts
+++ b/algo-compendium/_algorithms/graph/floyd-warshall.ts
@@ -1,0 +1,95 @@
+import { registerAlgorithm } from '../registry';
+import type { GraphCommand, GraphState } from './commands';
+import { makeGraphState, graphReducer } from './commands';
+import { DIRECTED_WEIGHTED } from './types';
+
+export function floydWarshallCommands(state: GraphState): GraphCommand[] {
+  const cmds: GraphCommand[] = [];
+  const { graph } = state;
+
+  if (graph.nodes.length === 0) return cmds;
+
+  const nodeIds = graph.nodes.map((n) => n.id);
+  const n = nodeIds.length;
+  const idx = (id: string) => nodeIds.indexOf(id);
+
+  // Initialize distance matrix
+  const dist: number[][] = Array.from({ length: n }, () =>
+    Array(n).fill(Infinity)
+  );
+  for (let i = 0; i < n; i++) dist[i][i] = 0;
+  for (const edge of graph.edges) {
+    const u = idx(edge.from);
+    const v = idx(edge.to);
+    const w = edge.weight ?? 1;
+    dist[u][v] = Math.min(dist[u][v], w);
+  }
+
+  cmds.push({
+    type: 'visit_node',
+    nodeId: nodeIds[0],
+    description: 'Floyd-Warshall: Initialize distance matrix',
+  });
+
+  // Floyd-Warshall: try each intermediate node k
+  for (let k = 0; k < n; k++) {
+    const kId = nodeIds[k];
+    cmds.push({
+      type: 'visit_node',
+      nodeId: kId,
+      description: `Try intermediate node ${kId}`,
+    });
+
+    for (let i = 0; i < n; i++) {
+      for (let j = 0; j < n; j++) {
+        if (dist[i][k] !== Infinity && dist[k][j] !== Infinity) {
+          const newDist = dist[i][k] + dist[k][j];
+          if (newDist < dist[i][j]) {
+            dist[i][j] = newDist;
+            cmds.push({
+              type: 'update_distance',
+              nodeId: nodeIds[j],
+              distance: newDist,
+              description: `Update dist[${nodeIds[i]}][${nodeIds[j]}] = ${newDist} via ${kId}`,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // Finalize all nodes
+  for (let i = 0; i < n; i++) {
+    cmds.push({
+      type: 'finalize_node',
+      nodeId: nodeIds[i],
+      description: `Node ${nodeIds[i]}: shortest distances computed`,
+    });
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Floyd-Warshall',
+  slug: 'floyd-warshall',
+  category: 'graph',
+  description:
+    'Computes shortest paths between all pairs of vertices. Works with negative edge weights (but not negative cycles). Time complexity O(V³).',
+  bestCase: 'O(V³)',
+  averageCase: 'O(V³)',
+  worstCase: 'O(V³)',
+  spaceComplexity: 'O(V²)',
+  pseudocode: `FloydWarshall(graph):
+  dist[i][j] = weight(i,j) if edge exists, else ∞
+  dist[i][i] = 0 for all i
+  for k from 0 to V-1:
+    for i from 0 to V-1:
+      for j from 0 to V-1:
+        if dist[i][k] + dist[k][j] < dist[i][j]:
+          dist[i][j] = dist[i][k] + dist[k][j]`,
+  visualizerType: 'graph',
+  defaultInput: makeGraphState(DIRECTED_WEIGHTED),
+  run: floydWarshallCommands,
+  reduce: graphReducer,
+});

--- a/algo-compendium/_algorithms/graph/index.ts
+++ b/algo-compendium/_algorithms/graph/index.ts
@@ -1,0 +1,10 @@
+import './bfs';
+import './dfs';
+import './dijkstra';
+import './bellman-ford';
+import './floyd-warshall';
+import './kruskal';
+import './prim';
+import './topological-sort';
+import './tarjan-scc';
+import './a-star';

--- a/algo-compendium/_algorithms/graph/kruskal.test.ts
+++ b/algo-compendium/_algorithms/graph/kruskal.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { kruskalCommands } from './kruskal';
+import { makeGraphState, graphReducer } from './commands';
+import type { GraphCommand, GraphState } from './commands';
+import { UNDIRECTED_UNWEIGHTED } from './types';
+
+function runGraph(commands: GraphCommand[], initial: GraphState): GraphState {
+  return commands.reduce(graphReducer, initial);
+}
+
+describe('Kruskal', () => {
+  it('produces MST with V-1 edges', () => {
+    const initial = makeGraphState(UNDIRECTED_UNWEIGHTED);
+    const cmds = kruskalCommands(initial);
+    const result = runGraph(cmds, initial);
+    const V = UNDIRECTED_UNWEIGHTED.nodes.length;
+    expect(result.mstEdges).toHaveLength(V - 1);
+  });
+
+  it('handles empty graph', () => {
+    const emptyGraph = {
+      directed: false,
+      weighted: false,
+      nodes: [],
+      edges: [],
+    };
+    const initial = makeGraphState(emptyGraph);
+    const cmds = kruskalCommands(initial);
+    expect(cmds).toHaveLength(0);
+  });
+
+  it('generates mark_mst_edge commands', () => {
+    const initial = makeGraphState(UNDIRECTED_UNWEIGHTED);
+    const cmds = kruskalCommands(initial);
+    const mstCmds = cmds.filter((c) => c.type === 'mark_mst_edge');
+    expect(mstCmds.length).toBe(UNDIRECTED_UNWEIGHTED.nodes.length - 1);
+  });
+});

--- a/algo-compendium/_algorithms/graph/kruskal.ts
+++ b/algo-compendium/_algorithms/graph/kruskal.ts
@@ -1,0 +1,111 @@
+import { registerAlgorithm } from '../registry';
+import type { GraphCommand, GraphState } from './commands';
+import { makeGraphState, graphReducer } from './commands';
+import { UNDIRECTED_UNWEIGHTED } from './types';
+
+// Union-Find data structure
+class UnionFind {
+  private parent: Record<string, string> = {};
+  private rank: Record<string, number> = {};
+
+  constructor(nodes: string[]) {
+    for (const n of nodes) {
+      this.parent[n] = n;
+      this.rank[n] = 0;
+    }
+  }
+
+  find(x: string): string {
+    if (this.parent[x] !== x) {
+      this.parent[x] = this.find(this.parent[x]);
+    }
+    return this.parent[x];
+  }
+
+  union(x: string, y: string): boolean {
+    const rx = this.find(x);
+    const ry = this.find(y);
+    if (rx === ry) return false;
+    if (this.rank[rx] < this.rank[ry]) {
+      this.parent[rx] = ry;
+    } else if (this.rank[rx] > this.rank[ry]) {
+      this.parent[ry] = rx;
+    } else {
+      this.parent[ry] = rx;
+      this.rank[rx]++;
+    }
+    return true;
+  }
+}
+
+export function kruskalCommands(state: GraphState): GraphCommand[] {
+  const cmds: GraphCommand[] = [];
+  const { graph } = state;
+
+  if (graph.nodes.length === 0) return cmds;
+
+  const nodeIds = graph.nodes.map((n) => n.id);
+  const uf = new UnionFind(nodeIds);
+
+  // Sort edges by weight
+  const sortedEdges = [...graph.edges].sort(
+    (a, b) => (a.weight ?? 1) - (b.weight ?? 1)
+  );
+
+  cmds.push({
+    type: 'visit_node',
+    nodeId: nodeIds[0],
+    description: 'Kruskal: Sort edges by weight, initialize union-find',
+  });
+
+  for (const edge of sortedEdges) {
+    cmds.push({
+      type: 'visit_edge',
+      from: edge.from,
+      to: edge.to,
+      description: `Consider edge ${edge.from}-${edge.to} (weight=${edge.weight ?? 1})`,
+    });
+
+    if (uf.union(edge.from, edge.to)) {
+      cmds.push({
+        type: 'mark_mst_edge',
+        from: edge.from,
+        to: edge.to,
+        description: `Add edge ${edge.from}-${edge.to} to MST`,
+      });
+    } else {
+      cmds.push({
+        type: 'visit_node',
+        nodeId: edge.from,
+        description: `Skip edge ${edge.from}-${edge.to} (would create cycle)`,
+      });
+    }
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: "Kruskal's Algorithm",
+  slug: 'kruskal',
+  category: 'graph',
+  description:
+    'Builds a Minimum Spanning Tree by sorting all edges and greedily adding the smallest edge that does not create a cycle, using Union-Find for cycle detection.',
+  bestCase: 'O(E log E)',
+  averageCase: 'O(E log E)',
+  worstCase: 'O(E log E)',
+  spaceComplexity: 'O(V)',
+  pseudocode: `Kruskal(graph):
+  sort edges by weight
+  uf = UnionFind(all nodes)
+  mst = []
+  for each edge (u, v, w) in sorted order:
+    if find(u) != find(v):
+      union(u, v)
+      mst.add(edge)
+  return mst`,
+  visualizerType: 'graph',
+  defaultInput: makeGraphState(UNDIRECTED_UNWEIGHTED),
+  run: kruskalCommands,
+  reduce: graphReducer,
+});

--- a/algo-compendium/_algorithms/graph/prim.test.ts
+++ b/algo-compendium/_algorithms/graph/prim.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { primCommands } from './prim';
+import { makeGraphState, graphReducer } from './commands';
+import type { GraphCommand, GraphState } from './commands';
+import { UNDIRECTED_UNWEIGHTED } from './types';
+
+function runGraph(commands: GraphCommand[], initial: GraphState): GraphState {
+  return commands.reduce(graphReducer, initial);
+}
+
+describe('Prim', () => {
+  it('produces MST with V-1 edges', () => {
+    const initial = makeGraphState(UNDIRECTED_UNWEIGHTED);
+    const cmds = primCommands(initial);
+    const result = runGraph(cmds, initial);
+    const V = UNDIRECTED_UNWEIGHTED.nodes.length;
+    expect(result.mstEdges).toHaveLength(V - 1);
+  });
+
+  it('visits all nodes', () => {
+    const initial = makeGraphState(UNDIRECTED_UNWEIGHTED);
+    const cmds = primCommands(initial);
+    const result = runGraph(cmds, initial);
+    expect(result.visited).toHaveLength(UNDIRECTED_UNWEIGHTED.nodes.length);
+  });
+
+  it('handles empty graph', () => {
+    const emptyGraph = {
+      directed: false,
+      weighted: false,
+      nodes: [],
+      edges: [],
+    };
+    const initial = makeGraphState(emptyGraph);
+    const cmds = primCommands(initial);
+    expect(cmds).toHaveLength(0);
+  });
+
+  it('generates mark_mst_edge commands', () => {
+    const initial = makeGraphState(UNDIRECTED_UNWEIGHTED);
+    const cmds = primCommands(initial);
+    const mstCmds = cmds.filter((c) => c.type === 'mark_mst_edge');
+    expect(mstCmds.length).toBe(UNDIRECTED_UNWEIGHTED.nodes.length - 1);
+  });
+});

--- a/algo-compendium/_algorithms/graph/prim.ts
+++ b/algo-compendium/_algorithms/graph/prim.ts
@@ -1,0 +1,89 @@
+import { registerAlgorithm } from '../registry';
+import type { GraphCommand, GraphState } from './commands';
+import { makeGraphState, graphReducer } from './commands';
+import { UNDIRECTED_UNWEIGHTED } from './types';
+
+export function primCommands(state: GraphState): GraphCommand[] {
+  const cmds: GraphCommand[] = [];
+  const { graph } = state;
+
+  if (graph.nodes.length === 0) return cmds;
+
+  const startId = graph.nodes[0].id;
+  const inMST = new Set<string>();
+
+  // Build adjacency list with weights
+  const adj: Record<string, { to: string; weight: number }[]> = {};
+  for (const node of graph.nodes) adj[node.id] = [];
+  for (const edge of graph.edges) {
+    adj[edge.from].push({ to: edge.to, weight: edge.weight ?? 1 });
+    if (!graph.directed) {
+      adj[edge.to].push({ to: edge.from, weight: edge.weight ?? 1 });
+    }
+  }
+
+  inMST.add(startId);
+  cmds.push({
+    type: 'visit_node',
+    nodeId: startId,
+    description: `Prim: Start at node ${startId}`,
+  });
+
+  while (inMST.size < graph.nodes.length) {
+    let bestFrom = '';
+    let bestTo = '';
+    let bestWeight = Infinity;
+
+    // Find minimum-weight edge crossing the MST frontier
+    for (const nodeId of inMST) {
+      for (const { to, weight } of adj[nodeId]) {
+        if (!inMST.has(to) && weight < bestWeight) {
+          bestWeight = weight;
+          bestFrom = nodeId;
+          bestTo = to;
+        }
+      }
+    }
+
+    if (!bestTo) break; // Disconnected graph
+
+    inMST.add(bestTo);
+
+    cmds.push({
+      type: 'visit_node',
+      nodeId: bestTo,
+      description: `Visit node ${bestTo} via edge ${bestFrom}-${bestTo} (weight=${bestWeight})`,
+    });
+
+    cmds.push({
+      type: 'mark_mst_edge',
+      from: bestFrom,
+      to: bestTo,
+      description: `Add edge ${bestFrom}-${bestTo} to MST (weight=${bestWeight})`,
+    });
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: "Prim's Algorithm",
+  slug: 'prim',
+  category: 'graph',
+  description:
+    'Builds a Minimum Spanning Tree by starting from one node and greedily growing the MST one edge at a time, always picking the minimum-weight edge that connects a new vertex.',
+  bestCase: 'O(E log V)',
+  averageCase: 'O(E log V)',
+  worstCase: 'O(E log V)',
+  spaceComplexity: 'O(V)',
+  pseudocode: `Prim(graph, start):
+  inMST = {start}
+  while inMST.size < V:
+    find min-weight edge (u, v) where u in MST, v not in MST
+    add v to MST
+    add edge (u, v) to result`,
+  visualizerType: 'graph',
+  defaultInput: makeGraphState(UNDIRECTED_UNWEIGHTED),
+  run: primCommands,
+  reduce: graphReducer,
+});

--- a/algo-compendium/_algorithms/graph/tarjan-scc.test.ts
+++ b/algo-compendium/_algorithms/graph/tarjan-scc.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { tarjanSccCommands } from './tarjan-scc';
+import { makeGraphState, graphReducer } from './commands';
+import type { Graph } from './types';
+
+const testGraph: Graph = {
+  nodes: [
+    { id: 'a', label: 'A', x: 100, y: 200 },
+    { id: 'b', label: 'B', x: 250, y: 80 },
+    { id: 'c', label: 'C', x: 400, y: 200 },
+    { id: 'd', label: 'D', x: 250, y: 320 },
+    { id: 'e', label: 'E', x: 550, y: 200 },
+  ],
+  edges: [
+    { from: 'a', to: 'b' },
+    { from: 'b', to: 'c' },
+    { from: 'c', to: 'a' },
+    { from: 'b', to: 'd' },
+    { from: 'd', to: 'e' },
+    { from: 'e', to: 'd' },
+  ],
+  directed: true,
+  weighted: false,
+};
+
+describe('tarjanSCC', () => {
+  it('finds correct number of SCCs', () => {
+    const initial = makeGraphState(testGraph);
+    const cmds = tarjanSccCommands(initial);
+    const result = cmds.reduce(graphReducer, initial);
+    // Should have 2 SCCs: {a,b,c} and {d,e}
+    expect(result.result).toHaveLength(2);
+  });
+
+  it('result contains SCC labels', () => {
+    const initial = makeGraphState(testGraph);
+    const cmds = tarjanSccCommands(initial);
+    const result = cmds.reduce(graphReducer, initial);
+    const sccStr = result.result.join(' ');
+    expect(sccStr).toContain('SCC:');
+  });
+
+  it('visits all nodes', () => {
+    const initial = makeGraphState(testGraph);
+    const cmds = tarjanSccCommands(initial);
+    const result = cmds.reduce(graphReducer, initial);
+    expect(result.visited.length).toBe(testGraph.nodes.length);
+  });
+
+  it('finalizes all nodes', () => {
+    const initial = makeGraphState(testGraph);
+    const cmds = tarjanSccCommands(initial);
+    const result = cmds.reduce(graphReducer, initial);
+    expect(result.finalized.length).toBe(testGraph.nodes.length);
+  });
+
+  it('handles empty graph', () => {
+    const emptyGraph: Graph = {
+      nodes: [],
+      edges: [],
+      directed: true,
+      weighted: false,
+    };
+    const initial = makeGraphState(emptyGraph);
+    const cmds = tarjanSccCommands(initial);
+    const result = cmds.reduce(graphReducer, initial);
+    expect(result.result).toHaveLength(0);
+  });
+
+  it('reducer does not mutate state', () => {
+    const initial = makeGraphState(testGraph);
+    const cmds = tarjanSccCommands(initial);
+    if (cmds.length > 0) {
+      const s1 = graphReducer(initial, cmds[0]);
+      expect(initial.visited).toEqual([]);
+      expect(s1).not.toBe(initial);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/graph/tarjan-scc.ts
+++ b/algo-compendium/_algorithms/graph/tarjan-scc.ts
@@ -1,0 +1,146 @@
+import { registerAlgorithm } from '../registry';
+import type { GraphCommand, GraphState } from './commands';
+import { makeGraphState, graphReducer } from './commands';
+import type { Graph } from './types';
+
+const graph: Graph = {
+  nodes: [
+    { id: 'a', label: 'A', x: 100, y: 200 },
+    { id: 'b', label: 'B', x: 250, y: 80 },
+    { id: 'c', label: 'C', x: 400, y: 200 },
+    { id: 'd', label: 'D', x: 250, y: 320 },
+    { id: 'e', label: 'E', x: 550, y: 200 },
+  ],
+  edges: [
+    { from: 'a', to: 'b' },
+    { from: 'b', to: 'c' },
+    { from: 'c', to: 'a' },
+    { from: 'b', to: 'd' },
+    { from: 'd', to: 'e' },
+    { from: 'e', to: 'd' },
+  ],
+  directed: true,
+  weighted: false,
+};
+
+export function tarjanSccCommands(state: GraphState): GraphCommand[] {
+  const cmds: GraphCommand[] = [];
+  const { graph: g } = state;
+
+  const index: Record<string, number> = {};
+  const lowlink: Record<string, number> = {};
+  const onStack: Record<string, boolean> = {};
+  const stack: string[] = [];
+  const sccs: string[][] = [];
+  let counter = 0;
+
+  // Build adjacency list
+  const adj: Record<string, string[]> = {};
+  for (const node of g.nodes) adj[node.id] = [];
+  for (const edge of g.edges) {
+    adj[edge.from] = adj[edge.from] ?? [];
+    adj[edge.from].push(edge.to);
+  }
+
+  function strongconnect(v: string): void {
+    index[v] = counter;
+    lowlink[v] = counter;
+    counter++;
+    stack.push(v);
+    onStack[v] = true;
+
+    cmds.push({
+      type: 'visit_node',
+      nodeId: v,
+      description: `Visit ${v}: index=${index[v]}, lowlink=${lowlink[v]}`,
+    });
+
+    for (const w of adj[v] ?? []) {
+      cmds.push({
+        type: 'visit_edge',
+        from: v,
+        to: w,
+        description: `Explore edge ${v} → ${w}`,
+      });
+
+      if (index[w] === undefined) {
+        // w not yet visited
+        strongconnect(w);
+        lowlink[v] = Math.min(lowlink[v], lowlink[w]);
+        cmds.push({
+          type: 'update_distance',
+          nodeId: v,
+          distance: lowlink[v],
+          description: `Update lowlink[${v}] = min(${lowlink[v]}, lowlink[${w}]=${lowlink[w]}) = ${lowlink[v]}`,
+        });
+      } else if (onStack[w]) {
+        lowlink[v] = Math.min(lowlink[v], index[w]);
+        cmds.push({
+          type: 'update_distance',
+          nodeId: v,
+          distance: lowlink[v],
+          description: `${w} on stack: update lowlink[${v}] = ${lowlink[v]}`,
+        });
+      }
+    }
+
+    // If v is a root node, pop the stack and generate an SCC
+    if (lowlink[v] === index[v]) {
+      const scc: string[] = [];
+      let w: string;
+      do {
+        w = stack.pop()!;
+        onStack[w] = false;
+        scc.push(w);
+        cmds.push({
+          type: 'finalize_node',
+          nodeId: w,
+          description: `Pop ${w} from stack (SCC component)`,
+        });
+      } while (w !== v);
+      sccs.push(scc);
+    }
+  }
+
+  for (const node of g.nodes) {
+    if (index[node.id] === undefined) {
+      strongconnect(node.id);
+    }
+  }
+
+  const sccStrings = sccs.map((scc) => `SCC: ${scc.sort().join(',')}`);
+  cmds.push({
+    type: 'set_result',
+    result: sccStrings,
+    description: `Found ${sccs.length} strongly connected components`,
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: "Tarjan's SCC",
+  slug: 'tarjan-scc',
+  category: 'graph',
+  description:
+    'Finds all Strongly Connected Components (SCCs) in a directed graph using a single DFS pass. Maintains a stack and uses discovery index and low-link values to identify component roots.',
+  bestCase: 'O(V+E)',
+  averageCase: 'O(V+E)',
+  worstCase: 'O(V+E)',
+  spaceComplexity: 'O(V)',
+  pseudocode: `function strongconnect(v):
+  index[v] = lowlink[v] = counter++
+  push v onto stack; onStack[v] = true
+  for each edge (v, w):
+    if w not visited:
+      strongconnect(w)
+      lowlink[v] = min(lowlink[v], lowlink[w])
+    else if w on stack:
+      lowlink[v] = min(lowlink[v], index[w])
+  if lowlink[v] == index[v]:  // v is root of SCC
+    pop stack until v, emit SCC`,
+  visualizerType: 'graph',
+  defaultInput: makeGraphState(graph),
+  run: tarjanSccCommands,
+  reduce: graphReducer,
+});

--- a/algo-compendium/_algorithms/graph/topological-sort.test.ts
+++ b/algo-compendium/_algorithms/graph/topological-sort.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { topologicalSortCommands } from './topological-sort';
+import { makeGraphState, graphReducer } from './commands';
+import type { GraphCommand, GraphState } from './commands';
+import { DIRECTED_DAG } from './types';
+
+function runGraph(commands: GraphCommand[], initial: GraphState): GraphState {
+  return commands.reduce(graphReducer, initial);
+}
+
+function isValidTopologicalOrder(
+  result: string[],
+  graph: typeof DIRECTED_DAG
+): boolean {
+  const pos: Record<string, number> = {};
+  result.forEach((id, i) => {
+    pos[id] = i;
+  });
+
+  for (const edge of graph.edges) {
+    if (pos[edge.from] === undefined || pos[edge.to] === undefined)
+      return false;
+    if (pos[edge.from] >= pos[edge.to]) return false;
+  }
+  return true;
+}
+
+describe('Topological Sort', () => {
+  it('visits all nodes', () => {
+    const initial = makeGraphState(DIRECTED_DAG);
+    const cmds = topologicalSortCommands(initial);
+    const result = runGraph(cmds, initial);
+    expect(result.visited).toHaveLength(DIRECTED_DAG.nodes.length);
+  });
+
+  it('produces a valid topological order', () => {
+    const initial = makeGraphState(DIRECTED_DAG);
+    const cmds = topologicalSortCommands(initial);
+    const result = runGraph(cmds, initial);
+    expect(result.result).toHaveLength(DIRECTED_DAG.nodes.length);
+    expect(isValidTopologicalOrder(result.result, DIRECTED_DAG)).toBe(true);
+  });
+
+  it('result contains all node IDs', () => {
+    const initial = makeGraphState(DIRECTED_DAG);
+    const cmds = topologicalSortCommands(initial);
+    const result = runGraph(cmds, initial);
+    const nodeIds = new Set(DIRECTED_DAG.nodes.map((n) => n.id));
+    const resultIds = new Set(result.result);
+    expect(resultIds).toEqual(nodeIds);
+  });
+
+  it('finalizes all nodes', () => {
+    const initial = makeGraphState(DIRECTED_DAG);
+    const cmds = topologicalSortCommands(initial);
+    const result = runGraph(cmds, initial);
+    expect(result.finalized).toHaveLength(DIRECTED_DAG.nodes.length);
+  });
+
+  it('handles empty graph', () => {
+    const emptyGraph = {
+      directed: true,
+      weighted: false,
+      nodes: [],
+      edges: [],
+    };
+    const initial = makeGraphState(emptyGraph);
+    const cmds = topologicalSortCommands(initial);
+    expect(cmds).toHaveLength(0);
+  });
+});

--- a/algo-compendium/_algorithms/graph/topological-sort.ts
+++ b/algo-compendium/_algorithms/graph/topological-sort.ts
@@ -1,0 +1,88 @@
+import { registerAlgorithm } from '../registry';
+import type { GraphCommand, GraphState } from './commands';
+import { makeGraphState, graphReducer } from './commands';
+import { DIRECTED_DAG } from './types';
+
+export function topologicalSortCommands(state: GraphState): GraphCommand[] {
+  const cmds: GraphCommand[] = [];
+  const { graph } = state;
+
+  if (graph.nodes.length === 0) return cmds;
+
+  const visited = new Set<string>();
+  const stack: string[] = [];
+
+  // Build adjacency list
+  const adj: Record<string, string[]> = {};
+  for (const node of graph.nodes) adj[node.id] = [];
+  for (const edge of graph.edges) {
+    adj[edge.from].push(edge.to);
+  }
+
+  function dfs(nodeId: string) {
+    visited.add(nodeId);
+    cmds.push({
+      type: 'visit_node',
+      nodeId,
+      description: `DFS: Visit node ${nodeId}`,
+    });
+
+    for (const neighbor of adj[nodeId] ?? []) {
+      if (!visited.has(neighbor)) {
+        dfs(neighbor);
+      }
+    }
+
+    stack.push(nodeId);
+    cmds.push({
+      type: 'finalize_node',
+      nodeId,
+      description: `Finalize node ${nodeId} (push to stack)`,
+    });
+  }
+
+  for (const node of graph.nodes) {
+    if (!visited.has(node.id)) {
+      dfs(node.id);
+    }
+  }
+
+  const result = [...stack].reverse();
+
+  cmds.push({
+    type: 'set_result',
+    result,
+    description: `Topological order: ${result.join(' → ')}`,
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Topological Sort',
+  slug: 'topological-sort',
+  category: 'graph',
+  description:
+    'Orders vertices in a Directed Acyclic Graph (DAG) such that for every directed edge u → v, u appears before v. Uses DFS with a post-order stack.',
+  bestCase: 'O(V+E)',
+  averageCase: 'O(V+E)',
+  worstCase: 'O(V+E)',
+  spaceComplexity: 'O(V)',
+  pseudocode: `TopologicalSort(graph):
+  visited = {}
+  stack = []
+  function dfs(node):
+    visited.add(node)
+    for each neighbor of node:
+      if neighbor not visited:
+        dfs(neighbor)
+    stack.push(node)
+  for each node in graph:
+    if node not visited:
+      dfs(node)
+  return reverse(stack)`,
+  visualizerType: 'graph',
+  defaultInput: makeGraphState(DIRECTED_DAG),
+  run: topologicalSortCommands,
+  reduce: graphReducer,
+});

--- a/algo-compendium/_algorithms/graph/types.ts
+++ b/algo-compendium/_algorithms/graph/types.ts
@@ -1,0 +1,88 @@
+export type GraphNode = {
+  id: string;
+  label: string;
+  x: number; // pre-set position for visualization (0-100 range, normalized)
+  y: number;
+};
+
+export type GraphEdge = {
+  from: string;
+  to: string;
+  weight?: number;
+  directed?: boolean;
+};
+
+export type Graph = {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  directed: boolean;
+  weighted: boolean;
+};
+
+// Pre-built default graphs
+export const UNDIRECTED_UNWEIGHTED: Graph = {
+  directed: false,
+  weighted: false,
+  nodes: [
+    { id: 'A', label: 'A', x: 50, y: 10 },
+    { id: 'B', label: 'B', x: 20, y: 40 },
+    { id: 'C', label: 'C', x: 80, y: 40 },
+    { id: 'D', label: 'D', x: 10, y: 80 },
+    { id: 'E', label: 'E', x: 50, y: 70 },
+    { id: 'F', label: 'F', x: 90, y: 80 },
+  ],
+  edges: [
+    { from: 'A', to: 'B' },
+    { from: 'A', to: 'C' },
+    { from: 'B', to: 'D' },
+    { from: 'B', to: 'E' },
+    { from: 'C', to: 'E' },
+    { from: 'C', to: 'F' },
+    { from: 'D', to: 'E' },
+  ],
+};
+
+export const DIRECTED_WEIGHTED: Graph = {
+  directed: true,
+  weighted: true,
+  nodes: [
+    { id: 'A', label: 'A', x: 10, y: 50 },
+    { id: 'B', label: 'B', x: 35, y: 20 },
+    { id: 'C', label: 'C', x: 35, y: 80 },
+    { id: 'D', label: 'D', x: 65, y: 20 },
+    { id: 'E', label: 'E', x: 65, y: 80 },
+    { id: 'F', label: 'F', x: 90, y: 50 },
+  ],
+  edges: [
+    { from: 'A', to: 'B', weight: 4 },
+    { from: 'A', to: 'C', weight: 2 },
+    { from: 'B', to: 'D', weight: 3 },
+    { from: 'B', to: 'C', weight: 1 },
+    { from: 'C', to: 'E', weight: 5 },
+    { from: 'D', to: 'F', weight: 2 },
+    { from: 'E', to: 'D', weight: 1 },
+    { from: 'E', to: 'F', weight: 3 },
+  ],
+};
+
+// For DAG (topological sort)
+export const DIRECTED_DAG: Graph = {
+  directed: true,
+  weighted: false,
+  nodes: [
+    { id: '5', label: '5', x: 10, y: 50 },
+    { id: '4', label: '4', x: 10, y: 10 },
+    { id: '2', label: '2', x: 40, y: 30 },
+    { id: '0', label: '0', x: 70, y: 10 },
+    { id: '1', label: '1', x: 70, y: 50 },
+    { id: '3', label: '3', x: 40, y: 70 },
+  ],
+  edges: [
+    { from: '5', to: '2' },
+    { from: '5', to: '0' },
+    { from: '4', to: '0' },
+    { from: '4', to: '1' },
+    { from: '2', to: '3' },
+    { from: '3', to: '1' },
+  ],
+};

--- a/algo-compendium/_algorithms/math/commands.ts
+++ b/algo-compendium/_algorithms/math/commands.ts
@@ -1,0 +1,96 @@
+export type MathCommand =
+  | { type: 'highlight_number'; index: number; description: string }
+  | { type: 'mark_prime'; index: number; description: string }
+  | { type: 'mark_composite'; index: number; description: string }
+  | {
+      type: 'step';
+      a: number;
+      b: number;
+      remainder: number;
+      description: string;
+    }
+  | { type: 'set_result'; result: number | string; description: string }
+  | { type: 'set_value'; index: number; value: number; description: string }
+  | {
+      type: 'binary_step';
+      bit: number;
+      current: number;
+      result: number;
+      description: string;
+    };
+
+export type MathState = {
+  numbers: number[];
+  primes: number[];
+  composites: number[];
+  highlighted: number | null;
+  steps: { a: number; b: number; remainder: number; description: string }[];
+  sequence: number[];
+  binarySteps: { bit: number; current: number; result: number }[];
+  result: number | string | null;
+  description: string;
+};
+
+export function makeMathState(numbers?: number[]): MathState {
+  return {
+    numbers: numbers ?? [],
+    primes: [],
+    composites: [],
+    highlighted: null,
+    steps: [],
+    sequence: [],
+    binarySteps: [],
+    result: null,
+    description: 'Ready',
+  };
+}
+
+export function mathReducer(state: MathState, cmd: MathCommand): MathState {
+  switch (cmd.type) {
+    case 'highlight_number':
+      return { ...state, highlighted: cmd.index, description: cmd.description };
+    case 'mark_prime':
+      return {
+        ...state,
+        primes: [...new Set([...state.primes, cmd.index])],
+        highlighted: cmd.index,
+        description: cmd.description,
+      };
+    case 'mark_composite':
+      return {
+        ...state,
+        composites: [...new Set([...state.composites, cmd.index])],
+        description: cmd.description,
+      };
+    case 'step':
+      return {
+        ...state,
+        steps: [
+          ...state.steps,
+          {
+            a: cmd.a,
+            b: cmd.b,
+            remainder: cmd.remainder,
+            description: cmd.description,
+          },
+        ],
+        description: cmd.description,
+      };
+    case 'set_result':
+      return { ...state, result: cmd.result, description: cmd.description };
+    case 'set_value': {
+      const sequence = [...state.sequence];
+      sequence[cmd.index] = cmd.value;
+      return { ...state, sequence, description: cmd.description };
+    }
+    case 'binary_step':
+      return {
+        ...state,
+        binarySteps: [
+          ...state.binarySteps,
+          { bit: cmd.bit, current: cmd.current, result: cmd.result },
+        ],
+        description: cmd.description,
+      };
+  }
+}

--- a/algo-compendium/_algorithms/math/euclidean-gcd.test.ts
+++ b/algo-compendium/_algorithms/math/euclidean-gcd.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { gcdCommands } from './euclidean-gcd';
+import { makeMathState, mathReducer } from './commands';
+
+describe('euclideanGcd', () => {
+  it('gcd(48, 18) = 6', () => {
+    const initial = makeMathState([48, 18]);
+    const result = gcdCommands(initial).reduce(mathReducer, initial);
+    expect(result.result).toBe(6);
+  });
+
+  it('gcd(0, 5) = 5', () => {
+    const initial = makeMathState([0, 5]);
+    const result = gcdCommands(initial).reduce(mathReducer, initial);
+    expect(result.result).toBe(5);
+  });
+
+  it('gcd(7, 7) = 7', () => {
+    const initial = makeMathState([7, 7]);
+    const result = gcdCommands(initial).reduce(mathReducer, initial);
+    expect(result.result).toBe(7);
+  });
+
+  it('gcd(100, 75) = 25', () => {
+    const initial = makeMathState([100, 75]);
+    const result = gcdCommands(initial).reduce(mathReducer, initial);
+    expect(result.result).toBe(25);
+  });
+
+  it('gcd(17, 13) = 1 (coprime)', () => {
+    const initial = makeMathState([17, 13]);
+    const result = gcdCommands(initial).reduce(mathReducer, initial);
+    expect(result.result).toBe(1);
+  });
+
+  it('records steps', () => {
+    const initial = makeMathState([48, 18]);
+    const result = gcdCommands(initial).reduce(mathReducer, initial);
+    expect(result.steps.length).toBeGreaterThan(0);
+  });
+});

--- a/algo-compendium/_algorithms/math/euclidean-gcd.ts
+++ b/algo-compendium/_algorithms/math/euclidean-gcd.ts
@@ -1,0 +1,61 @@
+import { registerAlgorithm } from '../registry';
+import type { MathCommand, MathState } from './commands';
+import { makeMathState, mathReducer } from './commands';
+
+export function gcdCommands(state: MathState): MathCommand[] {
+  const cmds: MathCommand[] = [];
+  let a = state.numbers[0];
+  let b = state.numbers[1];
+
+  while (b !== 0) {
+    const remainder = a % b;
+    cmds.push({
+      type: 'step',
+      a,
+      b,
+      remainder,
+      description: `gcd(${a}, ${b}): ${a} = ${Math.floor(a / b)} × ${b} + ${remainder}`,
+    });
+    a = b;
+    b = remainder;
+  }
+
+  // Final step showing gcd(a, 0) = a
+  cmds.push({
+    type: 'step',
+    a,
+    b: 0,
+    remainder: 0,
+    description: `gcd(${a}, 0) = ${a}`,
+  });
+
+  cmds.push({
+    type: 'set_result',
+    result: a,
+    description: `GCD = ${a}`,
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Euclidean GCD',
+  slug: 'euclidean-gcd',
+  category: 'math',
+  description:
+    'Computes the Greatest Common Divisor of two numbers using repeated division. Each step reduces the problem until the remainder is zero.',
+  bestCase: 'O(1)',
+  averageCase: 'O(log min(a,b))',
+  worstCase: 'O(log min(a,b))',
+  spaceComplexity: 'O(1)',
+  pseudocode: `function gcd(a, b):
+  while b != 0:
+    remainder = a mod b
+    a = b
+    b = remainder
+  return a`,
+  visualizerType: 'math',
+  defaultInput: makeMathState([48, 18]),
+  run: gcdCommands,
+  reduce: mathReducer,
+});

--- a/algo-compendium/_algorithms/math/extended-gcd.test.ts
+++ b/algo-compendium/_algorithms/math/extended-gcd.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { extendedGcdCommands } from './extended-gcd';
+import { makeMathState, mathReducer } from './commands';
+
+function runExtGcd(a: number, b: number) {
+  const initial = makeMathState([a, b]);
+  const cmds = extendedGcdCommands(initial);
+  return cmds.reduce(mathReducer, initial);
+}
+
+describe('extendedGcd', () => {
+  it('finds gcd(35,15) = 5 with correct Bezout coefficients', () => {
+    const result = runExtGcd(35, 15);
+    // gcd(35,15) = 5, Bezout: 35*1 + 15*(-2) = 5
+    expect(result.result).toContain('gcd=5');
+  });
+
+  it('Bezout coefficients satisfy ax + by = gcd for (35,15)', () => {
+    const result = runExtGcd(35, 15);
+    const resultStr = result.result as string;
+    const xMatch = resultStr.match(/x=(-?\d+)/);
+    const yMatch = resultStr.match(/y=(-?\d+)/);
+    if (xMatch && yMatch) {
+      const x = parseInt(xMatch[1]);
+      const y = parseInt(yMatch[1]);
+      expect(35 * x + 15 * y).toBe(5);
+    }
+  });
+
+  it('finds gcd(48,18) = 6', () => {
+    const result = runExtGcd(48, 18);
+    expect(result.result).toContain('gcd=6');
+  });
+
+  it('handles gcd(0, 5) = 5', () => {
+    const result = runExtGcd(0, 5);
+    expect(result.result).toContain('gcd=5');
+  });
+
+  it('emits step commands for each Euclidean step', () => {
+    const initial = makeMathState([35, 15]);
+    const cmds = extendedGcdCommands(initial);
+    const stepCmds = cmds.filter((c) => c.type === 'step');
+    expect(stepCmds.length).toBeGreaterThan(0);
+  });
+
+  it('reducer does not mutate state', () => {
+    const initial = makeMathState([35, 15]);
+    const cmds = extendedGcdCommands(initial);
+    if (cmds.length > 0) {
+      const s1 = mathReducer(initial, cmds[0]);
+      expect(initial.result).toBeNull();
+      expect(s1).not.toBe(initial);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/math/extended-gcd.ts
+++ b/algo-compendium/_algorithms/math/extended-gcd.ts
@@ -1,0 +1,111 @@
+import { registerAlgorithm } from '../registry';
+import type { MathCommand, MathState } from './commands';
+import { makeMathState, mathReducer } from './commands';
+
+export function extendedGcdCommands(state: MathState): MathCommand[] {
+  const cmds: MathCommand[] = [];
+  const origA = state.numbers[0];
+  const origB = state.numbers[1];
+
+  if (origA === undefined || origB === undefined) {
+    cmds.push({
+      type: 'set_result',
+      result: 'Invalid input',
+      description: 'Need two numbers',
+    });
+    return cmds;
+  }
+
+  // Iterative extended Euclidean algorithm
+  // Maintain: a = old_a, b = old_b
+  // At each step: a = q*b + r, then a := b, b := r
+  // Coefficients: (old_x, old_y), (x, y) tracking ax + by = current value
+
+  let a = origA;
+  let b = origB;
+  let x0 = 1;
+  let y0 = 0;
+  let x1 = 0;
+  let y1 = 1;
+
+  cmds.push({
+    type: 'highlight_number',
+    index: 0,
+    description: `Extended GCD(${origA}, ${origB}): find x,y such that ${origA}x + ${origB}y = gcd`,
+  });
+
+  while (b !== 0) {
+    const q = Math.floor(a / b);
+    const remainder = a % b;
+
+    cmds.push({
+      type: 'step',
+      a,
+      b,
+      remainder,
+      description: `${a} = ${q} × ${b} + ${remainder} | coeff: (${x0}, ${y0}) → (${x1}, ${y1})`,
+    });
+
+    const newX = x0 - q * x1;
+    const newY = y0 - q * y1;
+
+    a = b;
+    b = remainder;
+    x0 = x1;
+    y0 = y1;
+    x1 = newX;
+    y1 = newY;
+  }
+
+  // Final step
+  const gcd = a;
+  const x = x0;
+  const y = y0;
+
+  cmds.push({
+    type: 'step',
+    a,
+    b: 0,
+    remainder: 0,
+    description: `gcd(${a}, 0) = ${a} | Bezout coefficients: x=${x}, y=${y}`,
+  });
+
+  cmds.push({
+    type: 'highlight_number',
+    index: 0,
+    description: `Verification: ${origA}×(${x}) + ${origB}×(${y}) = ${origA * x + origB * y} = ${gcd}`,
+  });
+
+  cmds.push({
+    type: 'set_result',
+    result: `gcd=${gcd}, x=${x}, y=${y}`,
+    description: `${origA}×${x} + ${origB}×${y} = ${gcd}`,
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Extended GCD',
+  slug: 'extended-gcd',
+  category: 'math',
+  description:
+    'Extends the Euclidean algorithm to find Bézout coefficients x and y such that ax + by = gcd(a,b). These coefficients are useful for computing modular inverses in cryptography.',
+  bestCase: 'O(log min(a,b))',
+  averageCase: 'O(log min(a,b))',
+  worstCase: 'O(log min(a,b))',
+  spaceComplexity: 'O(log min(a,b))',
+  pseudocode: `function extGcd(a, b):
+  if b == 0: return (a, 1, 0)
+  x0, y0, x1, y1 = 1, 0, 0, 1
+  while b != 0:
+    q = floor(a / b)
+    a, b = b, a mod b
+    x0, x1 = x1, x0 - q*x1
+    y0, y1 = y1, y0 - q*y1
+  return (a, x0, y0)  // gcd, x, y`,
+  visualizerType: 'math',
+  defaultInput: makeMathState([35, 15]),
+  run: extendedGcdCommands,
+  reduce: mathReducer,
+});

--- a/algo-compendium/_algorithms/math/fast-power.test.ts
+++ b/algo-compendium/_algorithms/math/fast-power.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { fastPowerCommands } from './fast-power';
+import { makeMathState, mathReducer } from './commands';
+
+describe('fastPower', () => {
+  it('2^10 = 1024', () => {
+    const initial = makeMathState([2, 10]);
+    const result = fastPowerCommands(initial).reduce(mathReducer, initial);
+    expect(result.result).toBe(1024);
+  });
+
+  it('3^5 = 243', () => {
+    const initial = makeMathState([3, 5]);
+    const result = fastPowerCommands(initial).reduce(mathReducer, initial);
+    expect(result.result).toBe(243);
+  });
+
+  it('5^0 = 1', () => {
+    const initial = makeMathState([5, 0]);
+    const result = fastPowerCommands(initial).reduce(mathReducer, initial);
+    expect(result.result).toBe(1);
+  });
+
+  it('2^1 = 2', () => {
+    const initial = makeMathState([2, 1]);
+    const result = fastPowerCommands(initial).reduce(mathReducer, initial);
+    expect(result.result).toBe(2);
+  });
+
+  it('records binary steps', () => {
+    const initial = makeMathState([2, 10]);
+    const result = fastPowerCommands(initial).reduce(mathReducer, initial);
+    expect(result.binarySteps.length).toBeGreaterThan(0);
+  });
+});

--- a/algo-compendium/_algorithms/math/fast-power.ts
+++ b/algo-compendium/_algorithms/math/fast-power.ts
@@ -1,0 +1,61 @@
+import { registerAlgorithm } from '../registry';
+import type { MathCommand, MathState } from './commands';
+import { makeMathState, mathReducer } from './commands';
+
+export function fastPowerCommands(state: MathState): MathCommand[] {
+  const cmds: MathCommand[] = [];
+  const base = state.numbers[0];
+  let exp = state.numbers[1];
+  let current = base;
+  let result = 1;
+
+  while (exp > 0) {
+    const bit = exp & 1;
+    cmds.push({
+      type: 'binary_step',
+      bit,
+      current,
+      result: bit ? result * current : result,
+      description: `exp bit=${bit}, current=${current}, result=${bit ? result * current : result}`,
+    });
+
+    if (bit === 1) {
+      result *= current;
+    }
+    current *= current;
+    exp >>= 1;
+  }
+
+  cmds.push({
+    type: 'set_result',
+    result,
+    description: `${base}^${state.numbers[1]} = ${result}`,
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Fast Power (Binary Exponentiation)',
+  slug: 'fast-power',
+  category: 'math',
+  description:
+    'Computes base^exp in O(log exp) time by squaring the base at each step and multiplying into the result only when the corresponding bit of the exponent is set.',
+  bestCase: 'O(1)',
+  averageCase: 'O(log n)',
+  worstCase: 'O(log n)',
+  spaceComplexity: 'O(1)',
+  pseudocode: `function fastPower(base, exp):
+  result = 1
+  current = base
+  while exp > 0:
+    if exp is odd:
+      result = result * current
+    current = current * current
+    exp = exp >> 1  // divide by 2
+  return result`,
+  visualizerType: 'math',
+  defaultInput: makeMathState([2, 10]),
+  run: fastPowerCommands,
+  reduce: mathReducer,
+});

--- a/algo-compendium/_algorithms/math/fibonacci-variants.test.ts
+++ b/algo-compendium/_algorithms/math/fibonacci-variants.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { fibonacciCommands } from './fibonacci-variants';
+import { makeMathState, mathReducer } from './commands';
+
+describe('fibonacciVariants', () => {
+  it('F(10) = 55', () => {
+    const initial = makeMathState([]);
+    const result = fibonacciCommands(initial).reduce(mathReducer, initial);
+    expect(result.result).toBe(55);
+  });
+
+  it('builds correct sequence F(0)..F(10)', () => {
+    const initial = makeMathState([]);
+    const result = fibonacciCommands(initial).reduce(mathReducer, initial);
+    expect(result.sequence).toEqual([0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]);
+  });
+
+  it('F(0) = 0 and F(1) = 1 (base cases)', () => {
+    const initial = makeMathState([]);
+    const result = fibonacciCommands(initial).reduce(mathReducer, initial);
+    expect(result.sequence[0]).toBe(0);
+    expect(result.sequence[1]).toBe(1);
+  });
+
+  it('sequence has 11 elements (F(0) through F(10))', () => {
+    const initial = makeMathState([]);
+    const result = fibonacciCommands(initial).reduce(mathReducer, initial);
+    expect(result.sequence.length).toBe(11);
+  });
+});

--- a/algo-compendium/_algorithms/math/fibonacci-variants.ts
+++ b/algo-compendium/_algorithms/math/fibonacci-variants.ts
@@ -1,0 +1,69 @@
+import { registerAlgorithm } from '../registry';
+import type { MathCommand, MathState } from './commands';
+import { makeMathState, mathReducer } from './commands';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function fibonacciCommands(_state: MathState): MathCommand[] {
+  const cmds: MathCommand[] = [];
+  const n = 10;
+
+  // Build Fibonacci sequence iteratively
+  const fib: number[] = new Array(n + 1).fill(0);
+  fib[0] = 0;
+  fib[1] = 1;
+
+  cmds.push({
+    type: 'set_value',
+    index: 0,
+    value: 0,
+    description: 'F(0) = 0 (base case)',
+  });
+
+  cmds.push({
+    type: 'set_value',
+    index: 1,
+    value: 1,
+    description: 'F(1) = 1 (base case)',
+  });
+
+  for (let i = 2; i <= n; i++) {
+    fib[i] = fib[i - 1] + fib[i - 2];
+    cmds.push({
+      type: 'set_value',
+      index: i,
+      value: fib[i],
+      description: `F(${i}) = F(${i - 1}) + F(${i - 2}) = ${fib[i - 1]} + ${fib[i - 2]} = ${fib[i]}`,
+    });
+  }
+
+  cmds.push({
+    type: 'set_result',
+    result: fib[n],
+    description: `F(${n}) = ${fib[n]}`,
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Fibonacci Variants',
+  slug: 'fibonacci-variants',
+  category: 'math',
+  description:
+    'Demonstrates iterative Fibonacci computation with memoization. Each value is computed from the two preceding values, building the sequence step by step.',
+  bestCase: 'O(n)',
+  averageCase: 'O(n)',
+  worstCase: 'O(n)',
+  spaceComplexity: 'O(n)',
+  pseudocode: `function fibonacci(n):
+  if n <= 1: return n
+  fib = array of size n+1
+  fib[0] = 0, fib[1] = 1
+  for i from 2 to n:
+    fib[i] = fib[i-1] + fib[i-2]
+  return fib[n]`,
+  visualizerType: 'math',
+  defaultInput: makeMathState([]),
+  run: fibonacciCommands,
+  reduce: mathReducer,
+});

--- a/algo-compendium/_algorithms/math/index.ts
+++ b/algo-compendium/_algorithms/math/index.ts
@@ -1,0 +1,7 @@
+import './sieve-of-eratosthenes';
+import './euclidean-gcd';
+import './fast-power';
+import './prime-factorization';
+import './fibonacci-variants';
+import './extended-gcd';
+import './miller-rabin';

--- a/algo-compendium/_algorithms/math/miller-rabin.test.ts
+++ b/algo-compendium/_algorithms/math/miller-rabin.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { millerRabinCommands } from './miller-rabin';
+import { makeMathState, mathReducer } from './commands';
+
+function runMillerRabin(n: number) {
+  const initial = makeMathState([n]);
+  const cmds = millerRabinCommands(initial);
+  return cmds.reduce(mathReducer, initial);
+}
+
+describe('millerRabin', () => {
+  it('correctly identifies 97 as prime', () => {
+    const result = runMillerRabin(97);
+    expect(result.result).toContain('prime');
+    expect(result.result).not.toContain('composite');
+  });
+
+  it('correctly identifies 2 as prime', () => {
+    const result = runMillerRabin(2);
+    expect(result.result).toContain('prime');
+  });
+
+  it('correctly identifies 100 as composite', () => {
+    const result = runMillerRabin(100);
+    expect(result.result).toContain('composite');
+  });
+
+  it('correctly identifies 561 as composite (Carmichael number)', () => {
+    const result = runMillerRabin(561);
+    expect(result.result).toContain('composite');
+  });
+
+  it('correctly identifies 7 as prime', () => {
+    const result = runMillerRabin(7);
+    expect(result.result).toContain('prime');
+  });
+
+  it('correctly identifies 4 as composite', () => {
+    const result = runMillerRabin(4);
+    expect(result.result).toContain('composite');
+  });
+
+  it('marks prime index for prime numbers', () => {
+    const result = runMillerRabin(97);
+    expect(result.primes).toContain(0);
+  });
+
+  it('marks composite index for composite numbers', () => {
+    const result = runMillerRabin(100);
+    expect(result.composites).toContain(0);
+  });
+
+  it('reducer does not mutate state', () => {
+    const initial = makeMathState([97]);
+    const cmds = millerRabinCommands(initial);
+    if (cmds.length > 0) {
+      const s1 = mathReducer(initial, cmds[0]);
+      expect(initial.result).toBeNull();
+      expect(s1).not.toBe(initial);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/math/miller-rabin.ts
+++ b/algo-compendium/_algorithms/math/miller-rabin.ts
@@ -1,0 +1,192 @@
+import { registerAlgorithm } from '../registry';
+import type { MathCommand, MathState } from './commands';
+import { makeMathState, mathReducer } from './commands';
+
+function modPow(base: number, exp: number, mod: number): number {
+  let result = 1;
+  base = base % mod;
+  while (exp > 0) {
+    if (exp % 2 === 1) {
+      result = (result * base) % mod;
+    }
+    exp = Math.floor(exp / 2);
+    base = (base * base) % mod;
+  }
+  return result;
+}
+
+export function millerRabinCommands(state: MathState): MathCommand[] {
+  const cmds: MathCommand[] = [];
+  const n = state.numbers[0];
+
+  if (n === undefined || n < 2) {
+    cmds.push({
+      type: 'set_result',
+      result: `${n} is not prime`,
+      description: 'Numbers less than 2 are not prime',
+    });
+    return cmds;
+  }
+
+  cmds.push({
+    type: 'highlight_number',
+    index: 0,
+    description: `Testing ${n} for primality using Miller-Rabin with witnesses 2, 3, 5, 7`,
+  });
+
+  // Handle small cases
+  if (n === 2 || n === 3 || n === 5 || n === 7) {
+    cmds.push({
+      type: 'mark_prime',
+      index: 0,
+      description: `${n} is a known prime`,
+    });
+    cmds.push({
+      type: 'set_result',
+      result: `${n} is prime`,
+      description: `${n} is prime (base case)`,
+    });
+    return cmds;
+  }
+
+  if (n % 2 === 0) {
+    cmds.push({
+      type: 'mark_composite',
+      index: 0,
+      description: `${n} is even, not prime`,
+    });
+    cmds.push({
+      type: 'set_result',
+      result: `${n} is composite`,
+      description: `${n} is divisible by 2`,
+    });
+    return cmds;
+  }
+
+  // Write n-1 = 2^r * d
+  let d = n - 1;
+  let r = 0;
+  while (d % 2 === 0) {
+    d = Math.floor(d / 2);
+    r++;
+  }
+
+  cmds.push({
+    type: 'step',
+    a: n - 1,
+    b: r,
+    remainder: d,
+    description: `n-1 = ${n - 1} = 2^${r} × ${d} (r=${r}, d=${d})`,
+  });
+
+  const witnesses = [2, 3, 5, 7];
+  let isPrime = true;
+
+  for (let wi = 0; wi < witnesses.length; wi++) {
+    const a = witnesses[wi];
+
+    if (a >= n) continue;
+
+    cmds.push({
+      type: 'highlight_number',
+      index: 0,
+      description: `Test witness a=${a}: compute ${a}^${d} mod ${n}`,
+    });
+
+    let x = modPow(a, d, n);
+
+    cmds.push({
+      type: 'binary_step',
+      bit: wi,
+      current: a,
+      result: x,
+      description: `Witness ${a}: ${a}^${d} mod ${n} = ${x}`,
+    });
+
+    if (x === 1 || x === n - 1) {
+      cmds.push({
+        type: 'highlight_number',
+        index: 0,
+        description: `Witness ${a} passes (x=${x} is 1 or n-1)`,
+      });
+      continue;
+    }
+
+    let composite = true;
+    for (let i = 0; i < r - 1; i++) {
+      x = (x * x) % n;
+      cmds.push({
+        type: 'binary_step',
+        bit: i,
+        current: x,
+        result: x,
+        description: `Square: x = ${x} (iteration ${i + 1})`,
+      });
+      if (x === n - 1) {
+        composite = false;
+        cmds.push({
+          type: 'highlight_number',
+          index: 0,
+          description: `Witness ${a} passes (x became n-1=${n - 1})`,
+        });
+        break;
+      }
+    }
+
+    if (composite) {
+      isPrime = false;
+      cmds.push({
+        type: 'mark_composite',
+        index: 0,
+        description: `Witness ${a} proves ${n} is composite`,
+      });
+      break;
+    }
+  }
+
+  if (isPrime) {
+    cmds.push({
+      type: 'mark_prime',
+      index: 0,
+      description: `All witnesses passed — ${n} is (probably) prime`,
+    });
+    cmds.push({
+      type: 'set_result',
+      result: `${n} is prime`,
+      description: `Miller-Rabin: ${n} is prime`,
+    });
+  } else {
+    cmds.push({
+      type: 'set_result',
+      result: `${n} is composite`,
+      description: `Miller-Rabin: ${n} is composite`,
+    });
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Miller-Rabin Primality Test',
+  slug: 'miller-rabin',
+  category: 'math',
+  description:
+    'A probabilistic primality test that uses witnesses to determine whether a number is composite or probably prime. Testing with witnesses 2, 3, 5, and 7 gives a deterministic result for all n < 3,215,031,751.',
+  bestCase: 'O(k log²n)',
+  averageCase: 'O(k log²n)',
+  worstCase: 'O(k log²n)',
+  spaceComplexity: 'O(1)',
+  pseudocode: `write n-1 as 2^r * d
+for each witness a in {2,3,5,7}:
+  x = a^d mod n
+  if x == 1 or x == n-1: continue
+  for i = 0 to r-2:
+    x = x² mod n
+    if x == n-1: goto next witness
+  return COMPOSITE
+return PROBABLY PRIME`,
+  visualizerType: 'math',
+  defaultInput: makeMathState([97]),
+  run: millerRabinCommands,
+  reduce: mathReducer,
+});

--- a/algo-compendium/_algorithms/math/prime-factorization.test.ts
+++ b/algo-compendium/_algorithms/math/prime-factorization.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { primeFactorizationCommands } from './prime-factorization';
+import { makeMathState, mathReducer } from './commands';
+
+describe('primeFactorization', () => {
+  it('360 = 2 × 2 × 2 × 3 × 3 × 5', () => {
+    const initial = makeMathState([360]);
+    const result = primeFactorizationCommands(initial).reduce(
+      mathReducer,
+      initial
+    );
+    expect(result.result).toBe('2 × 2 × 2 × 3 × 3 × 5');
+  });
+
+  it('12 = 2 × 2 × 3', () => {
+    const initial = makeMathState([12]);
+    const result = primeFactorizationCommands(initial).reduce(
+      mathReducer,
+      initial
+    );
+    expect(result.result).toBe('2 × 2 × 3');
+  });
+
+  it('prime number 13 = 13', () => {
+    const initial = makeMathState([13]);
+    const result = primeFactorizationCommands(initial).reduce(
+      mathReducer,
+      initial
+    );
+    expect(result.result).toBe('13');
+  });
+
+  it('100 = 2 × 2 × 5 × 5', () => {
+    const initial = makeMathState([100]);
+    const result = primeFactorizationCommands(initial).reduce(
+      mathReducer,
+      initial
+    );
+    expect(result.result).toBe('2 × 2 × 5 × 5');
+  });
+
+  it('builds sequence of factors', () => {
+    const initial = makeMathState([12]);
+    const result = primeFactorizationCommands(initial).reduce(
+      mathReducer,
+      initial
+    );
+    expect(result.sequence.length).toBeGreaterThan(0);
+  });
+});

--- a/algo-compendium/_algorithms/math/prime-factorization.ts
+++ b/algo-compendium/_algorithms/math/prime-factorization.ts
@@ -1,0 +1,81 @@
+import { registerAlgorithm } from '../registry';
+import type { MathCommand, MathState } from './commands';
+import { makeMathState, mathReducer } from './commands';
+
+export function primeFactorizationCommands(state: MathState): MathCommand[] {
+  const cmds: MathCommand[] = [];
+  let n = state.numbers[0];
+  const factors: number[] = [];
+
+  let divisor = 2;
+  while (divisor * divisor <= n) {
+    cmds.push({
+      type: 'highlight_number',
+      index: divisor,
+      description: `Trying divisor ${divisor}`,
+    });
+
+    while (n % divisor === 0) {
+      factors.push(divisor);
+      cmds.push({
+        type: 'set_value',
+        index: factors.length - 1,
+        value: divisor,
+        description: `${divisor} is a factor — ${state.numbers[0]} / ${divisor} = ${n / divisor}`,
+      });
+      n = Math.floor(n / divisor);
+    }
+    divisor++;
+  }
+
+  if (n > 1) {
+    factors.push(n);
+    cmds.push({
+      type: 'highlight_number',
+      index: n,
+      description: `${n} is a prime factor`,
+    });
+    cmds.push({
+      type: 'set_value',
+      index: factors.length - 1,
+      value: n,
+      description: `Remaining factor: ${n}`,
+    });
+  }
+
+  const factorizationStr = factors.join(' × ');
+  cmds.push({
+    type: 'set_result',
+    result: factorizationStr,
+    description: `${state.numbers[0]} = ${factorizationStr}`,
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Prime Factorization',
+  slug: 'prime-factorization',
+  category: 'math',
+  description:
+    'Decomposes a number into its prime factors by trial division up to the square root of n.',
+  bestCase: 'O(√n)',
+  averageCase: 'O(√n)',
+  worstCase: 'O(√n)',
+  spaceComplexity: 'O(log n)',
+  pseudocode: `function primeFactorize(n):
+  factors = []
+  divisor = 2
+  while divisor * divisor <= n:
+    while n % divisor == 0:
+      factors.push(divisor)
+      n = n / divisor
+    divisor++
+  if n > 1:
+    factors.push(n)
+  return factors`,
+  visualizerType: 'math',
+  defaultInput: makeMathState([360]),
+  run: primeFactorizationCommands,
+  reduce: mathReducer,
+});

--- a/algo-compendium/_algorithms/math/sieve-of-eratosthenes.test.ts
+++ b/algo-compendium/_algorithms/math/sieve-of-eratosthenes.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { sieveCommands } from './sieve-of-eratosthenes';
+import { makeMathState, mathReducer } from './commands';
+
+describe('sieveOfEratosthenes', () => {
+  it('finds primes up to 50', () => {
+    const nums = Array.from({ length: 50 }, (_, i) => i);
+    const initial = makeMathState(nums);
+    const cmds = sieveCommands(initial);
+    const result = cmds.reduce(mathReducer, initial);
+    const primeNums = result.primes.map((i) => nums[i]);
+    expect(primeNums).toContain(2);
+    expect(primeNums).toContain(3);
+    expect(primeNums).toContain(5);
+    expect(primeNums).toContain(47);
+    expect(primeNums).not.toContain(4);
+    expect(primeNums).not.toContain(1);
+    expect(primeNums).not.toContain(0);
+  });
+
+  it('correctly marks composites', () => {
+    const nums = Array.from({ length: 20 }, (_, i) => i);
+    const initial = makeMathState(nums);
+    const cmds = sieveCommands(initial);
+    const result = cmds.reduce(mathReducer, initial);
+    const compositeNums = result.composites.map((i) => nums[i]);
+    expect(compositeNums).toContain(4);
+    expect(compositeNums).toContain(6);
+    expect(compositeNums).toContain(9);
+    expect(compositeNums).toContain(12);
+  });
+
+  it('produces correct primes up to 20', () => {
+    const nums = Array.from({ length: 21 }, (_, i) => i);
+    const initial = makeMathState(nums);
+    const cmds = sieveCommands(initial);
+    const result = cmds.reduce(mathReducer, initial);
+    const primeNums = result.primes.map((i) => nums[i]).sort((a, b) => a - b);
+    expect(primeNums).toEqual([2, 3, 5, 7, 11, 13, 17, 19]);
+  });
+});

--- a/algo-compendium/_algorithms/math/sieve-of-eratosthenes.ts
+++ b/algo-compendium/_algorithms/math/sieve-of-eratosthenes.ts
@@ -1,0 +1,74 @@
+import { registerAlgorithm } from '../registry';
+import type { MathCommand, MathState } from './commands';
+import { makeMathState, mathReducer } from './commands';
+
+export function sieveCommands(state: MathState): MathCommand[] {
+  const cmds: MathCommand[] = [];
+  const n = state.numbers.length;
+  const isPrime = new Array(n).fill(true);
+  isPrime[0] = false;
+  isPrime[1] = false;
+
+  for (let i = 2; i < n; i++) {
+    cmds.push({
+      type: 'highlight_number',
+      index: i,
+      description: `Checking if ${state.numbers[i]} is prime`,
+    });
+
+    if (isPrime[i]) {
+      cmds.push({
+        type: 'mark_prime',
+        index: i,
+        description: `${state.numbers[i]} is prime`,
+      });
+
+      for (let j = i * i; j < n; j += i) {
+        if (isPrime[j]) {
+          isPrime[j] = false;
+          cmds.push({
+            type: 'mark_composite',
+            index: j,
+            description: `${state.numbers[j]} is composite (multiple of ${state.numbers[i]})`,
+          });
+        }
+      }
+    }
+  }
+
+  const primeNums = state.numbers
+    .filter((_, i) => isPrime[i] && i >= 2)
+    .join(', ');
+
+  cmds.push({
+    type: 'set_result',
+    result: `Primes: ${primeNums}`,
+    description: `Found all primes up to ${n - 1}`,
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Sieve of Eratosthenes',
+  slug: 'sieve-of-eratosthenes',
+  category: 'math',
+  description:
+    'Efficiently finds all prime numbers up to N by iteratively marking multiples of each prime as composite.',
+  bestCase: 'O(n log log n)',
+  averageCase: 'O(n log log n)',
+  worstCase: 'O(n log log n)',
+  spaceComplexity: 'O(n)',
+  pseudocode: `function sieve(n):
+  isPrime = array of true, size n+1
+  isPrime[0] = isPrime[1] = false
+  for i from 2 to sqrt(n):
+    if isPrime[i]:
+      for j from i*i to n step i:
+        isPrime[j] = false
+  return all i where isPrime[i] is true`,
+  visualizerType: 'math',
+  defaultInput: makeMathState(Array.from({ length: 50 }, (_, i) => i)),
+  run: sieveCommands,
+  reduce: mathReducer,
+});

--- a/algo-compendium/_algorithms/registry.test.ts
+++ b/algo-compendium/_algorithms/registry.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  registerAlgorithm,
+  getAlgorithm,
+  getAlgorithmsByCategory,
+  getAllAlgorithms,
+} from './registry';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeMeta(slug: string, category: 'sorting' | 'math' = 'sorting'): any {
+  return {
+    name: slug,
+    slug,
+    category,
+    description: 'test',
+    bestCase: 'O(1)',
+    averageCase: 'O(n)',
+    worstCase: 'O(n²)',
+    spaceComplexity: 'O(1)',
+    pseudocode: '',
+    visualizerType: 'array',
+    defaultInput: {},
+    run: () => [],
+    reduce: (s: unknown) => s,
+  };
+}
+
+const SORT_SLUG = '_reg-test-sort-' + Math.random().toString(36).slice(2);
+const MATH_SLUG = '_reg-test-math-' + Math.random().toString(36).slice(2);
+
+registerAlgorithm(makeMeta(SORT_SLUG, 'sorting'));
+registerAlgorithm(makeMeta(MATH_SLUG, 'math'));
+
+describe('registry', () => {
+  it('getAlgorithm returns registered entry', () => {
+    const algo = getAlgorithm('sorting', SORT_SLUG);
+    expect(algo).toBeDefined();
+    expect(algo?.slug).toBe(SORT_SLUG);
+    expect(algo?.category).toBe('sorting');
+  });
+
+  it('getAlgorithm returns undefined for unknown slug', () => {
+    expect(getAlgorithm('sorting', '__nonexistent__')).toBeUndefined();
+  });
+
+  it('getAlgorithm returns undefined for wrong category', () => {
+    expect(getAlgorithm('graph', SORT_SLUG)).toBeUndefined();
+  });
+
+  it('getAlgorithmsByCategory filters by category', () => {
+    const sortAlgos = getAlgorithmsByCategory('sorting');
+    const slugs = sortAlgos.map((a) => a.slug);
+    expect(slugs).toContain(SORT_SLUG);
+    expect(slugs).not.toContain(MATH_SLUG);
+  });
+
+  it('getAlgorithmsByCategory returns math entry', () => {
+    const mathAlgos = getAlgorithmsByCategory('math');
+    expect(mathAlgos.map((a) => a.slug)).toContain(MATH_SLUG);
+  });
+
+  it('getAllAlgorithms includes both registered entries', () => {
+    const all = getAllAlgorithms().map((a) => a.slug);
+    expect(all).toContain(SORT_SLUG);
+    expect(all).toContain(MATH_SLUG);
+  });
+
+  it('overwriting same key replaces entry', () => {
+    const updated = {
+      ...makeMeta(SORT_SLUG, 'sorting'),
+      description: 'updated',
+    };
+    registerAlgorithm(updated);
+    expect(getAlgorithm('sorting', SORT_SLUG)?.description).toBe('updated');
+  });
+});

--- a/algo-compendium/_algorithms/registry.ts
+++ b/algo-compendium/_algorithms/registry.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { AlgorithmMeta, AlgorithmCategory } from './_shared/types';
+
+const registry = new Map<string, AlgorithmMeta<any, any>>();
+
+export function registerAlgorithm(meta: AlgorithmMeta<any, any>): void {
+  registry.set(`${meta.category}/${meta.slug}`, meta);
+}
+
+export function getAlgorithm(
+  category: AlgorithmCategory,
+  slug: string
+): AlgorithmMeta<any, any> | undefined {
+  return registry.get(`${category}/${slug}`);
+}
+
+export function getAlgorithmsByCategory(
+  category: AlgorithmCategory
+): AlgorithmMeta<any, any>[] {
+  return [...registry.values()].filter((m) => m.category === category);
+}
+
+export function getAllAlgorithms(): AlgorithmMeta<any, any>[] {
+  return [...registry.values()];
+}

--- a/algo-compendium/_algorithms/searching/binary.test.ts
+++ b/algo-compendium/_algorithms/searching/binary.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { binarySearchCommands } from './binary';
+import { makeSearchState, searchReducer } from './commands';
+
+function runSearch(arr: number[], target: number) {
+  const initial = makeSearchState(arr, target);
+  const cmds = binarySearchCommands(arr, target);
+  return cmds.reduce(searchReducer, initial);
+}
+
+describe('binarySearch', () => {
+  it('finds target', () => {
+    const result = runSearch([11, 21, 34, 39, 45, 56, 67, 73, 82, 91], 45);
+    expect(result.found).toBe(4);
+  });
+  it('target not found', () => {
+    const result = runSearch([1, 2, 3, 4, 5], 99);
+    expect(result.found).toBeNull();
+  });
+  it('empty array', () => expect(runSearch([], 5).found).toBeNull());
+  it('single element match', () => expect(runSearch([5], 5).found).toBe(0));
+  it('single element no match', () =>
+    expect(runSearch([5], 3).found).toBeNull());
+  it('finds first element', () => {
+    const result = runSearch([1, 2, 3, 4, 5], 1);
+    expect(result.found).toBe(0);
+  });
+  it('finds last element', () => {
+    const result = runSearch([1, 2, 3, 4, 5], 5);
+    expect(result.found).toBe(4);
+  });
+  it('reducer does not mutate previous state', () => {
+    const arr = [1, 2, 3];
+    const initial = makeSearchState(arr, 2);
+    const cmds = binarySearchCommands(arr, 2);
+    const s1 = searchReducer(initial, cmds[0]);
+    expect(initial.low).toBeNull();
+    expect(s1).not.toBe(initial);
+  });
+});

--- a/algo-compendium/_algorithms/searching/binary.ts
+++ b/algo-compendium/_algorithms/searching/binary.ts
@@ -1,0 +1,113 @@
+import { registerAlgorithm } from '../registry';
+import type { SearchCommand } from './commands';
+import { makeSearchState, searchReducer } from './commands';
+
+export function binarySearchCommands(
+  array: number[],
+  target: number
+): SearchCommand[] {
+  const cmds: SearchCommand[] = [];
+  const n = array.length;
+
+  if (n === 0) {
+    cmds.push({
+      type: 'not_found',
+      description: `${target} not found in empty array`,
+    });
+    return cmds;
+  }
+
+  let low = 0;
+  let high = n - 1;
+
+  cmds.push({
+    type: 'set_bounds',
+    low,
+    high,
+    description: `Initialize: low=${low}, high=${high}`,
+  });
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+
+    cmds.push({
+      type: 'set_mid',
+      index: mid,
+      description: `mid = (${low} + ${high}) / 2 = ${mid}`,
+    });
+    cmds.push({
+      type: 'compare',
+      index: mid,
+      description: `Comparing a[${mid}]=${array[mid]} with target=${target}`,
+    });
+
+    if (array[mid] === target) {
+      cmds.push({
+        type: 'found',
+        index: mid,
+        description: `Found ${target} at index ${mid}`,
+      });
+      return cmds;
+    } else if (array[mid] < target) {
+      cmds.push({
+        type: 'eliminate',
+        from: low,
+        to: mid,
+        description: `Eliminate left half [${low}..${mid}], target > a[${mid}]`,
+      });
+      low = mid + 1;
+      cmds.push({
+        type: 'set_bounds',
+        low,
+        high,
+        description: `New bounds: low=${low}, high=${high}`,
+      });
+    } else {
+      cmds.push({
+        type: 'eliminate',
+        from: mid,
+        to: high,
+        description: `Eliminate right half [${mid}..${high}], target < a[${mid}]`,
+      });
+      high = mid - 1;
+      cmds.push({
+        type: 'set_bounds',
+        low,
+        high,
+        description: `New bounds: low=${low}, high=${high}`,
+      });
+    }
+  }
+
+  cmds.push({
+    type: 'not_found',
+    description: `${target} not found in array`,
+  });
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Binary Search',
+  slug: 'binary-search',
+  category: 'searching',
+  description:
+    'Efficiently searches a sorted array by repeatedly dividing the search interval in half. If the target is less than the midpoint, search the left half; otherwise search the right half.',
+  bestCase: 'O(1)',
+  averageCase: 'O(log n)',
+  worstCase: 'O(log n)',
+  spaceComplexity: 'O(1)',
+  pseudocode: `low = 0, high = n-1
+while low <= high
+  mid = (low + high) / 2
+  if a[mid] == target
+    return mid
+  else if a[mid] < target
+    low = mid + 1
+  else
+    high = mid - 1
+return -1`,
+  visualizerType: 'array',
+  defaultInput: makeSearchState([11, 21, 34, 39, 45, 56, 67, 73, 82, 91], 45),
+  run: (state) => binarySearchCommands(state.array, state.target),
+  reduce: searchReducer,
+});

--- a/algo-compendium/_algorithms/searching/commands.ts
+++ b/algo-compendium/_algorithms/searching/commands.ts
@@ -1,0 +1,78 @@
+export type SearchCommand =
+  | { type: 'visit'; index: number; description: string }
+  | { type: 'compare'; index: number; description: string }
+  | { type: 'eliminate'; from: number; to: number; description: string }
+  | { type: 'found'; index: number; description: string }
+  | { type: 'not_found'; description: string }
+  | { type: 'set_bounds'; low: number; high: number; description: string }
+  | { type: 'set_mid'; index: number; description: string };
+
+export type SearchState = {
+  array: number[];
+  target: number;
+  current: number | null; // index currently being examined
+  low: number | null; // lower bound for binary-style searches
+  high: number | null; // upper bound
+  mid: number | null; // midpoint
+  eliminated: number[]; // indices eliminated from search
+  found: number | null; // index where target was found, or null
+  description: string;
+};
+
+export function makeSearchState(array: number[], target: number): SearchState {
+  return {
+    array: [...array],
+    target,
+    current: null,
+    low: null,
+    high: null,
+    mid: null,
+    eliminated: [],
+    found: null,
+    description: `Searching for ${target}`,
+  };
+}
+
+export function searchReducer(
+  state: SearchState,
+  cmd: SearchCommand
+): SearchState {
+  switch (cmd.type) {
+    case 'visit':
+      return { ...state, current: cmd.index, description: cmd.description };
+    case 'compare':
+      return { ...state, current: cmd.index, description: cmd.description };
+    case 'eliminate':
+      return {
+        ...state,
+        eliminated: [
+          ...new Set([...state.eliminated, ...range(cmd.from, cmd.to)]),
+        ],
+        description: cmd.description,
+      };
+    case 'found':
+      return {
+        ...state,
+        found: cmd.index,
+        current: cmd.index,
+        description: cmd.description,
+      };
+    case 'not_found':
+      return { ...state, current: null, description: cmd.description };
+    case 'set_bounds':
+      return {
+        ...state,
+        low: cmd.low,
+        high: cmd.high,
+        description: cmd.description,
+      };
+    case 'set_mid':
+      return { ...state, mid: cmd.index, description: cmd.description };
+  }
+}
+
+function range(from: number, to: number): number[] {
+  const result: number[] = [];
+  for (let i = from; i <= to; i++) result.push(i);
+  return result;
+}

--- a/algo-compendium/_algorithms/searching/exponential.test.ts
+++ b/algo-compendium/_algorithms/searching/exponential.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { exponentialSearchCommands } from './exponential';
+import { makeSearchState, searchReducer } from './commands';
+
+function runSearch(arr: number[], target: number) {
+  const initial = makeSearchState(arr, target);
+  const cmds = exponentialSearchCommands(arr, target);
+  return cmds.reduce(searchReducer, initial);
+}
+
+describe('exponentialSearch', () => {
+  it('finds target', () => {
+    const result = runSearch([11, 21, 34, 39, 45, 56, 67, 73, 82, 91], 45);
+    expect(result.found).toBe(4);
+  });
+  it('target not found', () => {
+    const result = runSearch([1, 2, 3, 4, 5], 99);
+    expect(result.found).toBeNull();
+  });
+  it('empty array', () => expect(runSearch([], 5).found).toBeNull());
+  it('single element match', () => expect(runSearch([5], 5).found).toBe(0));
+  it('single element no match', () =>
+    expect(runSearch([5], 3).found).toBeNull());
+  it('finds first element', () => {
+    const result = runSearch([1, 2, 3, 4, 5], 1);
+    expect(result.found).toBe(0);
+  });
+  it('finds large index', () => {
+    const arr = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+    const result = runSearch(arr, 17);
+    expect(result.found).toBe(8);
+  });
+  it('reducer does not mutate previous state', () => {
+    const arr = [1, 2, 3];
+    const initial = makeSearchState(arr, 2);
+    const cmds = exponentialSearchCommands(arr, 2);
+    const s1 = searchReducer(initial, cmds[0]);
+    expect(initial.current).toBeNull();
+    expect(s1).not.toBe(initial);
+  });
+});

--- a/algo-compendium/_algorithms/searching/exponential.ts
+++ b/algo-compendium/_algorithms/searching/exponential.ts
@@ -1,0 +1,146 @@
+import { registerAlgorithm } from '../registry';
+import type { SearchCommand } from './commands';
+import { makeSearchState, searchReducer } from './commands';
+
+export function exponentialSearchCommands(
+  array: number[],
+  target: number
+): SearchCommand[] {
+  const cmds: SearchCommand[] = [];
+  const n = array.length;
+
+  if (n === 0) {
+    cmds.push({
+      type: 'not_found',
+      description: `${target} not found in empty array`,
+    });
+    return cmds;
+  }
+
+  // Check first element
+  cmds.push({
+    type: 'compare',
+    index: 0,
+    description: `Check a[0]=${array[0]} against target=${target}`,
+  });
+  if (array[0] === target) {
+    cmds.push({
+      type: 'found',
+      index: 0,
+      description: `Found ${target} at index 0`,
+    });
+    return cmds;
+  }
+
+  // Find range by doubling
+  let bound = 1;
+  while (bound < n && array[bound] <= target) {
+    cmds.push({
+      type: 'visit',
+      index: bound,
+      description: `Exponential jump to index ${bound}: a[${bound}]=${array[bound]}`,
+    });
+    cmds.push({
+      type: 'compare',
+      index: bound,
+      description: `a[${bound}]=${array[bound]} <= ${target}, double bound`,
+    });
+    bound *= 2;
+  }
+
+  // Binary search in range [bound/2, min(bound, n-1)]
+  const low = Math.floor(bound / 2);
+  const high = Math.min(bound, n - 1);
+
+  cmds.push({
+    type: 'eliminate',
+    from: 0,
+    to: low - 1 >= 0 ? low - 1 : 0,
+    description: `Eliminate [0..${low > 0 ? low - 1 : 0}], binary search in [${low}..${high}]`,
+  });
+  cmds.push({
+    type: 'set_bounds',
+    low,
+    high,
+    description: `Binary search range: low=${low}, high=${high}`,
+  });
+
+  let bLow = low;
+  let bHigh = high;
+  while (bLow <= bHigh) {
+    const mid = Math.floor((bLow + bHigh) / 2);
+    cmds.push({
+      type: 'set_mid',
+      index: mid,
+      description: `mid = (${bLow} + ${bHigh}) / 2 = ${mid}`,
+    });
+    cmds.push({
+      type: 'compare',
+      index: mid,
+      description: `Comparing a[${mid}]=${array[mid]} with target=${target}`,
+    });
+    if (array[mid] === target) {
+      cmds.push({
+        type: 'found',
+        index: mid,
+        description: `Found ${target} at index ${mid}`,
+      });
+      return cmds;
+    } else if (array[mid] < target) {
+      cmds.push({
+        type: 'eliminate',
+        from: bLow,
+        to: mid,
+        description: `Eliminate left [${bLow}..${mid}]`,
+      });
+      bLow = mid + 1;
+      cmds.push({
+        type: 'set_bounds',
+        low: bLow,
+        high: bHigh,
+        description: `New bounds: low=${bLow}, high=${bHigh}`,
+      });
+    } else {
+      cmds.push({
+        type: 'eliminate',
+        from: mid,
+        to: bHigh,
+        description: `Eliminate right [${mid}..${bHigh}]`,
+      });
+      bHigh = mid - 1;
+      cmds.push({
+        type: 'set_bounds',
+        low: bLow,
+        high: bHigh,
+        description: `New bounds: low=${bLow}, high=${bHigh}`,
+      });
+    }
+  }
+
+  cmds.push({
+    type: 'not_found',
+    description: `${target} not found in array`,
+  });
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Exponential Search',
+  slug: 'exponential-search',
+  category: 'searching',
+  description:
+    'Finds the range where the target may exist by exponentially doubling the bound, then performs binary search within that range. Useful for unbounded or infinite sorted arrays.',
+  bestCase: 'O(1)',
+  averageCase: 'O(log n)',
+  worstCase: 'O(log n)',
+  spaceComplexity: 'O(1)',
+  pseudocode: `if a[0] == target: return 0
+bound = 1
+while bound < n and a[bound] <= target
+  bound *= 2
+binary search in a[bound/2 .. min(bound, n-1)]`,
+  visualizerType: 'array',
+  defaultInput: makeSearchState([11, 21, 34, 39, 45, 56, 67, 73, 82, 91], 45),
+  run: (state) => exponentialSearchCommands(state.array, state.target),
+  reduce: searchReducer,
+});

--- a/algo-compendium/_algorithms/searching/fibonacci-search.test.ts
+++ b/algo-compendium/_algorithms/searching/fibonacci-search.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { fibonacciSearchCommands } from './fibonacci-search';
+import { makeSearchState, searchReducer } from './commands';
+
+function runSearch(array: number[], target: number) {
+  const initial = makeSearchState(array, target);
+  const cmds = fibonacciSearchCommands(array, target);
+  return cmds.reduce(searchReducer, initial);
+}
+
+describe('fibonacciSearch', () => {
+  it('finds target in the middle', () => {
+    const result = runSearch([10, 22, 35, 40, 45, 50, 80, 82, 85, 90, 100], 85);
+    expect(result.found).toBe(8);
+  });
+
+  it('finds target at the beginning', () => {
+    const result = runSearch([10, 22, 35, 40, 45], 10);
+    expect(result.found).toBe(0);
+  });
+
+  it('finds target at the end', () => {
+    const result = runSearch([10, 22, 35, 40, 45], 45);
+    expect(result.found).toBeGreaterThanOrEqual(4);
+  });
+
+  it('returns not found for missing target', () => {
+    const result = runSearch([10, 22, 35, 40, 45], 99);
+    expect(result.found).toBeNull();
+  });
+
+  it('handles empty array', () => {
+    const result = runSearch([], 5);
+    expect(result.found).toBeNull();
+  });
+
+  it('handles single element — found', () => {
+    const result = runSearch([42], 42);
+    expect(result.found).toBe(0);
+  });
+
+  it('handles single element — not found', () => {
+    const result = runSearch([42], 99);
+    expect(result.found).toBeNull();
+  });
+
+  it('reducer does not mutate state', () => {
+    const initial = makeSearchState([10, 22, 35], 22);
+    const cmds = fibonacciSearchCommands([10, 22, 35], 22);
+    if (cmds.length > 0) {
+      const s1 = searchReducer(initial, cmds[0]);
+      expect(initial.array).toEqual([10, 22, 35]);
+      expect(s1).not.toBe(initial);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/searching/fibonacci-search.ts
+++ b/algo-compendium/_algorithms/searching/fibonacci-search.ts
@@ -1,0 +1,149 @@
+import { registerAlgorithm } from '../registry';
+import type { SearchCommand } from './commands';
+import { makeSearchState, searchReducer } from './commands';
+
+export function fibonacciSearchCommands(
+  array: number[],
+  target: number
+): SearchCommand[] {
+  const cmds: SearchCommand[] = [];
+  const n = array.length;
+
+  if (n === 0) {
+    cmds.push({ type: 'not_found', description: 'Array is empty' });
+    return cmds;
+  }
+
+  // Build Fibonacci numbers up to n
+  let fibM2 = 0; // (m-2)th Fibonacci
+  let fibM1 = 1; // (m-1)th Fibonacci
+  let fibM = fibM2 + fibM1; // mth Fibonacci
+
+  while (fibM < n) {
+    fibM2 = fibM1;
+    fibM1 = fibM;
+    fibM = fibM2 + fibM1;
+  }
+
+  let offset = -1;
+
+  cmds.push({
+    type: 'set_bounds',
+    low: 0,
+    high: n - 1,
+    description: `Fibonacci search: fibM=${fibM}, searching for ${target} in ${n} elements`,
+  });
+
+  while (fibM > 1) {
+    const i = Math.min(offset + fibM2, n - 1);
+
+    cmds.push({
+      type: 'set_mid',
+      index: i,
+      description: `Check index ${i} (fibM2=${fibM2})`,
+    });
+    cmds.push({
+      type: 'compare',
+      index: i,
+      description: `Compare a[${i}]=${array[i]} with target ${target}`,
+    });
+
+    if (array[i] < target) {
+      fibM = fibM1;
+      fibM1 = fibM2;
+      fibM2 = fibM - fibM1;
+      offset = i;
+      cmds.push({
+        type: 'eliminate',
+        from: 0,
+        to: i,
+        description: `a[${i}]=${array[i]} < ${target}, eliminate left side`,
+      });
+      cmds.push({
+        type: 'set_bounds',
+        low: i + 1,
+        high: n - 1,
+        description: `New search range: [${i + 1}, ${n - 1}]`,
+      });
+    } else if (array[i] > target) {
+      fibM = fibM2;
+      fibM1 = fibM1 - fibM2;
+      fibM2 = fibM - fibM1;
+      cmds.push({
+        type: 'eliminate',
+        from: i,
+        to: n - 1,
+        description: `a[${i}]=${array[i]} > ${target}, eliminate right side`,
+      });
+      cmds.push({
+        type: 'set_bounds',
+        low: offset + 1,
+        high: i - 1,
+        description: `New search range: [${offset + 1}, ${i - 1}]`,
+      });
+    } else {
+      cmds.push({
+        type: 'found',
+        index: i,
+        description: `Found ${target} at index ${i}`,
+      });
+      return cmds;
+    }
+  }
+
+  // Check last remaining element
+  if (fibM1 && offset + 1 < n) {
+    const i = offset + 1;
+    cmds.push({
+      type: 'compare',
+      index: i,
+      description: `Final check: compare a[${i}]=${array[i]} with target ${target}`,
+    });
+    if (array[i] === target) {
+      cmds.push({
+        type: 'found',
+        index: i,
+        description: `Found ${target} at index ${i}`,
+      });
+      return cmds;
+    }
+  }
+
+  cmds.push({
+    type: 'not_found',
+    description: `${target} not found in array`,
+  });
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Fibonacci Search',
+  slug: 'fibonacci-search',
+  category: 'searching',
+  description:
+    'Searches a sorted array using Fibonacci numbers to divide the search space. Similar to binary search but uses Fibonacci number offsets instead of halving, which can be advantageous in systems with sequential access.',
+  bestCase: 'O(1)',
+  averageCase: 'O(log n)',
+  worstCase: 'O(log n)',
+  spaceComplexity: 'O(1)',
+  pseudocode: `fibM2=0, fibM1=1, fibM=1
+while fibM < n: advance Fibonacci numbers
+offset = -1
+while fibM > 1:
+  i = min(offset + fibM2, n-1)
+  if a[i] < target:
+    fibM=fibM1; fibM1=fibM2; fibM2=fibM-fibM1
+    offset = i
+  else if a[i] > target:
+    fibM=fibM2; fibM1-=fibM2; fibM2=fibM-fibM1
+  else: return i
+if fibM1 and a[offset+1]==target: return offset+1
+return -1`,
+  visualizerType: 'array',
+  defaultInput: makeSearchState(
+    [10, 22, 35, 40, 45, 50, 80, 82, 85, 90, 100],
+    85
+  ),
+  run: (state) => fibonacciSearchCommands(state.array, state.target),
+  reduce: searchReducer,
+});

--- a/algo-compendium/_algorithms/searching/index.ts
+++ b/algo-compendium/_algorithms/searching/index.ts
@@ -1,0 +1,7 @@
+import './linear';
+import './binary';
+import './jump';
+import './interpolation';
+import './exponential';
+import './ternary';
+import './fibonacci-search';

--- a/algo-compendium/_algorithms/searching/interpolation.test.ts
+++ b/algo-compendium/_algorithms/searching/interpolation.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { interpolationSearchCommands } from './interpolation';
+import { makeSearchState, searchReducer } from './commands';
+
+function runSearch(arr: number[], target: number) {
+  const initial = makeSearchState(arr, target);
+  const cmds = interpolationSearchCommands(arr, target);
+  return cmds.reduce(searchReducer, initial);
+}
+
+describe('interpolationSearch', () => {
+  it('finds target', () => {
+    const result = runSearch([11, 21, 34, 39, 45, 56, 67, 73, 82, 91], 45);
+    expect(result.found).toBe(4);
+  });
+  it('target not found', () => {
+    const result = runSearch([1, 2, 3, 4, 5], 99);
+    expect(result.found).toBeNull();
+  });
+  it('empty array', () => expect(runSearch([], 5).found).toBeNull());
+  it('single element match', () => expect(runSearch([5], 5).found).toBe(0));
+  it('single element no match', () =>
+    expect(runSearch([5], 3).found).toBeNull());
+  it('finds first element', () => {
+    const result = runSearch([10, 20, 30, 40, 50], 10);
+    expect(result.found).toBe(0);
+  });
+  it('finds last element', () => {
+    const result = runSearch([10, 20, 30, 40, 50], 50);
+    expect(result.found).toBe(4);
+  });
+  it('reducer does not mutate previous state', () => {
+    const arr = [1, 2, 3];
+    const initial = makeSearchState(arr, 2);
+    const cmds = interpolationSearchCommands(arr, 2);
+    const s1 = searchReducer(initial, cmds[0]);
+    expect(initial.low).toBeNull();
+    expect(s1).not.toBe(initial);
+  });
+});

--- a/algo-compendium/_algorithms/searching/interpolation.ts
+++ b/algo-compendium/_algorithms/searching/interpolation.ts
@@ -1,0 +1,135 @@
+import { registerAlgorithm } from '../registry';
+import type { SearchCommand } from './commands';
+import { makeSearchState, searchReducer } from './commands';
+
+export function interpolationSearchCommands(
+  array: number[],
+  target: number
+): SearchCommand[] {
+  const cmds: SearchCommand[] = [];
+  const n = array.length;
+
+  if (n === 0) {
+    cmds.push({
+      type: 'not_found',
+      description: `${target} not found in empty array`,
+    });
+    return cmds;
+  }
+
+  let low = 0;
+  let high = n - 1;
+
+  cmds.push({
+    type: 'set_bounds',
+    low,
+    high,
+    description: `Initialize: low=${low}, high=${high}`,
+  });
+
+  while (low <= high && target >= array[low] && target <= array[high]) {
+    if (low === high) {
+      cmds.push({
+        type: 'compare',
+        index: low,
+        description: `Single element: comparing a[${low}]=${array[low]} with target=${target}`,
+      });
+      if (array[low] === target) {
+        cmds.push({
+          type: 'found',
+          index: low,
+          description: `Found ${target} at index ${low}`,
+        });
+      } else {
+        cmds.push({
+          type: 'not_found',
+          description: `${target} not found in array`,
+        });
+      }
+      return cmds;
+    }
+
+    // Interpolation formula
+    const rangeDivisor = array[high] - array[low];
+    const pos =
+      low + Math.floor(((target - array[low]) * (high - low)) / rangeDivisor);
+    const clampedPos = Math.max(low, Math.min(high, pos));
+
+    cmds.push({
+      type: 'set_mid',
+      index: clampedPos,
+      description: `Interpolated pos = ${low} + ((${target} - ${array[low]}) * (${high} - ${low})) / (${array[high]} - ${array[low]}) = ${clampedPos}`,
+    });
+    cmds.push({
+      type: 'compare',
+      index: clampedPos,
+      description: `Comparing a[${clampedPos}]=${array[clampedPos]} with target=${target}`,
+    });
+
+    if (array[clampedPos] === target) {
+      cmds.push({
+        type: 'found',
+        index: clampedPos,
+        description: `Found ${target} at index ${clampedPos}`,
+      });
+      return cmds;
+    } else if (array[clampedPos] < target) {
+      cmds.push({
+        type: 'eliminate',
+        from: low,
+        to: clampedPos,
+        description: `Eliminate [${low}..${clampedPos}], target > a[${clampedPos}]`,
+      });
+      low = clampedPos + 1;
+      cmds.push({
+        type: 'set_bounds',
+        low,
+        high,
+        description: `New bounds: low=${low}, high=${high}`,
+      });
+    } else {
+      cmds.push({
+        type: 'eliminate',
+        from: clampedPos,
+        to: high,
+        description: `Eliminate [${clampedPos}..${high}], target < a[${clampedPos}]`,
+      });
+      high = clampedPos - 1;
+      cmds.push({
+        type: 'set_bounds',
+        low,
+        high,
+        description: `New bounds: low=${low}, high=${high}`,
+      });
+    }
+  }
+
+  cmds.push({
+    type: 'not_found',
+    description: `${target} not found in array`,
+  });
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Interpolation Search',
+  slug: 'interpolation-search',
+  category: 'searching',
+  description:
+    'An improved variant of binary search for uniformly distributed sorted arrays. Uses interpolation to estimate the position of the target, potentially finding it faster than binary search.',
+  bestCase: 'O(1)',
+  averageCase: 'O(log log n)',
+  worstCase: 'O(n)',
+  spaceComplexity: 'O(1)',
+  pseudocode: `low = 0, high = n-1
+while low <= high and target in [a[low], a[high]]
+  pos = low + ((target - a[low]) * (high - low)) / (a[high] - a[low])
+  if a[pos] == target: return pos
+  else if a[pos] < target: low = pos + 1
+  else: high = pos - 1
+return -1`,
+  visualizerType: 'array',
+  defaultInput: makeSearchState([11, 21, 34, 39, 45, 56, 67, 73, 82, 91], 45),
+  run: (state) => interpolationSearchCommands(state.array, state.target),
+  reduce: searchReducer,
+});

--- a/algo-compendium/_algorithms/searching/jump.test.ts
+++ b/algo-compendium/_algorithms/searching/jump.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { jumpSearchCommands } from './jump';
+import { makeSearchState, searchReducer } from './commands';
+
+function runSearch(arr: number[], target: number) {
+  const initial = makeSearchState(arr, target);
+  const cmds = jumpSearchCommands(arr, target);
+  return cmds.reduce(searchReducer, initial);
+}
+
+describe('jumpSearch', () => {
+  it('finds target', () => {
+    const result = runSearch([11, 21, 34, 39, 45, 56, 67, 73, 82, 91], 45);
+    expect(result.found).toBe(4);
+  });
+  it('target not found', () => {
+    const result = runSearch([1, 2, 3, 4, 5], 99);
+    expect(result.found).toBeNull();
+  });
+  it('empty array', () => expect(runSearch([], 5).found).toBeNull());
+  it('single element match', () => expect(runSearch([5], 5).found).toBe(0));
+  it('single element no match', () =>
+    expect(runSearch([5], 3).found).toBeNull());
+  it('finds first element', () => {
+    const result = runSearch([1, 2, 3, 4, 5], 1);
+    expect(result.found).toBe(0);
+  });
+  it('finds last element', () => {
+    const result = runSearch([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 10);
+    expect(result.found).toBe(9);
+  });
+  it('reducer does not mutate previous state', () => {
+    const arr = [1, 2, 3, 4];
+    const initial = makeSearchState(arr, 3);
+    const cmds = jumpSearchCommands(arr, 3);
+    const s1 = searchReducer(initial, cmds[0]);
+    expect(initial.current).toBeNull();
+    expect(s1).not.toBe(initial);
+  });
+});

--- a/algo-compendium/_algorithms/searching/jump.ts
+++ b/algo-compendium/_algorithms/searching/jump.ts
@@ -1,0 +1,107 @@
+import { registerAlgorithm } from '../registry';
+import type { SearchCommand } from './commands';
+import { makeSearchState, searchReducer } from './commands';
+
+export function jumpSearchCommands(
+  array: number[],
+  target: number
+): SearchCommand[] {
+  const cmds: SearchCommand[] = [];
+  const n = array.length;
+
+  if (n === 0) {
+    cmds.push({
+      type: 'not_found',
+      description: `${target} not found in empty array`,
+    });
+    return cmds;
+  }
+
+  const step = Math.floor(Math.sqrt(n));
+  let prev = 0;
+  let curr = Math.min(step, n) - 1;
+
+  // Jump phase: find the block where target may exist
+  while (curr < n && array[curr] < target) {
+    cmds.push({
+      type: 'visit',
+      index: curr,
+      description: `Jump to index ${curr}: a[${curr}]=${array[curr]} < ${target}, jump ahead`,
+    });
+    cmds.push({
+      type: 'compare',
+      index: curr,
+      description: `a[${curr}]=${array[curr]} < target=${target}, continue jumping`,
+    });
+    cmds.push({
+      type: 'eliminate',
+      from: prev,
+      to: curr,
+      description: `Block [${prev}..${curr}] eliminated`,
+    });
+    prev = curr + 1;
+    if (prev >= n) break;
+    curr = Math.min(curr + step, n - 1);
+  }
+
+  // Linear scan phase within the identified block
+  cmds.push({
+    type: 'set_bounds',
+    low: prev,
+    high: Math.min(curr, n - 1),
+    description: `Linear scan in block [${prev}..${Math.min(curr, n - 1)}]`,
+  });
+
+  for (let i = prev; i <= Math.min(curr, n - 1); i++) {
+    cmds.push({
+      type: 'visit',
+      index: i,
+      description: `Linear scan at index ${i}: a[${i}]=${array[i]}`,
+    });
+    cmds.push({
+      type: 'compare',
+      index: i,
+      description: `Comparing a[${i}]=${array[i]} with target=${target}`,
+    });
+    if (array[i] === target) {
+      cmds.push({
+        type: 'found',
+        index: i,
+        description: `Found ${target} at index ${i}`,
+      });
+      return cmds;
+    }
+    if (array[i] > target) break;
+  }
+
+  cmds.push({
+    type: 'not_found',
+    description: `${target} not found in array`,
+  });
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Jump Search',
+  slug: 'jump-search',
+  category: 'searching',
+  description:
+    'Works on sorted arrays by jumping ahead by fixed steps of √n, then performing a linear search backwards in the identified block. Faster than linear search for large sorted arrays.',
+  bestCase: 'O(1)',
+  averageCase: 'O(√n)',
+  worstCase: 'O(√n)',
+  spaceComplexity: 'O(1)',
+  pseudocode: `step = sqrt(n)
+prev = 0
+while a[min(step,n)-1] < target
+  prev = step
+  step += sqrt(n)
+  if prev >= n: return -1
+for i = prev to min(step, n)-1
+  if a[i] == target: return i
+return -1`,
+  visualizerType: 'array',
+  defaultInput: makeSearchState([11, 21, 34, 39, 45, 56, 67, 73, 82, 91], 45),
+  run: (state) => jumpSearchCommands(state.array, state.target),
+  reduce: searchReducer,
+});

--- a/algo-compendium/_algorithms/searching/linear.test.ts
+++ b/algo-compendium/_algorithms/searching/linear.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { linearSearchCommands } from './linear';
+import { makeSearchState, searchReducer } from './commands';
+
+function runSearch(arr: number[], target: number) {
+  const initial = makeSearchState(arr, target);
+  const cmds = linearSearchCommands(arr, target);
+  return cmds.reduce(searchReducer, initial);
+}
+
+describe('linearSearch', () => {
+  it('finds target', () => {
+    const result = runSearch([11, 21, 34, 39, 45], 34);
+    expect(result.found).toBe(2);
+  });
+  it('target not found', () => {
+    const result = runSearch([1, 2, 3], 99);
+    expect(result.found).toBeNull();
+  });
+  it('empty array', () => expect(runSearch([], 5).found).toBeNull());
+  it('single element match', () => expect(runSearch([5], 5).found).toBe(0));
+  it('single element no match', () =>
+    expect(runSearch([5], 3).found).toBeNull());
+  it('finds first occurrence', () => {
+    const result = runSearch([1, 2, 3, 4, 5], 1);
+    expect(result.found).toBe(0);
+  });
+  it('finds last element', () => {
+    const result = runSearch([1, 2, 3, 4, 5], 5);
+    expect(result.found).toBe(4);
+  });
+  it('reducer does not mutate previous state', () => {
+    const arr = [1, 2, 3];
+    const initial = makeSearchState(arr, 2);
+    const cmds = linearSearchCommands(arr, 2);
+    const s1 = searchReducer(initial, cmds[0]);
+    expect(initial.current).toBeNull();
+    expect(s1).not.toBe(initial);
+  });
+});

--- a/algo-compendium/_algorithms/searching/linear.ts
+++ b/algo-compendium/_algorithms/searching/linear.ts
@@ -1,0 +1,58 @@
+import { registerAlgorithm } from '../registry';
+import type { SearchCommand } from './commands';
+import { makeSearchState, searchReducer } from './commands';
+
+export function linearSearchCommands(
+  array: number[],
+  target: number
+): SearchCommand[] {
+  const cmds: SearchCommand[] = [];
+  const n = array.length;
+
+  for (let i = 0; i < n; i++) {
+    cmds.push({
+      type: 'visit',
+      index: i,
+      description: `Visiting index ${i}: value = ${array[i]}`,
+    });
+    cmds.push({
+      type: 'compare',
+      index: i,
+      description: `Comparing a[${i}]=${array[i]} with target=${target}`,
+    });
+    if (array[i] === target) {
+      cmds.push({
+        type: 'found',
+        index: i,
+        description: `Found ${target} at index ${i}`,
+      });
+      return cmds;
+    }
+  }
+
+  cmds.push({
+    type: 'not_found',
+    description: `${target} not found in array`,
+  });
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Linear Search',
+  slug: 'linear-search',
+  category: 'searching',
+  description:
+    'Sequentially checks each element of the list until a match is found or the whole list has been searched. Works on both sorted and unsorted arrays.',
+  bestCase: 'O(1)',
+  averageCase: 'O(n)',
+  worstCase: 'O(n)',
+  spaceComplexity: 'O(1)',
+  pseudocode: `for i = 0 to n-1
+  if a[i] == target
+    return i
+return -1`,
+  visualizerType: 'array',
+  defaultInput: makeSearchState([11, 21, 34, 39, 45, 56, 67, 73, 82, 91], 45),
+  run: (state) => linearSearchCommands(state.array, state.target),
+  reduce: searchReducer,
+});

--- a/algo-compendium/_algorithms/searching/ternary.test.ts
+++ b/algo-compendium/_algorithms/searching/ternary.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { ternarySearchCommands } from './ternary';
+import { makeSearchState, searchReducer } from './commands';
+
+function runSearch(arr: number[], target: number) {
+  const initial = makeSearchState(arr, target);
+  const cmds = ternarySearchCommands(arr, target);
+  return cmds.reduce(searchReducer, initial);
+}
+
+describe('ternarySearch', () => {
+  it('finds target', () => {
+    const result = runSearch([11, 21, 34, 39, 45, 56, 67, 73, 82, 91], 45);
+    expect(result.found).toBe(4);
+  });
+  it('target not found', () => {
+    const result = runSearch([1, 2, 3, 4, 5], 99);
+    expect(result.found).toBeNull();
+  });
+  it('empty array', () => expect(runSearch([], 5).found).toBeNull());
+  it('single element match', () => expect(runSearch([5], 5).found).toBe(0));
+  it('single element no match', () =>
+    expect(runSearch([5], 3).found).toBeNull());
+  it('finds first element', () => {
+    const result = runSearch([1, 2, 3, 4, 5], 1);
+    expect(result.found).toBe(0);
+  });
+  it('finds last element', () => {
+    const result = runSearch([1, 2, 3, 4, 5], 5);
+    expect(result.found).toBe(4);
+  });
+  it('reducer does not mutate previous state', () => {
+    const arr = [1, 2, 3];
+    const initial = makeSearchState(arr, 2);
+    const cmds = ternarySearchCommands(arr, 2);
+    const s1 = searchReducer(initial, cmds[0]);
+    expect(initial.low).toBeNull();
+    expect(s1).not.toBe(initial);
+  });
+});

--- a/algo-compendium/_algorithms/searching/ternary.ts
+++ b/algo-compendium/_algorithms/searching/ternary.ts
@@ -1,0 +1,154 @@
+import { registerAlgorithm } from '../registry';
+import type { SearchCommand } from './commands';
+import { makeSearchState, searchReducer } from './commands';
+
+export function ternarySearchCommands(
+  array: number[],
+  target: number
+): SearchCommand[] {
+  const cmds: SearchCommand[] = [];
+  const n = array.length;
+
+  if (n === 0) {
+    cmds.push({
+      type: 'not_found',
+      description: `${target} not found in empty array`,
+    });
+    return cmds;
+  }
+
+  let low = 0;
+  let high = n - 1;
+
+  cmds.push({
+    type: 'set_bounds',
+    low,
+    high,
+    description: `Initialize: low=${low}, high=${high}`,
+  });
+
+  while (low <= high) {
+    const third = Math.floor((high - low) / 3);
+    const mid1 = low + third;
+    const mid2 = high - third;
+
+    cmds.push({
+      type: 'set_mid',
+      index: mid1,
+      description: `mid1=${mid1}, mid2=${mid2} (dividing [${low}..${high}] into 3 parts)`,
+    });
+
+    cmds.push({
+      type: 'compare',
+      index: mid1,
+      description: `Comparing a[${mid1}]=${array[mid1]} with target=${target}`,
+    });
+
+    if (array[mid1] === target) {
+      cmds.push({
+        type: 'found',
+        index: mid1,
+        description: `Found ${target} at index ${mid1}`,
+      });
+      return cmds;
+    }
+
+    cmds.push({
+      type: 'compare',
+      index: mid2,
+      description: `Comparing a[${mid2}]=${array[mid2]} with target=${target}`,
+    });
+
+    if (array[mid2] === target) {
+      cmds.push({
+        type: 'found',
+        index: mid2,
+        description: `Found ${target} at index ${mid2}`,
+      });
+      return cmds;
+    }
+
+    if (target < array[mid1]) {
+      cmds.push({
+        type: 'eliminate',
+        from: mid1,
+        to: high,
+        description: `target < a[${mid1}], eliminate [${mid1}..${high}]`,
+      });
+      high = mid1 - 1;
+      cmds.push({
+        type: 'set_bounds',
+        low,
+        high,
+        description: `New bounds: low=${low}, high=${high}`,
+      });
+    } else if (target > array[mid2]) {
+      cmds.push({
+        type: 'eliminate',
+        from: low,
+        to: mid2,
+        description: `target > a[${mid2}], eliminate [${low}..${mid2}]`,
+      });
+      low = mid2 + 1;
+      cmds.push({
+        type: 'set_bounds',
+        low,
+        high,
+        description: `New bounds: low=${low}, high=${high}`,
+      });
+    } else {
+      cmds.push({
+        type: 'eliminate',
+        from: low,
+        to: mid1,
+        description: `target in (a[${mid1}], a[${mid2}]), eliminate [${low}..${mid1}] and [${mid2}..${high}]`,
+      });
+      cmds.push({
+        type: 'eliminate',
+        from: mid2,
+        to: high,
+        description: `Eliminate [${mid2}..${high}]`,
+      });
+      low = mid1 + 1;
+      high = mid2 - 1;
+      cmds.push({
+        type: 'set_bounds',
+        low,
+        high,
+        description: `New bounds: low=${low}, high=${high}`,
+      });
+    }
+  }
+
+  cmds.push({
+    type: 'not_found',
+    description: `${target} not found in array`,
+  });
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Ternary Search',
+  slug: 'ternary-search',
+  category: 'searching',
+  description:
+    'Divides the sorted array into three parts by computing two midpoints, then eliminates two-thirds of the search space each iteration. Similar to binary search but with three partitions.',
+  bestCase: 'O(1)',
+  averageCase: 'O(log₃ n)',
+  worstCase: 'O(log₃ n)',
+  spaceComplexity: 'O(1)',
+  pseudocode: `low = 0, high = n-1
+while low <= high
+  mid1 = low + (high - low) / 3
+  mid2 = high - (high - low) / 3
+  if a[mid1] == target: return mid1
+  if a[mid2] == target: return mid2
+  if target < a[mid1]: high = mid1 - 1
+  else if target > a[mid2]: low = mid2 + 1
+  else: low = mid1 + 1, high = mid2 - 1
+return -1`,
+  visualizerType: 'array',
+  defaultInput: makeSearchState([11, 21, 34, 39, 45, 56, 67, 73, 82, 91], 45),
+  run: (state) => ternarySearchCommands(state.array, state.target),
+  reduce: searchReducer,
+});

--- a/algo-compendium/_algorithms/sorting/bubble.test.ts
+++ b/algo-compendium/_algorithms/sorting/bubble.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { bubbleSortCommands } from './bubble';
+import { makeSortState, sortReducer } from './commands';
+
+function runSort(arr: number[]) {
+  const initial = makeSortState(arr);
+  const cmds = bubbleSortCommands(arr);
+  return cmds.reduce(sortReducer, initial).array;
+}
+
+describe('bubbleSort', () => {
+  it('sorts correctly', () =>
+    expect(runSort([64, 34, 25, 12, 22])).toEqual([12, 22, 25, 34, 64]));
+  it('handles empty', () => expect(runSort([])).toEqual([]));
+  it('handles single', () => expect(runSort([5])).toEqual([5]));
+  it('handles already sorted', () =>
+    expect(runSort([1, 2, 3])).toEqual([1, 2, 3]));
+  it('handles reverse', () => expect(runSort([3, 2, 1])).toEqual([1, 2, 3]));
+  it('handles duplicates', () =>
+    expect(runSort([3, 1, 3, 2])).toEqual([1, 2, 3, 3]));
+  it('reducer does not mutate state', () => {
+    const state = makeSortState([3, 1, 2]);
+    const cmds = bubbleSortCommands([3, 1, 2]);
+    const s1 = sortReducer(state, cmds[0]);
+    expect(state.array).toEqual([3, 1, 2]);
+    expect(s1).not.toBe(state);
+  });
+});

--- a/algo-compendium/_algorithms/sorting/bubble.ts
+++ b/algo-compendium/_algorithms/sorting/bubble.ts
@@ -1,0 +1,84 @@
+import { registerAlgorithm } from '../registry';
+import type { SortCommand } from './commands';
+import { makeSortState, sortReducer } from './commands';
+
+export function bubbleSortCommands(input: number[]): SortCommand[] {
+  const cmds: SortCommand[] = [];
+  const a = [...input];
+  const n = a.length;
+
+  for (let i = 0; i < n - 1; i++) {
+    let swapped = false;
+    for (let j = 0; j < n - i - 1; j++) {
+      cmds.push({
+        type: 'compare',
+        i: j,
+        j: j + 1,
+        description: `Compare a[${j}]=${a[j]} and a[${j + 1}]=${a[j + 1]}`,
+      });
+      if (a[j] > a[j + 1]) {
+        [a[j], a[j + 1]] = [a[j + 1], a[j]];
+        cmds.push({
+          type: 'swap',
+          i: j,
+          j: j + 1,
+          description: `Swap a[${j}] and a[${j + 1}]`,
+        });
+        swapped = true;
+      }
+    }
+    cmds.push({
+      type: 'mark_sorted',
+      indices: [n - i - 1],
+      description: `Position ${n - i - 1} is sorted`,
+    });
+    if (!swapped) {
+      // Array is already sorted — mark remaining elements
+      const remaining: number[] = [];
+      for (let k = 0; k < n - i - 1; k++) remaining.push(k);
+      if (remaining.length > 0) {
+        cmds.push({
+          type: 'mark_sorted',
+          indices: remaining,
+          description: 'Array is fully sorted (early exit)',
+        });
+      }
+      break;
+    }
+  }
+  if (n > 0) {
+    cmds.push({
+      type: 'mark_sorted',
+      indices: [0],
+      description: 'All elements sorted',
+    });
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Bubble Sort',
+  slug: 'bubble-sort',
+  category: 'sorting',
+  description:
+    'Repeatedly steps through the list, compares adjacent elements, and swaps them if they are in the wrong order. The pass through the list is repeated until no swaps are needed.',
+  bestCase: 'O(n)',
+  averageCase: 'O(n²)',
+  worstCase: 'O(n²)',
+  spaceComplexity: 'O(1)',
+  stable: true,
+  inPlace: true,
+  pseudocode: `for i = 0 to n-1
+  swapped = false
+  for j = 0 to n-i-2
+    if a[j] > a[j+1]
+      swap(a[j], a[j+1])
+      swapped = true
+  if not swapped
+    break`,
+  visualizerType: 'array',
+  defaultInput: makeSortState([64, 34, 25, 12, 22, 11, 90]),
+  run: (state) => bubbleSortCommands(state.array),
+  reduce: sortReducer,
+});

--- a/algo-compendium/_algorithms/sorting/cocktail-shaker.test.ts
+++ b/algo-compendium/_algorithms/sorting/cocktail-shaker.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { cocktailShakerSortCommands } from './cocktail-shaker';
+import { makeSortState, sortReducer } from './commands';
+
+function runSort(arr: number[]) {
+  const initial = makeSortState(arr);
+  const cmds = cocktailShakerSortCommands(arr);
+  return cmds.reduce(sortReducer, initial).array;
+}
+
+describe('cocktailShakerSort', () => {
+  it('sorts correctly', () =>
+    expect(runSort([64, 34, 25, 12, 22])).toEqual([12, 22, 25, 34, 64]));
+  it('handles empty', () => expect(runSort([])).toEqual([]));
+  it('handles single', () => expect(runSort([5])).toEqual([5]));
+  it('handles already sorted', () =>
+    expect(runSort([1, 2, 3])).toEqual([1, 2, 3]));
+  it('handles reverse', () => expect(runSort([3, 2, 1])).toEqual([1, 2, 3]));
+  it('handles duplicates', () =>
+    expect(runSort([3, 1, 3, 2])).toEqual([1, 2, 3, 3]));
+  it('reducer does not mutate state', () => {
+    const state = makeSortState([3, 1, 2]);
+    const cmds = cocktailShakerSortCommands([3, 1, 2]);
+    if (cmds.length > 0) {
+      const s1 = sortReducer(state, cmds[0]);
+      expect(state.array).toEqual([3, 1, 2]);
+      expect(s1).not.toBe(state);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/sorting/cocktail-shaker.ts
+++ b/algo-compendium/_algorithms/sorting/cocktail-shaker.ts
@@ -1,0 +1,110 @@
+import { registerAlgorithm } from '../registry';
+import type { SortCommand } from './commands';
+import { makeSortState, sortReducer } from './commands';
+
+export function cocktailShakerSortCommands(input: number[]): SortCommand[] {
+  const cmds: SortCommand[] = [];
+  const a = [...input];
+  const n = a.length;
+  let start = 0;
+  let end = n - 1;
+  let swapped = true;
+
+  while (swapped) {
+    swapped = false;
+    // Forward pass
+    for (let i = start; i < end; i++) {
+      cmds.push({
+        type: 'compare',
+        i,
+        j: i + 1,
+        description: `Forward: compare a[${i}]=${a[i]} and a[${i + 1}]=${a[i + 1]}`,
+      });
+      if (a[i] > a[i + 1]) {
+        [a[i], a[i + 1]] = [a[i + 1], a[i]];
+        cmds.push({
+          type: 'swap',
+          i,
+          j: i + 1,
+          description: `Swap a[${i}] and a[${i + 1}]`,
+        });
+        swapped = true;
+      }
+    }
+    cmds.push({
+      type: 'mark_sorted',
+      indices: [end],
+      description: `Position ${end} is sorted`,
+    });
+    end--;
+
+    if (!swapped) break;
+
+    swapped = false;
+    // Backward pass
+    for (let i = end; i > start; i--) {
+      cmds.push({
+        type: 'compare',
+        i: i - 1,
+        j: i,
+        description: `Backward: compare a[${i - 1}]=${a[i - 1]} and a[${i}]=${a[i]}`,
+      });
+      if (a[i - 1] > a[i]) {
+        [a[i - 1], a[i]] = [a[i], a[i - 1]];
+        cmds.push({
+          type: 'swap',
+          i: i - 1,
+          j: i,
+          description: `Swap a[${i - 1}] and a[${i}]`,
+        });
+        swapped = true;
+      }
+    }
+    cmds.push({
+      type: 'mark_sorted',
+      indices: [start],
+      description: `Position ${start} is sorted`,
+    });
+    start++;
+  }
+
+  // Mark any remaining unsorted positions as sorted
+  const sortedIndices: number[] = [];
+  for (let i = start; i <= end; i++) sortedIndices.push(i);
+  if (sortedIndices.length > 0) {
+    cmds.push({
+      type: 'mark_sorted',
+      indices: sortedIndices,
+      description: 'All elements sorted',
+    });
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Cocktail Shaker Sort',
+  slug: 'cocktail-shaker-sort',
+  category: 'sorting',
+  description:
+    'A bidirectional variant of bubble sort that traverses the list in both directions alternately. This helps move small elements at the end of the list to the front more quickly.',
+  bestCase: 'O(n)',
+  averageCase: 'O(n²)',
+  worstCase: 'O(n²)',
+  spaceComplexity: 'O(1)',
+  stable: true,
+  inPlace: true,
+  pseudocode: `start = 0, end = n-1
+while swapped
+  swapped = false
+  for i = start to end-1
+    if a[i] > a[i+1]: swap; swapped = true
+  end--
+  for i = end downto start+1
+    if a[i-1] > a[i]: swap; swapped = true
+  start++`,
+  visualizerType: 'array',
+  defaultInput: makeSortState([64, 34, 25, 12, 22, 11, 90]),
+  run: (state) => cocktailShakerSortCommands(state.array),
+  reduce: sortReducer,
+});

--- a/algo-compendium/_algorithms/sorting/comb-sort.test.ts
+++ b/algo-compendium/_algorithms/sorting/comb-sort.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { combSortCommands } from './comb-sort';
+import { makeSortState, sortReducer } from './commands';
+
+function runSort(arr: number[]): number[] {
+  const initial = makeSortState(arr);
+  const cmds = combSortCommands(arr);
+  return cmds.reduce(sortReducer, initial).array;
+}
+
+describe('combSort', () => {
+  it('sorts correctly', () =>
+    expect(runSort([64, 34, 25, 12, 22, 11, 90, 42, 78, 5])).toEqual([
+      5, 11, 12, 22, 25, 34, 42, 64, 78, 90,
+    ]));
+  it('handles empty array', () => expect(runSort([])).toEqual([]));
+  it('handles single element', () => expect(runSort([7])).toEqual([7]));
+  it('handles already sorted', () =>
+    expect(runSort([1, 2, 3, 4, 5])).toEqual([1, 2, 3, 4, 5]));
+  it('handles reverse sorted', () =>
+    expect(runSort([5, 4, 3, 2, 1])).toEqual([1, 2, 3, 4, 5]));
+  it('handles duplicates', () =>
+    expect(runSort([3, 1, 4, 1, 5, 9, 2, 6])).toEqual([
+      1, 1, 2, 3, 4, 5, 6, 9,
+    ]));
+  it('reducer does not mutate state', () => {
+    const state = makeSortState([3, 1, 2]);
+    const cmds = combSortCommands([3, 1, 2]);
+    const s1 = sortReducer(state, cmds[0]);
+    expect(state.array).toEqual([3, 1, 2]);
+    expect(s1).not.toBe(state);
+  });
+});

--- a/algo-compendium/_algorithms/sorting/comb-sort.ts
+++ b/algo-compendium/_algorithms/sorting/comb-sort.ts
@@ -1,0 +1,76 @@
+import { registerAlgorithm } from '../registry';
+import type { SortCommand } from './commands';
+import { makeSortState, sortReducer } from './commands';
+
+export function combSortCommands(input: number[]): SortCommand[] {
+  const cmds: SortCommand[] = [];
+  const a = [...input];
+  const n = a.length;
+
+  let gap = n;
+  let sorted = false;
+
+  while (!sorted) {
+    gap = Math.floor(gap / 1.3);
+    if (gap <= 1) {
+      gap = 1;
+      sorted = true;
+    }
+
+    for (let i = 0; i + gap < n; i++) {
+      cmds.push({
+        type: 'compare',
+        i,
+        j: i + gap,
+        description: `Compare a[${i}]=${a[i]} and a[${i + gap}]=${a[i + gap]} (gap=${gap})`,
+      });
+      if (a[i] > a[i + gap]) {
+        [a[i], a[i + gap]] = [a[i + gap], a[i]];
+        cmds.push({
+          type: 'swap',
+          i,
+          j: i + gap,
+          description: `Swap a[${i}]=${a[i]} and a[${i + gap}]=${a[i + gap]}`,
+        });
+        sorted = false;
+      }
+    }
+  }
+
+  if (n > 0) {
+    cmds.push({
+      type: 'mark_sorted',
+      indices: Array.from({ length: n }, (_, i) => i),
+      description: 'All elements sorted',
+    });
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Comb Sort',
+  slug: 'comb-sort',
+  category: 'sorting',
+  description:
+    'An improvement over Bubble Sort that eliminates turtles (small values near the end) by using a gap larger than 1. The gap shrinks by a factor of 1.3 each pass until it reaches 1.',
+  bestCase: 'O(n log n)',
+  averageCase: 'O(n²/2^p)',
+  worstCase: 'O(n²)',
+  spaceComplexity: 'O(1)',
+  stable: false,
+  inPlace: true,
+  pseudocode: `gap = n
+sorted = false
+while not sorted:
+  gap = floor(gap / 1.3)
+  if gap <= 1: gap = 1; sorted = true
+  for i = 0 to n-gap-1:
+    if a[i] > a[i+gap]:
+      swap(a[i], a[i+gap])
+      sorted = false`,
+  visualizerType: 'array',
+  defaultInput: makeSortState([64, 34, 25, 12, 22, 11, 90, 42, 78, 5]),
+  run: (state) => combSortCommands(state.array),
+  reduce: sortReducer,
+});

--- a/algo-compendium/_algorithms/sorting/commands.ts
+++ b/algo-compendium/_algorithms/sorting/commands.ts
@@ -1,0 +1,70 @@
+export type SortCommand =
+  | { type: 'compare'; i: number; j: number; description: string }
+  | { type: 'swap'; i: number; j: number; description: string }
+  | { type: 'set'; index: number; value: number; description: string }
+  | { type: 'mark_sorted'; indices: number[]; description: string }
+  | { type: 'set_pivot'; index: number; description: string }
+  | { type: 'clear_pivot'; description: string };
+
+export type SortState = {
+  array: number[];
+  comparing: number[];
+  swapping: number[];
+  sorted: number[]; // number[] not Set for serialization + React useMemo
+  pivot: number | null;
+  description: string;
+};
+
+export function makeSortState(array: number[]): SortState {
+  return {
+    array: [...array],
+    comparing: [],
+    swapping: [],
+    sorted: [],
+    pivot: null,
+    description: 'Ready',
+  };
+}
+
+export function sortReducer(state: SortState, cmd: SortCommand): SortState {
+  switch (cmd.type) {
+    case 'compare':
+      return {
+        ...state,
+        comparing: [cmd.i, cmd.j],
+        swapping: [],
+        description: cmd.description,
+      };
+    case 'swap': {
+      const array = [...state.array];
+      [array[cmd.i], array[cmd.j]] = [array[cmd.j], array[cmd.i]];
+      return {
+        ...state,
+        array,
+        comparing: [],
+        swapping: [cmd.i, cmd.j],
+        description: cmd.description,
+      };
+    }
+    case 'set': {
+      const array = [...state.array];
+      array[cmd.index] = cmd.value;
+      return { ...state, array, description: cmd.description };
+    }
+    case 'mark_sorted': {
+      const sortedSet = new Set([...state.sorted, ...cmd.indices]);
+      return {
+        ...state,
+        sorted: [...sortedSet],
+        comparing: [],
+        swapping: [],
+        pivot: null,
+        description: cmd.description,
+      };
+    }
+    case 'set_pivot':
+      return { ...state, pivot: cmd.index, description: cmd.description };
+    case 'clear_pivot':
+      return { ...state, pivot: null, description: cmd.description };
+  }
+}

--- a/algo-compendium/_algorithms/sorting/counting.test.ts
+++ b/algo-compendium/_algorithms/sorting/counting.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { countingSortCommands } from './counting';
+import { makeSortState, sortReducer } from './commands';
+
+function runSort(arr: number[]) {
+  const initial = makeSortState(arr);
+  const cmds = countingSortCommands(arr);
+  return cmds.reduce(sortReducer, initial).array;
+}
+
+describe('countingSort', () => {
+  it('sorts correctly', () =>
+    expect(runSort([64, 34, 25, 12, 22])).toEqual([12, 22, 25, 34, 64]));
+  it('handles empty', () => expect(runSort([])).toEqual([]));
+  it('handles single', () => expect(runSort([5])).toEqual([5]));
+  it('handles already sorted', () =>
+    expect(runSort([1, 2, 3])).toEqual([1, 2, 3]));
+  it('handles reverse', () => expect(runSort([3, 2, 1])).toEqual([1, 2, 3]));
+  it('handles duplicates', () =>
+    expect(runSort([3, 1, 3, 2])).toEqual([1, 2, 3, 3]));
+  it('reducer does not mutate state', () => {
+    const state = makeSortState([3, 1, 2]);
+    const cmds = countingSortCommands([3, 1, 2]);
+    if (cmds.length > 0) {
+      const s1 = sortReducer(state, cmds[0]);
+      expect(state.array).toEqual([3, 1, 2]);
+      expect(s1).not.toBe(state);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/sorting/counting.ts
+++ b/algo-compendium/_algorithms/sorting/counting.ts
@@ -1,0 +1,76 @@
+import { registerAlgorithm } from '../registry';
+import type { SortCommand } from './commands';
+import { makeSortState, sortReducer } from './commands';
+
+export function countingSortCommands(input: number[]): SortCommand[] {
+  const cmds: SortCommand[] = [];
+  if (input.length === 0) return cmds;
+
+  const a = [...input];
+  const n = a.length;
+
+  // Find range (clamp to 0-99 for this visualizer)
+  const min = Math.min(...a);
+  const max = Math.max(...a);
+  const range = max - min + 1;
+
+  // Build count array
+  const count = new Array(range).fill(0);
+  for (const val of a) {
+    count[val - min]++;
+  }
+
+  // Build output array using set commands
+  let outIdx = 0;
+  for (let i = 0; i < range; i++) {
+    while (count[i] > 0) {
+      const value = i + min;
+      cmds.push({
+        type: 'set',
+        index: outIdx,
+        value,
+        description: `Place value ${value} at position ${outIdx}`,
+      });
+      a[outIdx] = value;
+      outIdx++;
+      count[i]--;
+    }
+  }
+
+  const allIndices = Array.from({ length: n }, (_, i) => i);
+  cmds.push({
+    type: 'mark_sorted',
+    indices: allIndices,
+    description: 'All elements sorted',
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Counting Sort',
+  slug: 'counting-sort',
+  category: 'sorting',
+  description:
+    'A non-comparison integer sorting algorithm that counts the occurrences of each value and uses those counts to place elements directly in their final positions. Efficient for small integer ranges.',
+  bestCase: 'O(n+k)',
+  averageCase: 'O(n+k)',
+  worstCase: 'O(n+k)',
+  spaceComplexity: 'O(k)',
+  stable: true,
+  inPlace: false,
+  pseudocode: `countingSort(a, n)
+  min = min(a), max = max(a)
+  count[0..max-min] = 0
+  for each val in a
+    count[val - min]++
+  outIdx = 0
+  for i = 0 to max-min
+    while count[i] > 0
+      a[outIdx++] = i + min
+      count[i]--`,
+  visualizerType: 'array',
+  defaultInput: makeSortState([45, 12, 78, 34, 56, 23, 89, 11, 67, 5]),
+  run: (state) => countingSortCommands(state.array),
+  reduce: sortReducer,
+});

--- a/algo-compendium/_algorithms/sorting/heap.test.ts
+++ b/algo-compendium/_algorithms/sorting/heap.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { heapSortCommands } from './heap';
+import { makeSortState, sortReducer } from './commands';
+
+function runSort(arr: number[]) {
+  const initial = makeSortState(arr);
+  const cmds = heapSortCommands(arr);
+  return cmds.reduce(sortReducer, initial).array;
+}
+
+describe('heapSort', () => {
+  it('sorts correctly', () =>
+    expect(runSort([64, 34, 25, 12, 22])).toEqual([12, 22, 25, 34, 64]));
+  it('handles empty', () => expect(runSort([])).toEqual([]));
+  it('handles single', () => expect(runSort([5])).toEqual([5]));
+  it('handles already sorted', () =>
+    expect(runSort([1, 2, 3])).toEqual([1, 2, 3]));
+  it('handles reverse', () => expect(runSort([3, 2, 1])).toEqual([1, 2, 3]));
+  it('handles duplicates', () =>
+    expect(runSort([3, 1, 3, 2])).toEqual([1, 2, 3, 3]));
+  it('reducer does not mutate state', () => {
+    const state = makeSortState([3, 1, 2]);
+    const cmds = heapSortCommands([3, 1, 2]);
+    if (cmds.length > 0) {
+      const s1 = sortReducer(state, cmds[0]);
+      expect(state.array).toEqual([3, 1, 2]);
+      expect(s1).not.toBe(state);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/sorting/heap.ts
+++ b/algo-compendium/_algorithms/sorting/heap.ts
@@ -1,0 +1,102 @@
+import { registerAlgorithm } from '../registry';
+import type { SortCommand } from './commands';
+import { makeSortState, sortReducer } from './commands';
+
+export function heapSortCommands(input: number[]): SortCommand[] {
+  const cmds: SortCommand[] = [];
+  const a = [...input];
+  const n = a.length;
+
+  function heapify(size: number, root: number): void {
+    let largest = root;
+    const left = 2 * root + 1;
+    const right = 2 * root + 2;
+
+    if (left < size) {
+      cmds.push({
+        type: 'compare',
+        i: left,
+        j: largest,
+        description: `Compare a[${left}]=${a[left]} and a[${largest}]=${a[largest]}`,
+      });
+      if (a[left] > a[largest]) largest = left;
+    }
+    if (right < size) {
+      cmds.push({
+        type: 'compare',
+        i: right,
+        j: largest,
+        description: `Compare a[${right}]=${a[right]} and a[${largest}]=${a[largest]}`,
+      });
+      if (a[right] > a[largest]) largest = right;
+    }
+    if (largest !== root) {
+      [a[root], a[largest]] = [a[largest], a[root]];
+      cmds.push({
+        type: 'swap',
+        i: root,
+        j: largest,
+        description: `Swap a[${root}]=${a[root]} and a[${largest}]=${a[largest]}`,
+      });
+      heapify(size, largest);
+    }
+  }
+
+  // Build max heap
+  for (let i = Math.floor(n / 2) - 1; i >= 0; i--) {
+    heapify(n, i);
+  }
+
+  // Extract elements from heap one by one
+  for (let i = n - 1; i > 0; i--) {
+    [a[0], a[i]] = [a[i], a[0]];
+    cmds.push({
+      type: 'swap',
+      i: 0,
+      j: i,
+      description: `Move max ${a[i]} to position ${i}`,
+    });
+    cmds.push({
+      type: 'mark_sorted',
+      indices: [i],
+      description: `Position ${i} is sorted`,
+    });
+    heapify(i, 0);
+  }
+  if (n > 0) {
+    cmds.push({
+      type: 'mark_sorted',
+      indices: [0],
+      description: 'All elements sorted',
+    });
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Heap Sort',
+  slug: 'heap-sort',
+  category: 'sorting',
+  description:
+    'Builds a max-heap from the array, then repeatedly extracts the maximum element and places it at the end of the sorted portion. Achieves O(n log n) in all cases with O(1) space.',
+  bestCase: 'O(n log n)',
+  averageCase: 'O(n log n)',
+  worstCase: 'O(n log n)',
+  spaceComplexity: 'O(1)',
+  stable: false,
+  inPlace: true,
+  pseudocode: `buildMaxHeap(a, n)
+  for i = n/2-1 downto 0
+    heapify(a, n, i)
+
+heapSort(a, n)
+  buildMaxHeap(a, n)
+  for i = n-1 downto 1
+    swap(a[0], a[i])
+    heapify(a, i, 0)`,
+  visualizerType: 'array',
+  defaultInput: makeSortState([64, 34, 25, 12, 22, 11, 90]),
+  run: (state) => heapSortCommands(state.array),
+  reduce: sortReducer,
+});

--- a/algo-compendium/_algorithms/sorting/index.ts
+++ b/algo-compendium/_algorithms/sorting/index.ts
@@ -1,0 +1,13 @@
+import './bubble';
+import './selection';
+import './insertion';
+import './shell';
+import './cocktail-shaker';
+import './merge';
+import './quick';
+import './heap';
+import './counting';
+import './radix';
+import './comb-sort';
+import './tim-sort';
+import './pancake-sort';

--- a/algo-compendium/_algorithms/sorting/insertion.test.ts
+++ b/algo-compendium/_algorithms/sorting/insertion.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { insertionSortCommands } from './insertion';
+import { makeSortState, sortReducer } from './commands';
+
+function runSort(arr: number[]) {
+  const initial = makeSortState(arr);
+  const cmds = insertionSortCommands(arr);
+  return cmds.reduce(sortReducer, initial).array;
+}
+
+describe('insertionSort', () => {
+  it('sorts correctly', () =>
+    expect(runSort([64, 34, 25, 12, 22])).toEqual([12, 22, 25, 34, 64]));
+  it('handles empty', () => expect(runSort([])).toEqual([]));
+  it('handles single', () => expect(runSort([5])).toEqual([5]));
+  it('handles already sorted', () =>
+    expect(runSort([1, 2, 3])).toEqual([1, 2, 3]));
+  it('handles reverse', () => expect(runSort([3, 2, 1])).toEqual([1, 2, 3]));
+  it('handles duplicates', () =>
+    expect(runSort([3, 1, 3, 2])).toEqual([1, 2, 3, 3]));
+  it('reducer does not mutate state', () => {
+    const state = makeSortState([3, 1, 2]);
+    const cmds = insertionSortCommands([3, 1, 2]);
+    if (cmds.length > 0) {
+      const s1 = sortReducer(state, cmds[0]);
+      expect(state.array).toEqual([3, 1, 2]);
+      expect(s1).not.toBe(state);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/sorting/insertion.ts
+++ b/algo-compendium/_algorithms/sorting/insertion.ts
@@ -1,0 +1,86 @@
+import { registerAlgorithm } from '../registry';
+import type { SortCommand } from './commands';
+import { makeSortState, sortReducer } from './commands';
+
+export function insertionSortCommands(input: number[]): SortCommand[] {
+  const cmds: SortCommand[] = [];
+  const a = [...input];
+  const n = a.length;
+
+  if (n > 0) {
+    cmds.push({
+      type: 'mark_sorted',
+      indices: [0],
+      description: 'First element is trivially sorted',
+    });
+  }
+
+  for (let i = 1; i < n; i++) {
+    const key = a[i];
+    let j = i - 1;
+    cmds.push({
+      type: 'set_pivot',
+      index: i,
+      description: `Insert a[${i}]=${key} into sorted portion`,
+    });
+    while (j >= 0 && a[j] > key) {
+      cmds.push({
+        type: 'compare',
+        i: j,
+        j: j + 1,
+        description: `a[${j}]=${a[j]} > ${key}, shift right`,
+      });
+      a[j + 1] = a[j];
+      cmds.push({
+        type: 'set',
+        index: j + 1,
+        value: a[j + 1],
+        description: `Shift a[${j}]=${a[j]} to position ${j + 1}`,
+      });
+      j--;
+    }
+    a[j + 1] = key;
+    cmds.push({
+      type: 'set',
+      index: j + 1,
+      value: key,
+      description: `Place ${key} at position ${j + 1}`,
+    });
+    cmds.push({
+      type: 'clear_pivot',
+      description: `Positions 0..${i} are sorted`,
+    });
+    cmds.push({
+      type: 'mark_sorted',
+      indices: [i],
+      description: `Positions 0..${i} are sorted`,
+    });
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Insertion Sort',
+  slug: 'insertion-sort',
+  category: 'sorting',
+  description:
+    'Builds the sorted array one element at a time by picking each element and inserting it into its correct position in the already-sorted portion.',
+  bestCase: 'O(n)',
+  averageCase: 'O(n²)',
+  worstCase: 'O(n²)',
+  spaceComplexity: 'O(1)',
+  stable: true,
+  inPlace: true,
+  pseudocode: `for i = 1 to n-1
+  key = a[i]
+  j = i - 1
+  while j >= 0 and a[j] > key
+    a[j+1] = a[j]
+    j = j - 1
+  a[j+1] = key`,
+  visualizerType: 'array',
+  defaultInput: makeSortState([64, 34, 25, 12, 22, 11, 90]),
+  run: (state) => insertionSortCommands(state.array),
+  reduce: sortReducer,
+});

--- a/algo-compendium/_algorithms/sorting/merge.test.ts
+++ b/algo-compendium/_algorithms/sorting/merge.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { mergeSortCommands } from './merge';
+import { makeSortState, sortReducer } from './commands';
+
+function runSort(arr: number[]) {
+  const initial = makeSortState(arr);
+  const cmds = mergeSortCommands(arr);
+  return cmds.reduce(sortReducer, initial).array;
+}
+
+describe('mergeSort', () => {
+  it('sorts correctly', () =>
+    expect(runSort([64, 34, 25, 12, 22])).toEqual([12, 22, 25, 34, 64]));
+  it('handles empty', () => expect(runSort([])).toEqual([]));
+  it('handles single', () => expect(runSort([5])).toEqual([5]));
+  it('handles already sorted', () =>
+    expect(runSort([1, 2, 3])).toEqual([1, 2, 3]));
+  it('handles reverse', () => expect(runSort([3, 2, 1])).toEqual([1, 2, 3]));
+  it('handles duplicates', () =>
+    expect(runSort([3, 1, 3, 2])).toEqual([1, 2, 3, 3]));
+  it('reducer does not mutate state', () => {
+    const state = makeSortState([3, 1, 2]);
+    const cmds = mergeSortCommands([3, 1, 2]);
+    if (cmds.length > 0) {
+      const s1 = sortReducer(state, cmds[0]);
+      expect(state.array).toEqual([3, 1, 2]);
+      expect(s1).not.toBe(state);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/sorting/merge.ts
+++ b/algo-compendium/_algorithms/sorting/merge.ts
@@ -1,0 +1,134 @@
+import { registerAlgorithm } from '../registry';
+import type { SortCommand } from './commands';
+import { makeSortState, sortReducer } from './commands';
+
+export function mergeSortCommands(input: number[]): SortCommand[] {
+  const cmds: SortCommand[] = [];
+  const a = [...input];
+
+  function mergeSort(arr: number[], left: number, right: number): void {
+    if (right - left <= 0) return;
+    const mid = Math.floor((left + right) / 2);
+    mergeSort(arr, left, mid);
+    mergeSort(arr, mid + 1, right);
+    merge(arr, left, mid, right);
+  }
+
+  function merge(
+    arr: number[],
+    left: number,
+    mid: number,
+    right: number
+  ): void {
+    const leftPart = arr.slice(left, mid + 1);
+    const rightPart = arr.slice(mid + 1, right + 1);
+    let i = 0,
+      j = 0,
+      k = left;
+
+    while (i < leftPart.length && j < rightPart.length) {
+      cmds.push({
+        type: 'compare',
+        i: left + i,
+        j: mid + 1 + j,
+        description: `Merge: compare ${leftPart[i]} and ${rightPart[j]}`,
+      });
+      if (leftPart[i] <= rightPart[j]) {
+        arr[k] = leftPart[i];
+        cmds.push({
+          type: 'set',
+          index: k,
+          value: leftPart[i],
+          description: `Place ${leftPart[i]} at position ${k}`,
+        });
+        i++;
+      } else {
+        arr[k] = rightPart[j];
+        cmds.push({
+          type: 'set',
+          index: k,
+          value: rightPart[j],
+          description: `Place ${rightPart[j]} at position ${k}`,
+        });
+        j++;
+      }
+      k++;
+    }
+    while (i < leftPart.length) {
+      arr[k] = leftPart[i];
+      cmds.push({
+        type: 'set',
+        index: k,
+        value: leftPart[i],
+        description: `Place remaining ${leftPart[i]} at position ${k}`,
+      });
+      i++;
+      k++;
+    }
+    while (j < rightPart.length) {
+      arr[k] = rightPart[j];
+      cmds.push({
+        type: 'set',
+        index: k,
+        value: rightPart[j],
+        description: `Place remaining ${rightPart[j]} at position ${k}`,
+      });
+      j++;
+      k++;
+    }
+
+    // Mark the merged range as sorted if it covers the full array
+    if (left === 0 && right === input.length - 1) {
+      const indices = Array.from(
+        { length: right - left + 1 },
+        (_, idx) => left + idx
+      );
+      cmds.push({
+        type: 'mark_sorted',
+        indices,
+        description: 'Array fully merged and sorted',
+      });
+    }
+  }
+
+  if (a.length > 0) {
+    mergeSort(a, 0, a.length - 1);
+    if (a.length === 1) {
+      cmds.push({
+        type: 'mark_sorted',
+        indices: [0],
+        description: 'Single element is sorted',
+      });
+    }
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Merge Sort',
+  slug: 'merge-sort',
+  category: 'sorting',
+  description:
+    'A divide-and-conquer algorithm that divides the array into halves, recursively sorts each half, and then merges the sorted halves. Guarantees O(n log n) in all cases.',
+  bestCase: 'O(n log n)',
+  averageCase: 'O(n log n)',
+  worstCase: 'O(n log n)',
+  spaceComplexity: 'O(n)',
+  stable: true,
+  inPlace: false,
+  pseudocode: `mergeSort(a, left, right)
+  if left >= right: return
+  mid = (left + right) / 2
+  mergeSort(a, left, mid)
+  mergeSort(a, mid+1, right)
+  merge(a, left, mid, right)
+
+merge(a, left, mid, right)
+  copy left and right halves
+  merge back using set commands`,
+  visualizerType: 'array',
+  defaultInput: makeSortState([64, 34, 25, 12, 22, 11, 90]),
+  run: (state) => mergeSortCommands(state.array),
+  reduce: sortReducer,
+});

--- a/algo-compendium/_algorithms/sorting/pancake-sort.test.ts
+++ b/algo-compendium/_algorithms/sorting/pancake-sort.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { pancakeSortCommands } from './pancake-sort';
+import { makeSortState, sortReducer } from './commands';
+
+function runSort(arr: number[]): number[] {
+  const initial = makeSortState(arr);
+  const cmds = pancakeSortCommands(arr);
+  return cmds.reduce(sortReducer, initial).array;
+}
+
+describe('pancakeSort', () => {
+  it('sorts correctly', () =>
+    expect(runSort([3, 6, 2, 7, 4, 9, 1, 5])).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 9,
+    ]));
+  it('handles empty array', () => expect(runSort([])).toEqual([]));
+  it('handles single element', () => expect(runSort([5])).toEqual([5]));
+  it('handles already sorted', () =>
+    expect(runSort([1, 2, 3])).toEqual([1, 2, 3]));
+  it('handles reverse sorted', () =>
+    expect(runSort([3, 2, 1])).toEqual([1, 2, 3]));
+  it('handles two elements', () => expect(runSort([2, 1])).toEqual([1, 2]));
+  it('reducer does not mutate state', () => {
+    const state = makeSortState([3, 1, 2]);
+    const cmds = pancakeSortCommands([3, 1, 2]);
+    if (cmds.length > 0) {
+      const s1 = sortReducer(state, cmds[0]);
+      expect(state.array).toEqual([3, 1, 2]);
+      expect(s1).not.toBe(state);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/sorting/pancake-sort.ts
+++ b/algo-compendium/_algorithms/sorting/pancake-sort.ts
@@ -1,0 +1,126 @@
+import { registerAlgorithm } from '../registry';
+import type { SortCommand } from './commands';
+import { makeSortState, sortReducer } from './commands';
+
+function flip(a: number[], k: number, cmds: SortCommand[]): void {
+  // Reverse a[0..k] in place, emitting set commands
+  let left = 0;
+  let right = k;
+  while (left < right) {
+    const tmp = a[left];
+    a[left] = a[right];
+    a[right] = tmp;
+    cmds.push({
+      type: 'set',
+      index: left,
+      value: a[left],
+      description: `Flip: set a[${left}]=${a[left]}`,
+    });
+    cmds.push({
+      type: 'set',
+      index: right,
+      value: a[right],
+      description: `Flip: set a[${right}]=${a[right]}`,
+    });
+    left++;
+    right--;
+  }
+}
+
+export function pancakeSortCommands(input: number[]): SortCommand[] {
+  const cmds: SortCommand[] = [];
+  const a = [...input];
+  const n = a.length;
+
+  for (let size = n; size > 1; size--) {
+    // Find index of maximum element in a[0..size-1]
+    let maxIdx = 0;
+    for (let i = 1; i < size; i++) {
+      cmds.push({
+        type: 'compare',
+        i: maxIdx,
+        j: i,
+        description: `Find max in [0..${size - 1}]: compare a[${maxIdx}]=${a[maxIdx]} with a[${i}]=${a[i]}`,
+      });
+      if (a[i] > a[maxIdx]) {
+        maxIdx = i;
+      }
+    }
+
+    if (maxIdx === size - 1) {
+      // Already in place
+      cmds.push({
+        type: 'mark_sorted',
+        indices: [size - 1],
+        description: `a[${size - 1}]=${a[size - 1]} is already in position`,
+      });
+      continue;
+    }
+
+    if (maxIdx !== 0) {
+      // Flip max to front
+      cmds.push({
+        type: 'set_pivot',
+        index: maxIdx,
+        description: `Flip max element ${a[maxIdx]} to front: flip [0..${maxIdx}]`,
+      });
+      flip(a, maxIdx, cmds);
+      cmds.push({
+        type: 'clear_pivot',
+        description: `Max ${a[0]} now at front`,
+      });
+    }
+
+    // Flip to final position
+    cmds.push({
+      type: 'set_pivot',
+      index: 0,
+      description: `Flip max ${a[0]} to position ${size - 1}: flip [0..${size - 1}]`,
+    });
+    flip(a, size - 1, cmds);
+    cmds.push({
+      type: 'clear_pivot',
+      description: `Max placed at position ${size - 1}`,
+    });
+
+    cmds.push({
+      type: 'mark_sorted',
+      indices: [size - 1],
+      description: `Position ${size - 1} sorted: a[${size - 1}]=${a[size - 1]}`,
+    });
+  }
+
+  if (n > 0) {
+    cmds.push({
+      type: 'mark_sorted',
+      indices: [0],
+      description: 'All elements sorted',
+    });
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Pancake Sort',
+  slug: 'pancake-sort',
+  category: 'sorting',
+  description:
+    'Sorts by repeatedly finding the maximum element and flipping it into position using a "pancake flip" operation that reverses a prefix of the array.',
+  bestCase: 'O(n)',
+  averageCase: 'O(n²)',
+  worstCase: 'O(n²)',
+  spaceComplexity: 'O(1)',
+  stable: false,
+  inPlace: true,
+  pseudocode: `for size = n downto 2:
+  maxIdx = index of max in a[0..size-1]
+  if maxIdx != size-1:
+    if maxIdx != 0:
+      flip(a, maxIdx)  // bring max to front
+    flip(a, size-1)    // move max to final position`,
+  visualizerType: 'array',
+  defaultInput: makeSortState([3, 6, 2, 7, 4, 9, 1, 5]),
+  run: (state) => pancakeSortCommands(state.array),
+  reduce: sortReducer,
+});

--- a/algo-compendium/_algorithms/sorting/quick.test.ts
+++ b/algo-compendium/_algorithms/sorting/quick.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { quickSortCommands } from './quick';
+import { makeSortState, sortReducer } from './commands';
+
+function runSort(arr: number[]) {
+  const initial = makeSortState(arr);
+  const cmds = quickSortCommands(arr);
+  return cmds.reduce(sortReducer, initial).array;
+}
+
+describe('quickSort', () => {
+  it('sorts correctly', () =>
+    expect(runSort([64, 34, 25, 12, 22])).toEqual([12, 22, 25, 34, 64]));
+  it('handles empty', () => expect(runSort([])).toEqual([]));
+  it('handles single', () => expect(runSort([5])).toEqual([5]));
+  it('handles already sorted', () =>
+    expect(runSort([1, 2, 3])).toEqual([1, 2, 3]));
+  it('handles reverse', () => expect(runSort([3, 2, 1])).toEqual([1, 2, 3]));
+  it('handles duplicates', () =>
+    expect(runSort([3, 1, 3, 2])).toEqual([1, 2, 3, 3]));
+  it('reducer does not mutate state', () => {
+    const state = makeSortState([3, 1, 2]);
+    const cmds = quickSortCommands([3, 1, 2]);
+    if (cmds.length > 0) {
+      const s1 = sortReducer(state, cmds[0]);
+      expect(state.array).toEqual([3, 1, 2]);
+      expect(s1).not.toBe(state);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/sorting/quick.ts
+++ b/algo-compendium/_algorithms/sorting/quick.ts
@@ -1,0 +1,112 @@
+import { registerAlgorithm } from '../registry';
+import type { SortCommand } from './commands';
+import { makeSortState, sortReducer } from './commands';
+
+export function quickSortCommands(input: number[]): SortCommand[] {
+  const cmds: SortCommand[] = [];
+  const a = [...input];
+
+  function quickSort(low: number, high: number): void {
+    if (low >= high) {
+      if (low === high) {
+        cmds.push({
+          type: 'mark_sorted',
+          indices: [low],
+          description: `Position ${low} is sorted`,
+        });
+      }
+      return;
+    }
+    const pivotIdx = partition(low, high);
+    quickSort(low, pivotIdx - 1);
+    quickSort(pivotIdx + 1, high);
+  }
+
+  function partition(low: number, high: number): number {
+    const pivot = a[high];
+    cmds.push({
+      type: 'set_pivot',
+      index: high,
+      description: `Pivot = a[${high}]=${pivot}`,
+    });
+    let i = low - 1;
+
+    for (let j = low; j < high; j++) {
+      cmds.push({
+        type: 'compare',
+        i: j,
+        j: high,
+        description: `Compare a[${j}]=${a[j]} with pivot=${pivot}`,
+      });
+      if (a[j] <= pivot) {
+        i++;
+        if (i !== j) {
+          [a[i], a[j]] = [a[j], a[i]];
+          cmds.push({
+            type: 'swap',
+            i,
+            j,
+            description: `Swap a[${i}]=${a[i]} and a[${j}]=${a[j]}`,
+          });
+        }
+      }
+    }
+    const pivotFinal = i + 1;
+    if (pivotFinal !== high) {
+      [a[pivotFinal], a[high]] = [a[high], a[pivotFinal]];
+      cmds.push({
+        type: 'swap',
+        i: pivotFinal,
+        j: high,
+        description: `Place pivot ${pivot} at position ${pivotFinal}`,
+      });
+    }
+    cmds.push({
+      type: 'clear_pivot',
+      description: `Pivot ${pivot} is at its final position ${pivotFinal}`,
+    });
+    cmds.push({
+      type: 'mark_sorted',
+      indices: [pivotFinal],
+      description: `Pivot position ${pivotFinal} is sorted`,
+    });
+    return pivotFinal;
+  }
+
+  if (a.length > 0) {
+    quickSort(0, a.length - 1);
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Quick Sort',
+  slug: 'quick-sort',
+  category: 'sorting',
+  description:
+    'A divide-and-conquer algorithm that selects a pivot element and partitions the array around it, recursively sorting the sub-arrays. Very efficient in practice with O(n log n) average case.',
+  bestCase: 'O(n log n)',
+  averageCase: 'O(n log n)',
+  worstCase: 'O(n²)',
+  spaceComplexity: 'O(log n)',
+  stable: false,
+  inPlace: true,
+  pseudocode: `quickSort(a, low, high)
+  if low < high
+    pivotIdx = partition(a, low, high)
+    quickSort(a, low, pivotIdx-1)
+    quickSort(a, pivotIdx+1, high)
+
+partition(a, low, high)
+  pivot = a[high]
+  i = low - 1
+  for j = low to high-1
+    if a[j] <= pivot: i++; swap(a[i], a[j])
+  swap(a[i+1], a[high])
+  return i+1`,
+  visualizerType: 'array',
+  defaultInput: makeSortState([64, 34, 25, 12, 22, 11, 90]),
+  run: (state) => quickSortCommands(state.array),
+  reduce: sortReducer,
+});

--- a/algo-compendium/_algorithms/sorting/radix.test.ts
+++ b/algo-compendium/_algorithms/sorting/radix.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { radixSortCommands } from './radix';
+import { makeSortState, sortReducer } from './commands';
+
+function runSort(arr: number[]) {
+  const initial = makeSortState(arr);
+  const cmds = radixSortCommands(arr);
+  return cmds.reduce(sortReducer, initial).array;
+}
+
+describe('radixSort', () => {
+  it('sorts correctly', () =>
+    expect(runSort([170, 45, 75, 90, 802, 24, 2, 66])).toEqual([
+      2, 24, 45, 66, 75, 90, 170, 802,
+    ]));
+  it('handles empty', () => expect(runSort([])).toEqual([]));
+  it('handles single', () => expect(runSort([5])).toEqual([5]));
+  it('handles already sorted', () =>
+    expect(runSort([1, 2, 3])).toEqual([1, 2, 3]));
+  it('handles reverse', () => expect(runSort([3, 2, 1])).toEqual([1, 2, 3]));
+  it('handles duplicates', () =>
+    expect(runSort([3, 1, 3, 2])).toEqual([1, 2, 3, 3]));
+  it('reducer does not mutate state', () => {
+    const state = makeSortState([3, 1, 2]);
+    const cmds = radixSortCommands([3, 1, 2]);
+    if (cmds.length > 0) {
+      const s1 = sortReducer(state, cmds[0]);
+      expect(state.array).toEqual([3, 1, 2]);
+      expect(s1).not.toBe(state);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/sorting/radix.ts
+++ b/algo-compendium/_algorithms/sorting/radix.ts
@@ -1,0 +1,86 @@
+import { registerAlgorithm } from '../registry';
+import type { SortCommand } from './commands';
+import { makeSortState, sortReducer } from './commands';
+
+export function radixSortCommands(input: number[]): SortCommand[] {
+  const cmds: SortCommand[] = [];
+  if (input.length === 0) return cmds;
+
+  const a = [...input];
+  const n = a.length;
+  const max = Math.max(...a);
+
+  function countingSortByDigit(exp: number): void {
+    const output = new Array(n).fill(0);
+    const count = new Array(10).fill(0);
+
+    // Count occurrences
+    for (let i = 0; i < n; i++) {
+      const digit = Math.floor(a[i] / exp) % 10;
+      count[digit]++;
+    }
+
+    // Change count[i] so that it contains the actual position
+    for (let i = 1; i < 10; i++) {
+      count[i] += count[i - 1];
+    }
+
+    // Build output array (traverse right-to-left for stability)
+    for (let i = n - 1; i >= 0; i--) {
+      const digit = Math.floor(a[i] / exp) % 10;
+      output[count[digit] - 1] = a[i];
+      count[digit]--;
+    }
+
+    // Copy output back and emit set commands
+    for (let i = 0; i < n; i++) {
+      a[i] = output[i];
+      cmds.push({
+        type: 'set',
+        index: i,
+        value: output[i],
+        description: `Radix (digit place ${exp}): place ${output[i]} at position ${i}`,
+      });
+    }
+  }
+
+  for (let exp = 1; Math.floor(max / exp) > 0; exp *= 10) {
+    countingSortByDigit(exp);
+  }
+
+  const allIndices = Array.from({ length: n }, (_, i) => i);
+  cmds.push({
+    type: 'mark_sorted',
+    indices: allIndices,
+    description: 'All elements sorted',
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Radix Sort',
+  slug: 'radix-sort',
+  category: 'sorting',
+  description:
+    'A non-comparison integer sorting algorithm that sorts elements digit by digit from the least significant digit (LSD) to the most significant digit (MSD) using counting sort as a stable subroutine.',
+  bestCase: 'O(nk)',
+  averageCase: 'O(nk)',
+  worstCase: 'O(nk)',
+  spaceComplexity: 'O(n+k)',
+  stable: true,
+  inPlace: false,
+  pseudocode: `radixSort(a, n)
+  max = max(a)
+  for exp = 1; max/exp > 0; exp *= 10
+    countingSortByDigit(a, n, exp)
+
+countingSortByDigit(a, n, exp)
+  count digit = (a[i] / exp) % 10
+  build stable output array
+  copy back to a`,
+  visualizerType: 'array',
+  defaultInput: makeSortState([170, 45, 75, 90, 802, 24, 2, 66]),
+  run: (state) => radixSortCommands(state.array),
+  reduce: sortReducer,
+});

--- a/algo-compendium/_algorithms/sorting/selection.test.ts
+++ b/algo-compendium/_algorithms/sorting/selection.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { selectionSortCommands } from './selection';
+import { makeSortState, sortReducer } from './commands';
+
+function runSort(arr: number[]) {
+  const initial = makeSortState(arr);
+  const cmds = selectionSortCommands(arr);
+  return cmds.reduce(sortReducer, initial).array;
+}
+
+describe('selectionSort', () => {
+  it('sorts correctly', () =>
+    expect(runSort([64, 34, 25, 12, 22])).toEqual([12, 22, 25, 34, 64]));
+  it('handles empty', () => expect(runSort([])).toEqual([]));
+  it('handles single', () => expect(runSort([5])).toEqual([5]));
+  it('handles already sorted', () =>
+    expect(runSort([1, 2, 3])).toEqual([1, 2, 3]));
+  it('handles reverse', () => expect(runSort([3, 2, 1])).toEqual([1, 2, 3]));
+  it('handles duplicates', () =>
+    expect(runSort([3, 1, 3, 2])).toEqual([1, 2, 3, 3]));
+  it('reducer does not mutate state', () => {
+    const state = makeSortState([3, 1, 2]);
+    const cmds = selectionSortCommands([3, 1, 2]);
+    if (cmds.length > 0) {
+      const s1 = sortReducer(state, cmds[0]);
+      expect(state.array).toEqual([3, 1, 2]);
+      expect(s1).not.toBe(state);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/sorting/selection.ts
+++ b/algo-compendium/_algorithms/sorting/selection.ts
@@ -1,0 +1,86 @@
+import { registerAlgorithm } from '../registry';
+import type { SortCommand } from './commands';
+import { makeSortState, sortReducer } from './commands';
+
+export function selectionSortCommands(input: number[]): SortCommand[] {
+  const cmds: SortCommand[] = [];
+  const a = [...input];
+  const n = a.length;
+
+  for (let i = 0; i < n - 1; i++) {
+    let minIdx = i;
+    cmds.push({
+      type: 'set_pivot',
+      index: i,
+      description: `Assume a[${i}]=${a[i]} is the minimum`,
+    });
+    for (let j = i + 1; j < n; j++) {
+      cmds.push({
+        type: 'compare',
+        i: minIdx,
+        j,
+        description: `Compare a[${minIdx}]=${a[minIdx]} and a[${j}]=${a[j]}`,
+      });
+      if (a[j] < a[minIdx]) {
+        minIdx = j;
+        cmds.push({
+          type: 'set_pivot',
+          index: minIdx,
+          description: `New minimum found: a[${minIdx}]=${a[minIdx]}`,
+        });
+      }
+    }
+    if (minIdx !== i) {
+      [a[i], a[minIdx]] = [a[minIdx], a[i]];
+      cmds.push({
+        type: 'swap',
+        i,
+        j: minIdx,
+        description: `Swap minimum a[${minIdx}] to position ${i}`,
+      });
+    }
+    cmds.push({
+      type: 'clear_pivot',
+      description: `Position ${i} is sorted`,
+    });
+    cmds.push({
+      type: 'mark_sorted',
+      indices: [i],
+      description: `Position ${i} is sorted`,
+    });
+  }
+  if (n > 0) {
+    cmds.push({
+      type: 'mark_sorted',
+      indices: [n - 1],
+      description: 'All elements sorted',
+    });
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Selection Sort',
+  slug: 'selection-sort',
+  category: 'sorting',
+  description:
+    'Divides the list into a sorted and unsorted portion. On each pass, finds the minimum element from the unsorted portion and places it at the end of the sorted portion.',
+  bestCase: 'O(n²)',
+  averageCase: 'O(n²)',
+  worstCase: 'O(n²)',
+  spaceComplexity: 'O(1)',
+  stable: false,
+  inPlace: true,
+  pseudocode: `for i = 0 to n-2
+  minIdx = i
+  for j = i+1 to n-1
+    if a[j] < a[minIdx]
+      minIdx = j
+  if minIdx != i
+    swap(a[i], a[minIdx])`,
+  visualizerType: 'array',
+  defaultInput: makeSortState([64, 34, 25, 12, 22, 11, 90]),
+  run: (state) => selectionSortCommands(state.array),
+  reduce: sortReducer,
+});

--- a/algo-compendium/_algorithms/sorting/shell.test.ts
+++ b/algo-compendium/_algorithms/sorting/shell.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { shellSortCommands } from './shell';
+import { makeSortState, sortReducer } from './commands';
+
+function runSort(arr: number[]) {
+  const initial = makeSortState(arr);
+  const cmds = shellSortCommands(arr);
+  return cmds.reduce(sortReducer, initial).array;
+}
+
+describe('shellSort', () => {
+  it('sorts correctly', () =>
+    expect(runSort([64, 34, 25, 12, 22])).toEqual([12, 22, 25, 34, 64]));
+  it('handles empty', () => expect(runSort([])).toEqual([]));
+  it('handles single', () => expect(runSort([5])).toEqual([5]));
+  it('handles already sorted', () =>
+    expect(runSort([1, 2, 3])).toEqual([1, 2, 3]));
+  it('handles reverse', () => expect(runSort([3, 2, 1])).toEqual([1, 2, 3]));
+  it('handles duplicates', () =>
+    expect(runSort([3, 1, 3, 2])).toEqual([1, 2, 3, 3]));
+  it('reducer does not mutate state', () => {
+    const state = makeSortState([3, 1, 2]);
+    const cmds = shellSortCommands([3, 1, 2]);
+    if (cmds.length > 0) {
+      const s1 = sortReducer(state, cmds[0]);
+      expect(state.array).toEqual([3, 1, 2]);
+      expect(s1).not.toBe(state);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/sorting/shell.ts
+++ b/algo-compendium/_algorithms/sorting/shell.ts
@@ -1,0 +1,94 @@
+import { registerAlgorithm } from '../registry';
+import type { SortCommand } from './commands';
+import { makeSortState, sortReducer } from './commands';
+
+export function shellSortCommands(input: number[]): SortCommand[] {
+  const cmds: SortCommand[] = [];
+  const a = [...input];
+  const n = a.length;
+
+  // Ciura gap sequence
+  const gaps = [701, 301, 132, 57, 23, 10, 4, 1].filter((g) => g < n);
+  if (gaps[gaps.length - 1] !== 1) gaps.push(1);
+
+  for (const gap of gaps) {
+    for (let i = gap; i < n; i++) {
+      const temp = a[i];
+      let j = i;
+      cmds.push({
+        type: 'set_pivot',
+        index: i,
+        description: `Shell sort with gap=${gap}: insert a[${i}]=${temp}`,
+      });
+      while (j >= gap) {
+        cmds.push({
+          type: 'compare',
+          i: j - gap,
+          j,
+          description: `Compare a[${j - gap}]=${a[j - gap]} and a[${j}]=${a[j]} (gap=${gap})`,
+        });
+        if (a[j - gap] > temp) {
+          a[j] = a[j - gap];
+          cmds.push({
+            type: 'set',
+            index: j,
+            value: a[j],
+            description: `Shift a[${j - gap}]=${a[j]} to position ${j}`,
+          });
+          j -= gap;
+        } else {
+          break;
+        }
+      }
+      a[j] = temp;
+      cmds.push({
+        type: 'set',
+        index: j,
+        value: temp,
+        description: `Place ${temp} at position ${j}`,
+      });
+      cmds.push({
+        type: 'clear_pivot',
+        description: `Inserted at position ${j}`,
+      });
+    }
+  }
+
+  if (n > 0) {
+    const allIndices = Array.from({ length: n }, (_, i) => i);
+    cmds.push({
+      type: 'mark_sorted',
+      indices: allIndices,
+      description: 'All elements sorted',
+    });
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Shell Sort',
+  slug: 'shell-sort',
+  category: 'sorting',
+  description:
+    'An extension of insertion sort that allows the exchange of far-apart elements. Uses a decreasing sequence of gaps to progressively reduce the disorder before a final insertion sort pass.',
+  bestCase: 'O(n log n)',
+  averageCase: 'O(n log² n)',
+  worstCase: 'O(n²)',
+  spaceComplexity: 'O(1)',
+  stable: false,
+  inPlace: true,
+  pseudocode: `gaps = [701, 301, 132, 57, 23, 10, 4, 1]
+for each gap in gaps
+  for i = gap to n-1
+    temp = a[i]
+    j = i
+    while j >= gap and a[j-gap] > temp
+      a[j] = a[j-gap]
+      j -= gap
+    a[j] = temp`,
+  visualizerType: 'array',
+  defaultInput: makeSortState([64, 34, 25, 12, 22, 11, 90]),
+  run: (state) => shellSortCommands(state.array),
+  reduce: sortReducer,
+});

--- a/algo-compendium/_algorithms/sorting/tim-sort.test.ts
+++ b/algo-compendium/_algorithms/sorting/tim-sort.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { timSortCommands } from './tim-sort';
+import { makeSortState, sortReducer } from './commands';
+
+function runSort(arr: number[]): number[] {
+  const initial = makeSortState(arr);
+  const cmds = timSortCommands(arr);
+  return cmds.reduce(sortReducer, initial).array;
+}
+
+describe('timSort', () => {
+  it('sorts correctly', () =>
+    expect(runSort([64, 34, 25, 12, 22, 11, 90, 42, 78, 5, 8, 37])).toEqual([
+      5, 8, 11, 12, 22, 25, 34, 37, 42, 64, 78, 90,
+    ]));
+  it('handles empty array', () => expect(runSort([])).toEqual([]));
+  it('handles single element', () => expect(runSort([42])).toEqual([42]));
+  it('handles two elements', () => expect(runSort([2, 1])).toEqual([1, 2]));
+  it('handles already sorted', () =>
+    expect(runSort([1, 2, 3, 4, 5])).toEqual([1, 2, 3, 4, 5]));
+  it('handles reverse sorted', () =>
+    expect(runSort([5, 4, 3, 2, 1])).toEqual([1, 2, 3, 4, 5]));
+  it('handles duplicates', () =>
+    expect(runSort([3, 1, 4, 1, 5, 9])).toEqual([1, 1, 3, 4, 5, 9]));
+  it('reducer does not mutate state', () => {
+    const state = makeSortState([3, 1, 2]);
+    const cmds = timSortCommands([3, 1, 2]);
+    if (cmds.length > 0) {
+      const s1 = sortReducer(state, cmds[0]);
+      expect(state.array).toEqual([3, 1, 2]);
+      expect(s1).not.toBe(state);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/sorting/tim-sort.ts
+++ b/algo-compendium/_algorithms/sorting/tim-sort.ts
@@ -1,0 +1,156 @@
+import { registerAlgorithm } from '../registry';
+import type { SortCommand } from './commands';
+import { makeSortState, sortReducer } from './commands';
+
+const RUN = 8;
+
+export function timSortCommands(input: number[]): SortCommand[] {
+  const cmds: SortCommand[] = [];
+  const a = [...input];
+  const n = a.length;
+
+  if (n <= 1) {
+    if (n === 1) {
+      cmds.push({
+        type: 'mark_sorted',
+        indices: [0],
+        description: 'Single element — already sorted',
+      });
+    }
+    return cmds;
+  }
+
+  // Insertion sort each run of size RUN
+  for (let left = 0; left < n; left += RUN) {
+    const right = Math.min(left + RUN - 1, n - 1);
+    for (let i = left + 1; i <= right; i++) {
+      const temp = a[i];
+      cmds.push({
+        type: 'set_pivot',
+        index: i,
+        description: `Insertion sort run [${left}..${right}]: insert a[${i}]=${temp}`,
+      });
+      let j = i - 1;
+      while (j >= left) {
+        cmds.push({
+          type: 'compare',
+          i: j,
+          j: j + 1,
+          description: `Compare a[${j}]=${a[j]} and key=${temp}`,
+        });
+        if (a[j] > temp) {
+          a[j + 1] = a[j];
+          cmds.push({
+            type: 'set',
+            index: j + 1,
+            value: a[j + 1],
+            description: `Shift a[${j}]=${a[j + 1]} to position ${j + 1}`,
+          });
+          j--;
+        } else {
+          break;
+        }
+      }
+      a[j + 1] = temp;
+      cmds.push({
+        type: 'set',
+        index: j + 1,
+        value: temp,
+        description: `Place ${temp} at position ${j + 1}`,
+      });
+      cmds.push({ type: 'clear_pivot', description: `Inserted ${temp}` });
+    }
+  }
+
+  // Merge runs
+  for (let size = RUN; size < n; size *= 2) {
+    for (let left = 0; left < n; left += 2 * size) {
+      const mid = Math.min(left + size - 1, n - 1);
+      const right = Math.min(left + 2 * size - 1, n - 1);
+
+      if (mid >= right) continue;
+
+      // Merge a[left..mid] and a[mid+1..right]
+      const leftArr = a.slice(left, mid + 1);
+      const rightArr = a.slice(mid + 1, right + 1);
+      let i = 0;
+      let j = 0;
+      let k = left;
+
+      while (i < leftArr.length && j < rightArr.length) {
+        if (leftArr[i] <= rightArr[j]) {
+          a[k] = leftArr[i++];
+        } else {
+          a[k] = rightArr[j++];
+        }
+        cmds.push({
+          type: 'set',
+          index: k,
+          value: a[k],
+          description: `Merge [${left}..${mid}] and [${mid + 1}..${right}]: place ${a[k]} at ${k}`,
+        });
+        k++;
+      }
+      while (i < leftArr.length) {
+        a[k] = leftArr[i++];
+        cmds.push({
+          type: 'set',
+          index: k,
+          value: a[k],
+          description: `Merge: copy remaining left ${a[k]} to ${k}`,
+        });
+        k++;
+      }
+      while (j < rightArr.length) {
+        a[k] = rightArr[j++];
+        cmds.push({
+          type: 'set',
+          index: k,
+          value: a[k],
+          description: `Merge: copy remaining right ${a[k]} to ${k}`,
+        });
+        k++;
+      }
+    }
+  }
+
+  cmds.push({
+    type: 'mark_sorted',
+    indices: Array.from({ length: n }, (_, i) => i),
+    description: 'All elements sorted',
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Tim Sort',
+  slug: 'tim-sort',
+  category: 'sorting',
+  description:
+    'A hybrid sorting algorithm derived from Merge Sort and Insertion Sort. It divides the array into small runs (size 8–64), sorts each with Insertion Sort, then merges the runs using a merge step.',
+  bestCase: 'O(n)',
+  averageCase: 'O(n log n)',
+  worstCase: 'O(n log n)',
+  spaceComplexity: 'O(n)',
+  stable: true,
+  inPlace: false,
+  pseudocode: `RUN = 8
+// Insertion sort each run
+for left = 0 to n-1 step RUN:
+  right = min(left+RUN-1, n-1)
+  insertionSort(a, left, right)
+
+// Merge runs bottom-up
+size = RUN
+while size < n:
+  for left = 0 to n-1 step 2*size:
+    mid = left + size - 1
+    right = min(left + 2*size - 1, n-1)
+    merge(a, left, mid, right)
+  size *= 2`,
+  visualizerType: 'array',
+  defaultInput: makeSortState([64, 34, 25, 12, 22, 11, 90, 42, 78, 5, 8, 37]),
+  run: (state) => timSortCommands(state.array),
+  reduce: sortReducer,
+});

--- a/algo-compendium/_algorithms/string-matching/boyer-moore-search.test.ts
+++ b/algo-compendium/_algorithms/string-matching/boyer-moore-search.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { boyerMooreSearchCommands } from './boyer-moore-search';
+import { makeStringState, stringReducer } from './commands';
+
+function runSearch(text: string, pattern: string) {
+  const initial = makeStringState(text, pattern);
+  const cmds = boyerMooreSearchCommands(text, pattern);
+  return cmds.reduce(stringReducer, initial);
+}
+
+describe('boyerMooreSearch', () => {
+  it('finds all occurrences', () => {
+    const result = runSearch('AABAACAADAABAABA', 'AABA');
+    expect(result.foundAt).toContain(0);
+    expect(result.foundAt.length).toBeGreaterThan(0);
+  });
+  it('returns empty when not found', () => {
+    const result = runSearch('ABCDEF', 'XYZ');
+    expect(result.foundAt).toHaveLength(0);
+  });
+  it('handles empty pattern', () => {
+    expect(() => boyerMooreSearchCommands('ABC', '')).not.toThrow();
+  });
+  it('handles pattern longer than text', () => {
+    const result = runSearch('AB', 'ABCDEF');
+    expect(result.foundAt).toHaveLength(0);
+  });
+  it('finds multiple occurrences', () => {
+    const result = runSearch('AABAACAADAABAABA', 'AABA');
+    expect(result.foundAt).toContain(0);
+    expect(result.foundAt).toContain(9);
+    expect(result.foundAt).toContain(12);
+    expect(result.foundAt).toHaveLength(3);
+  });
+  it('uses right-to-left comparison via mismatch commands', () => {
+    const cmds = boyerMooreSearchCommands('ABCDE', 'CDE');
+    const compareCmds = cmds.filter((c) => c.type === 'compare');
+    expect(compareCmds.length).toBeGreaterThan(0);
+  });
+});

--- a/algo-compendium/_algorithms/string-matching/boyer-moore-search.ts
+++ b/algo-compendium/_algorithms/string-matching/boyer-moore-search.ts
@@ -1,0 +1,123 @@
+import { registerAlgorithm } from '../registry';
+import type { StringCommand, StringState } from './commands';
+import { makeStringState, stringReducer } from './commands';
+
+export function boyerMooreSearchCommands(
+  text: string,
+  pattern: string
+): StringCommand[] {
+  const cmds: StringCommand[] = [];
+  const n = text.length;
+  const m = pattern.length;
+
+  if (m === 0) return cmds;
+
+  // Build bad character table
+  const badChar = new Map<string, number>();
+  for (let i = 0; i < m; i++) {
+    badChar.set(pattern[i], i);
+  }
+
+  let offset = 0;
+
+  while (offset <= n - m) {
+    cmds.push({
+      type: 'shift',
+      newOffset: offset,
+      description: `Aligning pattern at offset ${offset}`,
+    });
+
+    // Compare right to left
+    let j = m - 1;
+    let mismatchFound = false;
+
+    while (j >= 0) {
+      const ti = offset + j;
+      cmds.push({
+        type: 'compare',
+        textIndex: ti,
+        patternIndex: j,
+        description: `Compare text[${ti}]='${text[ti]}' with pattern[${j}]='${pattern[j]}' (right-to-left)`,
+      });
+
+      if (text[ti] === pattern[j]) {
+        cmds.push({
+          type: 'match_char',
+          textIndex: ti,
+          patternIndex: j,
+          description: `Match: text[${ti}]='${text[ti]}' == pattern[${j}]='${pattern[j]}'`,
+        });
+        j--;
+      } else {
+        cmds.push({
+          type: 'mismatch',
+          textIndex: ti,
+          patternIndex: j,
+          description: `Mismatch: text[${ti}]='${text[ti]}' != pattern[${j}]='${pattern[j]}'`,
+        });
+
+        // Bad character heuristic
+        const lastOccurrence = badChar.get(text[ti]) ?? -1;
+        const shift = Math.max(1, j - lastOccurrence);
+        const newOffset = offset + shift;
+
+        cmds.push({
+          type: 'shift',
+          newOffset,
+          description: `Bad character '${text[ti]}' last seen at pattern[${lastOccurrence}]; shift by ${shift} to offset ${newOffset}`,
+        });
+        offset = newOffset;
+        mismatchFound = true;
+        break;
+      }
+    }
+
+    if (!mismatchFound) {
+      // Full match
+      cmds.push({
+        type: 'found',
+        at: offset,
+        description: `Pattern found at index ${offset}`,
+      });
+      // Shift by 1 to continue searching
+      const newOffset = offset + 1;
+      cmds.push({
+        type: 'shift',
+        newOffset,
+        description: `Continue search after match at offset ${newOffset}`,
+      });
+      offset = newOffset;
+    }
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Boyer-Moore Search',
+  slug: 'boyer-moore-search',
+  category: 'string-matching',
+  description:
+    'Compares the pattern right-to-left and uses the bad character heuristic to skip large portions of the text. Often the fastest practical string matching algorithm for large alphabets.',
+  bestCase: 'O(n/m)',
+  averageCase: 'O(n/m)',
+  worstCase: 'O(nm)',
+  spaceComplexity: 'O(m+σ)',
+  pseudocode: `preprocess bad-character table
+offset = 0
+while offset <= n - m:
+  j = m - 1
+  while j >= 0 and pattern[j] == text[offset + j]:
+    j--
+  if j < 0:
+    report match at offset
+    offset += 1
+  else:
+    last = bad_char.get(text[offset + j], -1)
+    offset += max(1, j - last)`,
+  visualizerType: 'string',
+  defaultInput: makeStringState('AABAACAADAABAABA', 'AABA'),
+  run: (state: StringState) =>
+    boyerMooreSearchCommands(state.text, state.pattern),
+  reduce: stringReducer,
+});

--- a/algo-compendium/_algorithms/string-matching/commands.ts
+++ b/algo-compendium/_algorithms/string-matching/commands.ts
@@ -1,0 +1,122 @@
+export type StringCommand =
+  | {
+      type: 'compare';
+      textIndex: number;
+      patternIndex: number;
+      description: string;
+    }
+  | {
+      type: 'match_char';
+      textIndex: number;
+      patternIndex: number;
+      description: string;
+    }
+  | {
+      type: 'mismatch';
+      textIndex: number;
+      patternIndex: number;
+      description: string;
+    }
+  | { type: 'shift'; newOffset: number; description: string }
+  | { type: 'found'; at: number; description: string }
+  | {
+      type: 'update_hash';
+      textHash: number;
+      patternHash: number;
+      description: string;
+    }
+  | {
+      type: 'update_failure';
+      index: number;
+      value: number;
+      description: string;
+    };
+
+export type StringState = {
+  text: string;
+  pattern: string;
+  offset: number; // current alignment of pattern in text
+  matchedChars: number[]; // text indices that matched
+  mismatchedChars: number[]; // text indices that mismatched
+  foundAt: number[]; // all occurrences found
+  currentTextIndex: number | null;
+  currentPatternIndex: number | null;
+  failureTable: number[]; // KMP failure table
+  textHash: number | null; // Rabin-Karp
+  patternHash: number | null; // Rabin-Karp
+  description: string;
+};
+
+export function makeStringState(text: string, pattern: string): StringState {
+  return {
+    text,
+    pattern,
+    offset: 0,
+    matchedChars: [],
+    mismatchedChars: [],
+    foundAt: [],
+    currentTextIndex: null,
+    currentPatternIndex: null,
+    failureTable: [],
+    textHash: null,
+    patternHash: null,
+    description: `Searching for "${pattern}" in "${text}"`,
+  };
+}
+
+export function stringReducer(
+  state: StringState,
+  cmd: StringCommand
+): StringState {
+  switch (cmd.type) {
+    case 'compare':
+      return {
+        ...state,
+        currentTextIndex: cmd.textIndex,
+        currentPatternIndex: cmd.patternIndex,
+        description: cmd.description,
+      };
+    case 'match_char':
+      return {
+        ...state,
+        matchedChars: [...state.matchedChars, cmd.textIndex],
+        currentTextIndex: cmd.textIndex,
+        description: cmd.description,
+      };
+    case 'mismatch':
+      return {
+        ...state,
+        mismatchedChars: [
+          ...new Set([...state.mismatchedChars, cmd.textIndex]),
+        ],
+        currentTextIndex: cmd.textIndex,
+        description: cmd.description,
+      };
+    case 'shift':
+      return {
+        ...state,
+        offset: cmd.newOffset,
+        matchedChars: [],
+        mismatchedChars: [],
+        description: cmd.description,
+      };
+    case 'found':
+      return {
+        ...state,
+        foundAt: [...state.foundAt, cmd.at],
+        description: cmd.description,
+      };
+    case 'update_hash':
+      return {
+        ...state,
+        textHash: cmd.textHash,
+        patternHash: cmd.patternHash,
+        description: cmd.description,
+      };
+    case 'update_failure': {
+      const failureTable = [...state.failureTable];
+      failureTable[cmd.index] = cmd.value;
+      return { ...state, failureTable, description: cmd.description };
+    }
+  }
+}

--- a/algo-compendium/_algorithms/string-matching/index.ts
+++ b/algo-compendium/_algorithms/string-matching/index.ts
@@ -1,0 +1,5 @@
+import './naive-search';
+import './kmp-search';
+import './rabin-karp-search';
+import './boyer-moore-search';
+import './z-algorithm';

--- a/algo-compendium/_algorithms/string-matching/kmp-search.test.ts
+++ b/algo-compendium/_algorithms/string-matching/kmp-search.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { kmpSearchCommands } from './kmp-search';
+import { makeStringState, stringReducer } from './commands';
+
+function runSearch(text: string, pattern: string) {
+  const initial = makeStringState(text, pattern);
+  const cmds = kmpSearchCommands(text, pattern);
+  return cmds.reduce(stringReducer, initial);
+}
+
+describe('kmpSearch', () => {
+  it('finds all occurrences', () => {
+    const result = runSearch('AABAACAADAABAABA', 'AABA');
+    expect(result.foundAt).toContain(0);
+    expect(result.foundAt.length).toBeGreaterThan(0);
+  });
+  it('returns empty when not found', () => {
+    const result = runSearch('ABCDEF', 'XYZ');
+    expect(result.foundAt).toHaveLength(0);
+  });
+  it('handles empty pattern', () => {
+    expect(() => kmpSearchCommands('ABC', '')).not.toThrow();
+  });
+  it('handles pattern longer than text', () => {
+    const result = runSearch('AB', 'ABCDEF');
+    expect(result.foundAt).toHaveLength(0);
+  });
+  it('finds multiple occurrences and builds failure table', () => {
+    const result = runSearch('AABAACAADAABAABA', 'AABA');
+    expect(result.foundAt).toContain(0);
+    expect(result.foundAt).toContain(9);
+    expect(result.foundAt).toContain(12);
+    // KMP should build a failure table for the pattern
+    expect(result.failureTable.length).toBeGreaterThan(0);
+  });
+  it('finds overlapping-style patterns correctly', () => {
+    const result = runSearch('AAAAAA', 'AAA');
+    expect(result.foundAt.length).toBeGreaterThan(0);
+    expect(result.foundAt).toContain(0);
+  });
+});

--- a/algo-compendium/_algorithms/string-matching/kmp-search.ts
+++ b/algo-compendium/_algorithms/string-matching/kmp-search.ts
@@ -1,0 +1,144 @@
+import { registerAlgorithm } from '../registry';
+import type { StringCommand, StringState } from './commands';
+import { makeStringState, stringReducer } from './commands';
+
+export function kmpSearchCommands(
+  text: string,
+  pattern: string
+): StringCommand[] {
+  const cmds: StringCommand[] = [];
+  const n = text.length;
+  const m = pattern.length;
+
+  if (m === 0) return cmds;
+
+  // Build failure function (prefix table)
+  const failure: number[] = new Array(m).fill(0);
+  cmds.push({
+    type: 'update_failure',
+    index: 0,
+    value: 0,
+    description: `Failure table: failure[0] = 0 (base case)`,
+  });
+
+  let k = 0;
+  for (let i = 1; i < m; i++) {
+    while (k > 0 && pattern[k] !== pattern[i]) {
+      k = failure[k - 1];
+    }
+    if (pattern[k] === pattern[i]) {
+      k++;
+    }
+    failure[i] = k;
+    cmds.push({
+      type: 'update_failure',
+      index: i,
+      value: k,
+      description: `Failure table: failure[${i}] = ${k} (prefix of length ${k} matches suffix ending at ${i})`,
+    });
+  }
+
+  // Search phase
+  let q = 0; // number of chars matched
+  cmds.push({
+    type: 'shift',
+    newOffset: 0,
+    description: `Start search: aligning pattern at offset 0`,
+  });
+
+  for (let i = 0; i < n; i++) {
+    while (q > 0 && pattern[q] !== text[i]) {
+      const newOffset = i - failure[q - 1];
+      cmds.push({
+        type: 'mismatch',
+        textIndex: i,
+        patternIndex: q,
+        description: `Mismatch: text[${i}]='${text[i]}' != pattern[${q}]='${pattern[q]}', use failure table`,
+      });
+      q = failure[q - 1];
+      cmds.push({
+        type: 'shift',
+        newOffset: newOffset,
+        description: `KMP shift: new offset ${newOffset}, resume matching at pattern[${q}]`,
+      });
+    }
+
+    cmds.push({
+      type: 'compare',
+      textIndex: i,
+      patternIndex: q,
+      description: `Compare text[${i}]='${text[i]}' with pattern[${q}]='${pattern[q]}'`,
+    });
+
+    if (pattern[q] === text[i]) {
+      cmds.push({
+        type: 'match_char',
+        textIndex: i,
+        patternIndex: q,
+        description: `Match: text[${i}]='${text[i]}' == pattern[${q}]='${pattern[q]}'`,
+      });
+      q++;
+    } else {
+      cmds.push({
+        type: 'mismatch',
+        textIndex: i,
+        patternIndex: q,
+        description: `Mismatch: text[${i}]='${text[i]}' != pattern[${q}]='${pattern[q]}'`,
+      });
+    }
+
+    if (q === m) {
+      const at = i - m + 1;
+      cmds.push({
+        type: 'found',
+        at,
+        description: `Pattern found at index ${at}`,
+      });
+      const newOffset = at + failure[q - 1];
+      q = failure[q - 1];
+      if (i + 1 < n) {
+        cmds.push({
+          type: 'shift',
+          newOffset: newOffset,
+          description: `After match: shift to offset ${newOffset} using failure table`,
+        });
+      }
+    }
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'KMP Search',
+  slug: 'kmp-search',
+  category: 'string-matching',
+  description:
+    'Knuth-Morris-Pratt algorithm preprocesses the pattern to build a failure function that allows skipping redundant comparisons. Achieves linear time complexity by never re-examining characters.',
+  bestCase: 'O(n)',
+  averageCase: 'O(n+m)',
+  worstCase: 'O(n+m)',
+  spaceComplexity: 'O(m)',
+  pseudocode: `// Preprocessing: build failure table
+failure[0] = 0
+k = 0
+for i = 1 to m-1:
+  while k > 0 and pattern[k] != pattern[i]:
+    k = failure[k-1]
+  if pattern[k] == pattern[i]: k++
+  failure[i] = k
+
+// Search
+q = 0
+for i = 0 to n-1:
+  while q > 0 and pattern[q] != text[i]:
+    q = failure[q-1]
+  if pattern[q] == text[i]: q++
+  if q == m:
+    report match at i - m + 1
+    q = failure[q-1]`,
+  visualizerType: 'string',
+  defaultInput: makeStringState('AABAACAADAABAABA', 'AABA'),
+  run: (state: StringState) => kmpSearchCommands(state.text, state.pattern),
+  reduce: stringReducer,
+});

--- a/algo-compendium/_algorithms/string-matching/naive-search.test.ts
+++ b/algo-compendium/_algorithms/string-matching/naive-search.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { naiveSearchCommands } from './naive-search';
+import { makeStringState, stringReducer } from './commands';
+
+function runSearch(text: string, pattern: string) {
+  const initial = makeStringState(text, pattern);
+  const cmds = naiveSearchCommands(text, pattern);
+  return cmds.reduce(stringReducer, initial);
+}
+
+describe('naiveSearch', () => {
+  it('finds all occurrences', () => {
+    const result = runSearch('AABAACAADAABAABA', 'AABA');
+    expect(result.foundAt).toContain(0);
+    expect(result.foundAt.length).toBeGreaterThan(0);
+  });
+  it('returns empty when not found', () => {
+    const result = runSearch('ABCDEF', 'XYZ');
+    expect(result.foundAt).toHaveLength(0);
+  });
+  it('handles empty pattern', () => {
+    // should not crash
+    expect(() => naiveSearchCommands('ABC', '')).not.toThrow();
+  });
+  it('handles pattern longer than text', () => {
+    const result = runSearch('AB', 'ABCDEF');
+    expect(result.foundAt).toHaveLength(0);
+  });
+  it('finds multiple occurrences', () => {
+    const result = runSearch('AABAACAADAABAABA', 'AABA');
+    // Known occurrences at 0, 9, 12
+    expect(result.foundAt).toContain(0);
+    expect(result.foundAt).toContain(9);
+    expect(result.foundAt).toContain(12);
+    expect(result.foundAt).toHaveLength(3);
+  });
+  it('finds pattern at end of text', () => {
+    const result = runSearch('XYZAABA', 'AABA');
+    expect(result.foundAt).toContain(3);
+  });
+});

--- a/algo-compendium/_algorithms/string-matching/naive-search.ts
+++ b/algo-compendium/_algorithms/string-matching/naive-search.ts
@@ -1,0 +1,85 @@
+import { registerAlgorithm } from '../registry';
+import type { StringCommand, StringState } from './commands';
+import { makeStringState, stringReducer } from './commands';
+
+export function naiveSearchCommands(
+  text: string,
+  pattern: string
+): StringCommand[] {
+  const cmds: StringCommand[] = [];
+  const n = text.length;
+  const m = pattern.length;
+
+  if (m === 0) return cmds;
+
+  for (let offset = 0; offset <= n - m; offset++) {
+    cmds.push({
+      type: 'shift',
+      newOffset: offset,
+      description: `Aligning pattern at offset ${offset}`,
+    });
+
+    let matched = true;
+    for (let j = 0; j < m; j++) {
+      const ti = offset + j;
+      cmds.push({
+        type: 'compare',
+        textIndex: ti,
+        patternIndex: j,
+        description: `Compare text[${ti}]='${text[ti]}' with pattern[${j}]='${pattern[j]}'`,
+      });
+
+      if (text[ti] === pattern[j]) {
+        cmds.push({
+          type: 'match_char',
+          textIndex: ti,
+          patternIndex: j,
+          description: `Match: text[${ti}]='${text[ti]}' == pattern[${j}]='${pattern[j]}'`,
+        });
+      } else {
+        cmds.push({
+          type: 'mismatch',
+          textIndex: ti,
+          patternIndex: j,
+          description: `Mismatch: text[${ti}]='${text[ti]}' != pattern[${j}]='${pattern[j]}'`,
+        });
+        matched = false;
+        break;
+      }
+    }
+
+    if (matched) {
+      cmds.push({
+        type: 'found',
+        at: offset,
+        description: `Pattern found at index ${offset}`,
+      });
+    }
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Naive String Search',
+  slug: 'naive-search',
+  category: 'string-matching',
+  description:
+    'The simplest string matching algorithm that checks for the pattern at each position in the text by comparing characters one by one. Simple but inefficient for large inputs.',
+  bestCase: 'O(n)',
+  averageCase: 'O(nm)',
+  worstCase: 'O(nm)',
+  spaceComplexity: 'O(1)',
+  pseudocode: `for offset = 0 to n - m:
+  matched = true
+  for j = 0 to m - 1:
+    if text[offset + j] != pattern[j]:
+      matched = false
+      break
+  if matched:
+    report match at offset`,
+  visualizerType: 'string',
+  defaultInput: makeStringState('AABAACAADAABAABA', 'AABA'),
+  run: (state: StringState) => naiveSearchCommands(state.text, state.pattern),
+  reduce: stringReducer,
+});

--- a/algo-compendium/_algorithms/string-matching/rabin-karp-search.test.ts
+++ b/algo-compendium/_algorithms/string-matching/rabin-karp-search.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { rabinKarpSearchCommands } from './rabin-karp-search';
+import { makeStringState, stringReducer } from './commands';
+
+function runSearch(text: string, pattern: string) {
+  const initial = makeStringState(text, pattern);
+  const cmds = rabinKarpSearchCommands(text, pattern);
+  return cmds.reduce(stringReducer, initial);
+}
+
+describe('rabinKarpSearch', () => {
+  it('finds all occurrences', () => {
+    const result = runSearch('AABAACAADAABAABA', 'AABA');
+    expect(result.foundAt).toContain(0);
+    expect(result.foundAt.length).toBeGreaterThan(0);
+  });
+  it('returns empty when not found', () => {
+    const result = runSearch('ABCDEF', 'XYZ');
+    expect(result.foundAt).toHaveLength(0);
+  });
+  it('handles empty pattern', () => {
+    expect(() => rabinKarpSearchCommands('ABC', '')).not.toThrow();
+  });
+  it('handles pattern longer than text', () => {
+    const result = runSearch('AB', 'ABCDEF');
+    expect(result.foundAt).toHaveLength(0);
+  });
+  it('finds multiple occurrences', () => {
+    const result = runSearch('AABAACAADAABAABA', 'AABA');
+    expect(result.foundAt).toContain(0);
+    expect(result.foundAt).toContain(9);
+    expect(result.foundAt).toContain(12);
+    expect(result.foundAt).toHaveLength(3);
+  });
+  it('emits hash update commands', () => {
+    const cmds = rabinKarpSearchCommands('AABAACAADAABAABA', 'AABA');
+    const hashCmds = cmds.filter((c) => c.type === 'update_hash');
+    expect(hashCmds.length).toBeGreaterThan(0);
+  });
+});

--- a/algo-compendium/_algorithms/string-matching/rabin-karp-search.ts
+++ b/algo-compendium/_algorithms/string-matching/rabin-karp-search.ts
@@ -1,0 +1,125 @@
+import { registerAlgorithm } from '../registry';
+import type { StringCommand, StringState } from './commands';
+import { makeStringState, stringReducer } from './commands';
+
+const BASE = 31;
+const MOD = 1_000_000_007;
+
+export function rabinKarpSearchCommands(
+  text: string,
+  pattern: string
+): StringCommand[] {
+  const cmds: StringCommand[] = [];
+  const n = text.length;
+  const m = pattern.length;
+
+  if (m === 0 || m > n) return cmds;
+
+  // Compute pattern hash and initial window hash
+  let patternHash = 0;
+  let textHash = 0;
+  let highPow = 1; // BASE^(m-1) mod MOD
+
+  for (let i = 0; i < m - 1; i++) {
+    highPow = (highPow * BASE) % MOD;
+  }
+
+  for (let i = 0; i < m; i++) {
+    patternHash = (patternHash * BASE + pattern.charCodeAt(i)) % MOD;
+    textHash = (textHash * BASE + text.charCodeAt(i)) % MOD;
+  }
+
+  cmds.push({
+    type: 'update_hash',
+    textHash,
+    patternHash,
+    description: `Initial hashes — text window[0..${m - 1}]: ${textHash}, pattern: ${patternHash}`,
+  });
+
+  for (let offset = 0; offset <= n - m; offset++) {
+    cmds.push({
+      type: 'shift',
+      newOffset: offset,
+      description: `Check window at offset ${offset} (hash: ${textHash})`,
+    });
+
+    if (textHash === patternHash) {
+      // Hash match — verify character by character
+      let matched = true;
+      for (let j = 0; j < m; j++) {
+        const ti = offset + j;
+        cmds.push({
+          type: 'compare',
+          textIndex: ti,
+          patternIndex: j,
+          description: `Hash match! Verify: text[${ti}]='${text[ti]}' vs pattern[${j}]='${pattern[j]}'`,
+        });
+        if (text[ti] === pattern[j]) {
+          cmds.push({
+            type: 'match_char',
+            textIndex: ti,
+            patternIndex: j,
+            description: `Match: text[${ti}]='${text[ti]}' == pattern[${j}]='${pattern[j]}'`,
+          });
+        } else {
+          cmds.push({
+            type: 'mismatch',
+            textIndex: ti,
+            patternIndex: j,
+            description: `Spurious hash hit — mismatch: text[${ti}]='${text[ti]}' != pattern[${j}]='${pattern[j]}'`,
+          });
+          matched = false;
+          break;
+        }
+      }
+      if (matched) {
+        cmds.push({
+          type: 'found',
+          at: offset,
+          description: `Pattern found at index ${offset}`,
+        });
+      }
+    }
+
+    // Roll the hash to next window
+    if (offset < n - m) {
+      textHash =
+        (BASE * (textHash - ((text.charCodeAt(offset) * highPow) % MOD)) +
+          text.charCodeAt(offset + m) +
+          MOD * 2) %
+        MOD;
+      cmds.push({
+        type: 'update_hash',
+        textHash,
+        patternHash,
+        description: `Rolling hash: remove '${text[offset]}', add '${text[offset + m]}' → new hash ${textHash}`,
+      });
+    }
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Rabin-Karp Search',
+  slug: 'rabin-karp-search',
+  category: 'string-matching',
+  description:
+    'Uses rolling hash to efficiently scan the text. Computes a hash for each window of the text and compares it against the pattern hash. Only performs character-by-character verification on hash matches.',
+  bestCase: 'O(n)',
+  averageCase: 'O(n+m)',
+  worstCase: 'O(nm)',
+  spaceComplexity: 'O(1)',
+  pseudocode: `compute patternHash and textHash for first window
+for offset = 0 to n - m:
+  if textHash == patternHash:
+    verify character by character
+    if all match: report match at offset
+  if offset < n - m:
+    roll hash: remove leftmost char, add next char`,
+  visualizerType: 'string',
+  defaultInput: makeStringState('AABAACAADAABAABA', 'AABA'),
+  run: (state: StringState) =>
+    rabinKarpSearchCommands(state.text, state.pattern),
+  reduce: stringReducer,
+});

--- a/algo-compendium/_algorithms/string-matching/z-algorithm.test.ts
+++ b/algo-compendium/_algorithms/string-matching/z-algorithm.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { zAlgorithmCommands } from './z-algorithm';
+import { makeStringState, stringReducer } from './commands';
+
+function runZSearch(text: string, pattern: string) {
+  const initial = makeStringState(text, pattern);
+  const cmds = zAlgorithmCommands(text, pattern);
+  return cmds.reduce(stringReducer, initial);
+}
+
+describe('zAlgorithm', () => {
+  it('finds ABAB in AABABCABAB', () => {
+    const result = runZSearch('AABABCABAB', 'ABAB');
+    expect(result.foundAt).toContain(6);
+  });
+
+  it('finds multiple occurrences of AA in AAAA', () => {
+    const result = runZSearch('AAAA', 'AA');
+    expect(result.foundAt.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('returns no found for missing pattern', () => {
+    const result = runZSearch('AABABCABAB', 'XYZ');
+    expect(result.foundAt).toHaveLength(0);
+  });
+
+  it('handles empty pattern', () => {
+    const cmds = zAlgorithmCommands('HELLO', '');
+    expect(cmds).toHaveLength(0);
+  });
+
+  it('handles pattern longer than text', () => {
+    const result = runZSearch('AB', 'ABCD');
+    expect(result.foundAt).toHaveLength(0);
+  });
+
+  it('finds pattern at start', () => {
+    const result = runZSearch('ABCABC', 'ABC');
+    expect(result.foundAt).toContain(0);
+  });
+
+  it('reducer does not mutate state', () => {
+    const initial = makeStringState('AABABCABAB', 'ABAB');
+    const cmds = zAlgorithmCommands('AABABCABAB', 'ABAB');
+    if (cmds.length > 0) {
+      const s1 = stringReducer(initial, cmds[0]);
+      expect(initial.foundAt).toEqual([]);
+      expect(s1).not.toBe(initial);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/string-matching/z-algorithm.ts
+++ b/algo-compendium/_algorithms/string-matching/z-algorithm.ts
@@ -1,0 +1,162 @@
+import { registerAlgorithm } from '../registry';
+import type { StringCommand, StringState } from './commands';
+import { makeStringState, stringReducer } from './commands';
+
+export function zAlgorithmCommands(
+  text: string,
+  pattern: string
+): StringCommand[] {
+  const cmds: StringCommand[] = [];
+  const m = pattern.length;
+  const n = text.length;
+
+  if (m === 0) return cmds;
+
+  // Build concatenated string: pattern + '$' + text
+  const concat = pattern + '$' + text;
+  const L = concat.length;
+  const Z: number[] = new Array(L).fill(0);
+
+  // Z-array construction
+  let l = 0;
+  let r = 0;
+
+  for (let i = 1; i < L; i++) {
+    if (i < r) {
+      Z[i] = Math.min(r - i, Z[i - l]);
+    }
+
+    while (i + Z[i] < L && concat[Z[i]] === concat[i + Z[i]]) {
+      // This comparison corresponds to pattern char Z[i] vs concat char i+Z[i]
+      // Only emit visual commands for the text portion (i > m)
+      const textOffset = i - (m + 1);
+      if (textOffset >= 0 && i + Z[i] > m + 1) {
+        const textIdx = textOffset + Z[i];
+        if (textIdx < n) {
+          cmds.push({
+            type: 'compare',
+            textIndex: textIdx,
+            patternIndex: Z[i],
+            description: `Z-construction: compare pattern[${Z[i]}]='${pattern[Z[i]]}' with text[${textIdx}]='${text[textIdx]}'`,
+          });
+          cmds.push({
+            type: 'match_char',
+            textIndex: textIdx,
+            patternIndex: Z[i],
+            description: `Match at text[${textIdx}]`,
+          });
+        }
+      }
+      Z[i]++;
+    }
+
+    if (i + Z[i] > r) {
+      l = i;
+      r = i + Z[i];
+    }
+  }
+
+  // Now scan the Z-array for matches
+  // Z[i] for i >= m+1 gives the match length at text position i-(m+1)
+  const occurrences: number[] = [];
+  let currentOffset = -1;
+
+  for (let i = m + 1; i < L; i++) {
+    const textPos = i - (m + 1);
+
+    if (currentOffset !== textPos) {
+      currentOffset = textPos;
+      cmds.push({
+        type: 'shift',
+        newOffset: textPos,
+        description: `Check position ${textPos} in text (Z[${i}]=${Z[i]})`,
+      });
+    }
+
+    if (Z[i] >= m) {
+      // Pattern found at textPos
+      for (let k = 0; k < m; k++) {
+        cmds.push({
+          type: 'compare',
+          textIndex: textPos + k,
+          patternIndex: k,
+          description: `Verify match at text[${textPos + k}]='${text[textPos + k]}' == pattern[${k}]='${pattern[k]}'`,
+        });
+        cmds.push({
+          type: 'match_char',
+          textIndex: textPos + k,
+          patternIndex: k,
+          description: `Match: text[${textPos + k}] == pattern[${k}]`,
+        });
+      }
+      occurrences.push(textPos);
+      cmds.push({
+        type: 'found',
+        at: textPos,
+        description: `Pattern found at index ${textPos} (Z[${i}]=${Z[i]} >= m=${m})`,
+      });
+    } else if (Z[i] > 0) {
+      // Partial match
+      for (let k = 0; k < Z[i]; k++) {
+        cmds.push({
+          type: 'compare',
+          textIndex: textPos + k,
+          patternIndex: k,
+          description: `Partial: text[${textPos + k}]='${text[textPos + k]}' vs pattern[${k}]='${pattern[k]}'`,
+        });
+        if (concat[k] === concat[i + k]) {
+          cmds.push({
+            type: 'match_char',
+            textIndex: textPos + k,
+            patternIndex: k,
+            description: `Match`,
+          });
+        }
+      }
+      // Mismatch at Z[i]
+      if (textPos + Z[i] < n && Z[i] < m) {
+        cmds.push({
+          type: 'mismatch',
+          textIndex: textPos + Z[i],
+          patternIndex: Z[i],
+          description: `Mismatch at text[${textPos + Z[i]}]='${text[textPos + Z[i]]}' vs pattern[${Z[i]}]='${pattern[Z[i]]}'`,
+        });
+      }
+    }
+  }
+
+  if (occurrences.length === 0) {
+    cmds.push({
+      type: 'mismatch',
+      textIndex: 0,
+      patternIndex: 0,
+      description: `Pattern "${pattern}" not found in text`,
+    });
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Z-Algorithm',
+  slug: 'z-algorithm',
+  category: 'string-matching',
+  description:
+    'Builds a Z-array for the concatenated string "pattern$text" where Z[i] is the length of the longest substring starting at position i that matches a prefix. Pattern occurrences correspond to Z[i] ≥ pattern length.',
+  bestCase: 'O(n+m)',
+  averageCase: 'O(n+m)',
+  worstCase: 'O(n+m)',
+  spaceComplexity: 'O(n+m)',
+  pseudocode: `concat = pattern + '$' + text
+Z[0] = |concat|; l = 0; r = 0
+for i = 1 to |concat|-1:
+  if i < r: Z[i] = min(r-i, Z[i-l])
+  while i+Z[i] < |concat| and concat[Z[i]] == concat[i+Z[i]]:
+    Z[i]++
+  if i+Z[i] > r: l=i; r=i+Z[i]
+// Z[i] >= m means pattern found at i-(m+1)`,
+  visualizerType: 'string',
+  defaultInput: makeStringState('AABABCABAB', 'ABAB'),
+  run: (state: StringState) => zAlgorithmCommands(state.text, state.pattern),
+  reduce: stringReducer,
+});

--- a/algo-compendium/_algorithms/tree/avl-insert.test.ts
+++ b/algo-compendium/_algorithms/tree/avl-insert.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { avlInsertCommands } from './avl-insert';
+import { makeTreeState, treeReducer } from './commands';
+import type { TreeNode } from './types';
+
+function buildAvlTree(): TreeNode {
+  return {
+    id: 'n0',
+    value: 20,
+    left: { id: 'n1', value: 10, left: null, right: null },
+    right: {
+      id: 'n2',
+      value: 40,
+      left: { id: 'n3', value: 30, left: null, right: null },
+      right: { id: 'n4', value: 50, left: null, right: null },
+    },
+  };
+}
+
+function flattenValues(node: TreeNode | null): number[] {
+  if (!node) return [];
+  return [
+    node.value,
+    ...flattenValues(node.left),
+    ...flattenValues(node.right),
+  ];
+}
+
+describe('avlInsert', () => {
+  it('inserts 25 and tree contains 25', () => {
+    const initialTree = buildAvlTree();
+    const initial = makeTreeState(initialTree, 25);
+    const cmds = avlInsertCommands(initial);
+    const reduce = (state: typeof initial, cmd: (typeof cmds)[0]) => {
+      const next = treeReducer(state, cmd);
+      if (cmd.type === 'set_tree') return { ...next, tree: cmd.tree };
+      return next;
+    };
+    const result = cmds.reduce(reduce, initial);
+    const values = flattenValues(result.tree);
+    expect(values).toContain(25);
+  });
+
+  it('emits compare commands when traversing', () => {
+    const initial = makeTreeState(buildAvlTree(), 25);
+    const cmds = avlInsertCommands(initial);
+    const compareCmds = cmds.filter((c) => c.type === 'compare');
+    expect(compareCmds.length).toBeGreaterThan(0);
+  });
+
+  it('emits a final set_tree command', () => {
+    const initial = makeTreeState(buildAvlTree(), 25);
+    const cmds = avlInsertCommands(initial);
+    const setTreeCmds = cmds.filter((c) => c.type === 'set_tree');
+    expect(setTreeCmds.length).toBeGreaterThan(0);
+  });
+
+  it('handles inserting a value already in tree', () => {
+    const initial = makeTreeState(buildAvlTree(), 30);
+    const cmds = avlInsertCommands(initial);
+    expect(cmds.length).toBeGreaterThan(0);
+  });
+
+  it('reducer does not mutate state', () => {
+    const initial = makeTreeState(buildAvlTree(), 25);
+    const cmds = avlInsertCommands(initial);
+    if (cmds.length > 0) {
+      const s1 = treeReducer(initial, cmds[0]);
+      expect(initial.visited).toEqual([]);
+      expect(s1).not.toBe(initial);
+    }
+  });
+});

--- a/algo-compendium/_algorithms/tree/avl-insert.ts
+++ b/algo-compendium/_algorithms/tree/avl-insert.ts
@@ -1,0 +1,231 @@
+import { registerAlgorithm } from '../registry';
+import type { TreeCommand, TreeState } from './commands';
+import { makeTreeState, treeReducer } from './commands';
+import type { TreeNode } from './types';
+
+// Build a balanced AVL tree with values [10, 20, 30, 40, 50]
+// Inserting in order 10,20,30,40,50 with AVL rotations produces:
+// After inserting 10,20,30 → RR rotation on 10 → root=20, left=10, right=30
+// After inserting 40 → 30.right=40
+// After inserting 50 → RR rotation on 30 → 30.right becomes 40, 40.right=50 → rotate 30 up?
+// Final balanced tree: root=20, left=10, right=40, 40.left=30, 40.right=50
+function buildAvlTree(): TreeNode {
+  return {
+    id: 'n0',
+    value: 20,
+    left: { id: 'n1', value: 10, left: null, right: null },
+    right: {
+      id: 'n2',
+      value: 40,
+      left: { id: 'n3', value: 30, left: null, right: null },
+      right: { id: 'n4', value: 50, left: null, right: null },
+    },
+  };
+}
+
+function getHeight(node: TreeNode | null): number {
+  if (!node) return 0;
+  return 1 + Math.max(getHeight(node.left), getHeight(node.right));
+}
+
+function getBalance(node: TreeNode | null): number {
+  if (!node) return 0;
+  return getHeight(node.left) - getHeight(node.right);
+}
+
+let nodeIdCounter = 10;
+
+function rotateRight(y: TreeNode): TreeNode {
+  const x = y.left!;
+  const T2 = x.right;
+  return {
+    ...x,
+    right: { ...y, left: T2 },
+  };
+}
+
+function rotateLeft(x: TreeNode): TreeNode {
+  const y = x.right!;
+  const T2 = y.left;
+  return {
+    ...y,
+    left: { ...x, right: T2 },
+  };
+}
+
+export function avlInsertCommands(state: TreeState): TreeCommand[] {
+  const cmds: TreeCommand[] = [];
+  const target = state.targetValue ?? 25;
+
+  function insert(
+    node: TreeNode | null,
+    parentId: string | null,
+    direction: 'left' | 'right' | 'root'
+  ): TreeNode {
+    if (!node) {
+      const newId = `avl-${nodeIdCounter++}`;
+      cmds.push({
+        type: 'insert',
+        nodeId: newId,
+        parentId,
+        direction,
+        value: target,
+        description: `Insert ${target} as ${direction === 'root' ? 'root' : direction + ' child of node ' + parentId}`,
+      });
+      return { id: newId, value: target, left: null, right: null };
+    }
+
+    cmds.push({
+      type: 'compare',
+      nodeId: node.id,
+      description: `Compare ${target} with node ${node.value}`,
+    });
+
+    let updated: TreeNode;
+    if (target < node.value) {
+      cmds.push({
+        type: 'visit',
+        nodeId: node.id,
+        description: `${target} < ${node.value}, go left`,
+      });
+      updated = { ...node, left: insert(node.left, node.id, 'left') };
+    } else if (target > node.value) {
+      cmds.push({
+        type: 'visit',
+        nodeId: node.id,
+        description: `${target} > ${node.value}, go right`,
+      });
+      updated = { ...node, right: insert(node.right, node.id, 'right') };
+    } else {
+      // Duplicate
+      return node;
+    }
+
+    const balance = getBalance(updated);
+
+    // LL case
+    if (balance > 1 && updated.left && target < updated.left.value) {
+      cmds.push({
+        type: 'set_tree',
+        tree: updated,
+        description: `LL imbalance at ${updated.value} (balance=${balance}): right rotation`,
+      });
+      const rotated = rotateRight(updated);
+      cmds.push({
+        type: 'set_tree',
+        tree: rotated,
+        description: `After right rotation: new subtree root = ${rotated.value}`,
+      });
+      return rotated;
+    }
+
+    // RR case
+    if (balance < -1 && updated.right && target > updated.right.value) {
+      cmds.push({
+        type: 'set_tree',
+        tree: updated,
+        description: `RR imbalance at ${updated.value} (balance=${balance}): left rotation`,
+      });
+      const rotated = rotateLeft(updated);
+      cmds.push({
+        type: 'set_tree',
+        tree: rotated,
+        description: `After left rotation: new subtree root = ${rotated.value}`,
+      });
+      return rotated;
+    }
+
+    // LR case
+    if (balance > 1 && updated.left && target > updated.left.value) {
+      cmds.push({
+        type: 'set_tree',
+        tree: updated,
+        description: `LR imbalance at ${updated.value}: left-right rotation`,
+      });
+      const rotatedLeft = { ...updated, left: rotateLeft(updated.left) };
+      cmds.push({
+        type: 'set_tree',
+        tree: rotatedLeft,
+        description: `After left rotation on left child`,
+      });
+      const rotated = rotateRight(rotatedLeft);
+      cmds.push({
+        type: 'set_tree',
+        tree: rotated,
+        description: `After right rotation: new subtree root = ${rotated.value}`,
+      });
+      return rotated;
+    }
+
+    // RL case
+    if (balance < -1 && updated.right && target < updated.right.value) {
+      cmds.push({
+        type: 'set_tree',
+        tree: updated,
+        description: `RL imbalance at ${updated.value}: right-left rotation`,
+      });
+      const rotatedRight = { ...updated, right: rotateRight(updated.right) };
+      cmds.push({
+        type: 'set_tree',
+        tree: rotatedRight,
+        description: `After right rotation on right child`,
+      });
+      const rotated = rotateLeft(rotatedRight);
+      cmds.push({
+        type: 'set_tree',
+        tree: rotated,
+        description: `After left rotation: new subtree root = ${rotated.value}`,
+      });
+      return rotated;
+    }
+
+    return updated;
+  }
+
+  const newTree = insert(state.tree, null, 'root');
+  cmds.push({
+    type: 'set_tree',
+    tree: newTree,
+    description: `Inserted ${target}. Tree is balanced.`,
+  });
+  cmds.push({
+    type: 'mark_done',
+    nodeId: newTree.id,
+    description: 'AVL insert complete',
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'AVL Tree Insert',
+  slug: 'avl-insert',
+  category: 'tree',
+  description:
+    'Inserts a value into a self-balancing AVL tree. After BST insertion, checks the balance factor at each ancestor node and performs rotations (LL, RR, LR, RL) to maintain the AVL property: |height(left) - height(right)| ≤ 1.',
+  bestCase: 'O(log n)',
+  averageCase: 'O(log n)',
+  worstCase: 'O(log n)',
+  spaceComplexity: 'O(log n)',
+  pseudocode: `function insert(node, value):
+  // Standard BST insert
+  if not node: return newNode(value)
+  if value < node.value: node.left = insert(node.left, value)
+  else if value > node.value: node.right = insert(node.right, value)
+  else: return node  // duplicate
+  balance = height(left) - height(right)
+  // LL: balance > 1, value < left.value → rotateRight(node)
+  // RR: balance < -1, value > right.value → rotateLeft(node)
+  // LR: balance > 1, value > left.value → rotateLeft(left); rotateRight(node)
+  // RL: balance < -1, value < right.value → rotateRight(right); rotateLeft(node)`,
+  visualizerType: 'tree',
+  defaultInput: makeTreeState(buildAvlTree(), 25),
+  run: avlInsertCommands,
+  reduce: (state, cmd) => {
+    const next = treeReducer(state, cmd);
+    if (cmd.type === 'set_tree') {
+      return { ...next, tree: cmd.tree };
+    }
+    return next;
+  },
+});

--- a/algo-compendium/_algorithms/tree/bst-delete.test.ts
+++ b/algo-compendium/_algorithms/tree/bst-delete.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { bstDeleteCommands } from './bst-delete';
+import { makeTreeState, treeReducer } from './commands';
+import { buildBST, flattenTree } from './types';
+
+function runDelete(values: number[], target: number) {
+  const tree = buildBST(values);
+  const state = makeTreeState(tree, target);
+  const cmds = bstDeleteCommands(state);
+  return cmds.reduce(treeReducer, state);
+}
+
+describe('bstDelete', () => {
+  it('removes a leaf node', () => {
+    const result = runDelete([8, 4, 12, 2, 6, 10, 14], 2);
+    const values = flattenTree(result.tree);
+    expect(values).not.toContain(2);
+  });
+
+  it('removes a node with one child', () => {
+    // 4 has both children, but if we only build [8, 4, 12, 2] then 4 has 1 child on right (2 is left actually)
+    // Let's test removing 10 (leaf) and 12 (has only right child 14 if we remove 10)
+    const result = runDelete([8, 4, 12, 14], 12); // 12 has only right child (14)
+    const values = flattenTree(result.tree);
+    expect(values).not.toContain(12);
+    expect(values).toContain(14); // child preserved
+  });
+
+  it('removes a node with two children using in-order successor', () => {
+    const result = runDelete([8, 4, 12, 2, 6, 10, 14], 4);
+    const values = flattenTree(result.tree);
+    expect(values).not.toContain(4);
+    // The successor of 4 (6) should now be in the tree
+    expect(values).toContain(6);
+  });
+
+  it('tree has n-1 nodes after deleting an existing value', () => {
+    const originalValues = [8, 4, 12, 2, 6, 10, 14];
+    const result = runDelete(originalValues, 6);
+    const values = flattenTree(result.tree);
+    expect(values).toHaveLength(originalValues.length - 1);
+  });
+
+  it('handles deleting a non-existent value gracefully', () => {
+    const tree = buildBST([8, 4, 12]);
+    const state = makeTreeState(tree, 99);
+    const cmds = bstDeleteCommands(state);
+    const notFound = cmds.some((c) => c.type === 'not_found');
+    expect(notFound).toBe(true);
+  });
+
+  it('emits a set_tree command at the end', () => {
+    const tree = buildBST([8, 4, 12]);
+    const state = makeTreeState(tree, 4);
+    const cmds = bstDeleteCommands(state);
+    const lastCmd = cmds[cmds.length - 1];
+    expect(lastCmd.type).toBe('set_tree');
+  });
+});

--- a/algo-compendium/_algorithms/tree/bst-delete.ts
+++ b/algo-compendium/_algorithms/tree/bst-delete.ts
@@ -1,0 +1,140 @@
+import { registerAlgorithm } from '../registry';
+import type { TreeCommand, TreeState } from './commands';
+import { makeTreeState, treeReducer } from './commands';
+import { buildBST } from './types';
+import type { TreeNode } from './types';
+
+// Find the in-order successor (smallest node in right subtree)
+function findMin(node: TreeNode): TreeNode {
+  let current = node;
+  while (current.left) current = current.left;
+  return current;
+}
+
+export function bstDeleteCommands(state: TreeState): TreeCommand[] {
+  const cmds: TreeCommand[] = [];
+  const target = state.targetValue ?? 0;
+
+  function deleteNode(node: TreeNode | null): TreeNode | null {
+    if (!node) {
+      cmds.push({
+        type: 'not_found',
+        description: `${target} not found in tree`,
+      });
+      return null;
+    }
+
+    cmds.push({
+      type: 'compare',
+      nodeId: node.id,
+      description: `Compare ${target} with node ${node.value}`,
+    });
+
+    if (target < node.value) {
+      cmds.push({
+        type: 'visit',
+        nodeId: node.id,
+        description: `${target} < ${node.value}, go left`,
+      });
+      return { ...node, left: deleteNode(node.left) };
+    } else if (target > node.value) {
+      cmds.push({
+        type: 'visit',
+        nodeId: node.id,
+        description: `${target} > ${node.value}, go right`,
+      });
+      return { ...node, right: deleteNode(node.right) };
+    } else {
+      // Found the node to delete
+      cmds.push({
+        type: 'found',
+        nodeId: node.id,
+        description: `Found ${target}, preparing to delete`,
+      });
+
+      // Case 1: Leaf node
+      if (!node.left && !node.right) {
+        cmds.push({
+          type: 'delete',
+          nodeId: node.id,
+          description: `Delete leaf node ${node.value}`,
+        });
+        return null;
+      }
+
+      // Case 2: One child
+      if (!node.right) {
+        cmds.push({
+          type: 'delete',
+          nodeId: node.id,
+          description: `Delete node ${node.value}, replace with left child`,
+        });
+        return node.left;
+      }
+      if (!node.left) {
+        cmds.push({
+          type: 'delete',
+          nodeId: node.id,
+          description: `Delete node ${node.value}, replace with right child`,
+        });
+        return node.right;
+      }
+
+      // Case 3: Two children — replace with in-order successor
+      const successor = findMin(node.right);
+      cmds.push({
+        type: 'delete',
+        nodeId: node.id,
+        description: `Delete node ${node.value}, replace with in-order successor ${successor.value}`,
+      });
+      const newRight = deleteNode(node.right);
+      return { ...node, value: successor.value, id: node.id, right: newRight };
+    }
+  }
+
+  const newTree = deleteNode(state.tree);
+
+  cmds.push({
+    type: 'set_tree',
+    tree: newTree,
+    description: `Deleted ${target} from the BST`,
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'BST Delete',
+  slug: 'bst-delete',
+  category: 'tree',
+  description:
+    'Deletes a value from a Binary Search Tree, handling three cases: leaf node, one child, and two children (in-order successor).',
+  bestCase: 'O(log n)',
+  averageCase: 'O(log n)',
+  worstCase: 'O(n)',
+  spaceComplexity: 'O(h)',
+  pseudocode: `function delete(node, value):
+  if node is null: return null
+  if value < node.value:
+    node.left = delete(node.left, value)
+  else if value > node.value:
+    node.right = delete(node.right, value)
+  else: // found
+    if no left child: return node.right
+    if no right child: return node.left
+    // two children: replace with in-order successor
+    successor = findMin(node.right)
+    node.value = successor.value
+    node.right = delete(node.right, successor.value)
+  return node`,
+  visualizerType: 'tree',
+  defaultInput: makeTreeState(buildBST([8, 4, 12, 2, 6, 10, 14]), 4),
+  run: bstDeleteCommands,
+  reduce: (state, cmd) => {
+    const next = treeReducer(state, cmd);
+    if (cmd.type === 'set_tree') {
+      return { ...next, tree: cmd.tree };
+    }
+    return next;
+  },
+});

--- a/algo-compendium/_algorithms/tree/bst-insert.test.ts
+++ b/algo-compendium/_algorithms/tree/bst-insert.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { bstInsertCommands } from './bst-insert';
+import { makeTreeState, treeReducer } from './commands';
+import { buildBST, flattenTree } from './types';
+
+function runInsert(values: number[], target: number) {
+  const tree = buildBST(values);
+  const state = makeTreeState(tree, target);
+  const cmds = bstInsertCommands(state);
+  return cmds.reduce(treeReducer, state);
+}
+
+describe('bstInsert', () => {
+  it('inserts a new value into the tree', () => {
+    const result = runInsert([8, 4, 12, 2, 6, 10, 14], 7);
+    const values = flattenTree(result.tree);
+    expect(values).toContain(7);
+  });
+
+  it('does not duplicate an existing value', () => {
+    const result = runInsert([8, 4, 12], 4);
+    const values = flattenTree(result.tree);
+    expect(values.filter((v) => v === 4)).toHaveLength(1);
+  });
+
+  it('inserts into an empty tree to create root', () => {
+    const result = runInsert([], 5);
+    expect(result.tree).not.toBeNull();
+    expect(result.tree?.value).toBe(5);
+  });
+
+  it('the tree has n+1 nodes after inserting a new value', () => {
+    const originalValues = [8, 4, 12, 2, 6, 10, 14];
+    const result = runInsert(originalValues, 7);
+    const values = flattenTree(result.tree);
+    expect(values).toHaveLength(originalValues.length + 1);
+  });
+
+  it('emits a set_tree command at the end', () => {
+    const tree = buildBST([8, 4, 12]);
+    const state = makeTreeState(tree, 5);
+    const cmds = bstInsertCommands(state);
+    const lastCmd = cmds[cmds.length - 1];
+    expect(lastCmd.type).toBe('set_tree');
+  });
+});

--- a/algo-compendium/_algorithms/tree/bst-insert.ts
+++ b/algo-compendium/_algorithms/tree/bst-insert.ts
@@ -1,0 +1,105 @@
+import { registerAlgorithm } from '../registry';
+import type { TreeCommand, TreeState } from './commands';
+import { makeTreeState, treeReducer } from './commands';
+import { buildBST, bstInsertNode } from './types';
+import type { TreeNode } from './types';
+
+export function bstInsertCommands(state: TreeState): TreeCommand[] {
+  const cmds: TreeCommand[] = [];
+  const target = state.targetValue ?? 0;
+  let nodeCounter = 100; // start high to avoid colliding with existing IDs
+
+  function insert(
+    node: TreeNode | null,
+    parentId: string | null,
+    direction: 'left' | 'right' | 'root'
+  ): TreeNode {
+    if (!node) {
+      const newId = `ins-${nodeCounter++}`;
+      cmds.push({
+        type: 'insert',
+        nodeId: newId,
+        parentId,
+        direction,
+        value: target,
+        description: `Insert ${target} as ${direction === 'root' ? 'root' : direction + ' child of ' + parentId}`,
+      });
+      const newNode = { id: newId, value: target, left: null, right: null };
+      return newNode;
+    }
+
+    cmds.push({
+      type: 'compare',
+      nodeId: node.id,
+      description: `Compare ${target} with node ${node.value}`,
+    });
+
+    if (target === node.value) {
+      cmds.push({
+        type: 'found',
+        nodeId: node.id,
+        description: `${target} already exists in tree, no insertion needed`,
+      });
+      return node;
+    } else if (target < node.value) {
+      cmds.push({
+        type: 'visit',
+        nodeId: node.id,
+        description: `${target} < ${node.value}, go left`,
+      });
+      const newLeft = insert(node.left, node.id, 'left');
+      return { ...node, left: newLeft };
+    } else {
+      cmds.push({
+        type: 'visit',
+        nodeId: node.id,
+        description: `${target} > ${node.value}, go right`,
+      });
+      const newRight = insert(node.right, node.id, 'right');
+      return { ...node, right: newRight };
+    }
+  }
+
+  const newTree = insert(state.tree, null, 'root');
+
+  cmds.push({
+    type: 'set_tree',
+    tree: newTree,
+    description: `Inserted ${target} into the BST`,
+  });
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'BST Insert',
+  slug: 'bst-insert',
+  category: 'tree',
+  description:
+    'Inserts a new value into a Binary Search Tree by comparing at each node to find the correct position.',
+  bestCase: 'O(log n)',
+  averageCase: 'O(log n)',
+  worstCase: 'O(n)',
+  spaceComplexity: 'O(h)',
+  pseudocode: `function insert(node, value):
+  if node is null: return newNode(value)
+  if value < node.value:
+    node.left = insert(node.left, value)
+  else if value > node.value:
+    node.right = insert(node.right, value)
+  return node`,
+  visualizerType: 'tree',
+  defaultInput: makeTreeState(buildBST([8, 4, 12, 2, 6, 10, 14]), 7),
+  run: bstInsertCommands,
+  reduce: (state, cmd) => {
+    const next = treeReducer(state, cmd);
+    // When set_tree command arrives, update the tree in state
+    if (cmd.type === 'set_tree') {
+      return { ...next, tree: cmd.tree };
+    }
+    return next;
+  },
+});
+
+// Re-export for external use (tests, etc)
+export { bstInsertNode };

--- a/algo-compendium/_algorithms/tree/bst-search.test.ts
+++ b/algo-compendium/_algorithms/tree/bst-search.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { bstSearchCommands } from './bst-search';
+import { makeTreeState, treeReducer } from './commands';
+import { buildBST } from './types';
+
+function runSearch(values: number[], target: number) {
+  const tree = buildBST(values);
+  const state = makeTreeState(tree, target);
+  const cmds = bstSearchCommands(state);
+  return cmds.reduce(treeReducer, state);
+}
+
+describe('bstSearch', () => {
+  it('finds a value that exists in the tree', () => {
+    const result = runSearch([8, 4, 12, 2, 6, 10, 14], 6);
+    expect(result.found).not.toBeNull();
+  });
+
+  it('returns not_found for a missing value', () => {
+    const result = runSearch([8, 4, 12, 2, 6, 10, 14], 7);
+    expect(result.found).toBeNull();
+  });
+
+  it('finds the root', () => {
+    const result = runSearch([8, 4, 12], 8);
+    expect(result.found).not.toBeNull();
+  });
+
+  it('finds a leaf node', () => {
+    const result = runSearch([8, 4, 12, 2, 6, 10, 14], 2);
+    expect(result.found).not.toBeNull();
+  });
+
+  it('handles empty tree', () => {
+    const result = runSearch([], 5);
+    expect(result.found).toBeNull();
+  });
+
+  it('reducer does not mutate previous state', () => {
+    const tree = buildBST([8, 4, 12]);
+    const state = makeTreeState(tree, 4);
+    const cmds = bstSearchCommands(state);
+    const s1 = treeReducer(state, cmds[0]);
+    expect(state.current).toBeNull();
+    expect(s1).not.toBe(state);
+  });
+});

--- a/algo-compendium/_algorithms/tree/bst-search.ts
+++ b/algo-compendium/_algorithms/tree/bst-search.ts
@@ -1,0 +1,75 @@
+import { registerAlgorithm } from '../registry';
+import type { TreeCommand, TreeState } from './commands';
+import { makeTreeState, treeReducer } from './commands';
+import { buildBST } from './types';
+import type { TreeNode } from './types';
+
+export function bstSearchCommands(state: TreeState): TreeCommand[] {
+  const cmds: TreeCommand[] = [];
+  const target = state.targetValue ?? 0;
+
+  function search(node: TreeNode | null): boolean {
+    if (!node) {
+      cmds.push({
+        type: 'not_found',
+        description: `${target} not found in tree`,
+      });
+      return false;
+    }
+
+    cmds.push({
+      type: 'compare',
+      nodeId: node.id,
+      description: `Compare ${node.value} with target ${target}`,
+    });
+
+    if (node.value === target) {
+      cmds.push({
+        type: 'found',
+        nodeId: node.id,
+        description: `Found ${target} at node ${node.id}`,
+      });
+      return true;
+    } else if (target < node.value) {
+      cmds.push({
+        type: 'visit',
+        nodeId: node.id,
+        description: `${target} < ${node.value}, go left`,
+      });
+      return search(node.left);
+    } else {
+      cmds.push({
+        type: 'visit',
+        nodeId: node.id,
+        description: `${target} > ${node.value}, go right`,
+      });
+      return search(node.right);
+    }
+  }
+
+  search(state.tree);
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'BST Search',
+  slug: 'bst-search',
+  category: 'tree',
+  description:
+    'Searches for a value in a Binary Search Tree by comparing at each node and moving left or right accordingly.',
+  bestCase: 'O(1)',
+  averageCase: 'O(log n)',
+  worstCase: 'O(n)',
+  spaceComplexity: 'O(h)',
+  pseudocode: `function search(node, target):
+  if node is null: return NOT_FOUND
+  if target == node.value: return FOUND
+  if target < node.value:
+    return search(node.left, target)
+  else:
+    return search(node.right, target)`,
+  visualizerType: 'tree',
+  defaultInput: makeTreeState(buildBST([8, 4, 12, 2, 6, 10, 14]), 6),
+  run: bstSearchCommands,
+  reduce: treeReducer,
+});

--- a/algo-compendium/_algorithms/tree/commands.ts
+++ b/algo-compendium/_algorithms/tree/commands.ts
@@ -1,0 +1,71 @@
+import type { TreeNode } from './types';
+
+export type TreeCommand =
+  | { type: 'visit'; nodeId: string; description: string }
+  | { type: 'compare'; nodeId: string; description: string }
+  | { type: 'found'; nodeId: string; description: string }
+  | { type: 'not_found'; description: string }
+  | {
+      type: 'insert';
+      nodeId: string;
+      parentId: string | null;
+      direction: 'left' | 'right' | 'root';
+      value: number;
+      description: string;
+    }
+  | { type: 'delete'; nodeId: string; description: string }
+  | { type: 'mark_done'; nodeId: string; description: string }
+  | { type: 'set_tree'; tree: TreeNode | null; description: string };
+
+export type TreeState = {
+  tree: TreeNode | null;
+  visited: string[]; // node IDs visited/done
+  current: string | null; // currently active node ID
+  found: string | null; // found node ID
+  targetValue?: number;
+  description: string;
+};
+
+export function makeTreeState(
+  tree: TreeNode | null,
+  targetValue?: number
+): TreeState {
+  return {
+    tree,
+    visited: [],
+    current: null,
+    found: null,
+    targetValue,
+    description: 'Ready',
+  };
+}
+
+export function treeReducer(state: TreeState, cmd: TreeCommand): TreeState {
+  switch (cmd.type) {
+    case 'visit':
+      return { ...state, current: cmd.nodeId, description: cmd.description };
+    case 'compare':
+      return { ...state, current: cmd.nodeId, description: cmd.description };
+    case 'found':
+      return {
+        ...state,
+        found: cmd.nodeId,
+        current: cmd.nodeId,
+        description: cmd.description,
+      };
+    case 'not_found':
+      return { ...state, current: null, description: cmd.description };
+    case 'mark_done':
+      return {
+        ...state,
+        visited: [...state.visited, cmd.nodeId],
+        current: null,
+        description: cmd.description,
+      };
+    case 'set_tree':
+      return { ...state, tree: cmd.tree, description: cmd.description };
+    case 'insert':
+    case 'delete':
+      return { ...state, description: cmd.description };
+  }
+}

--- a/algo-compendium/_algorithms/tree/index.ts
+++ b/algo-compendium/_algorithms/tree/index.ts
@@ -1,0 +1,8 @@
+import './inorder';
+import './preorder';
+import './postorder';
+import './level-order';
+import './bst-insert';
+import './bst-search';
+import './bst-delete';
+import './avl-insert';

--- a/algo-compendium/_algorithms/tree/inorder.test.ts
+++ b/algo-compendium/_algorithms/tree/inorder.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { inorderTraversalCommands } from './inorder';
+import { makeTreeState, treeReducer } from './commands';
+import { buildBST } from './types';
+import type { TreeCommand } from './commands';
+
+function getVisitOrder(cmds: TreeCommand[], tree: ReturnType<typeof buildBST>) {
+  // Build a map from node ID to value
+  const idToValue = new Map<string, number>();
+  function collect(node: ReturnType<typeof buildBST>) {
+    if (!node) return;
+    idToValue.set(node.id, node.value);
+    collect(node.left);
+    collect(node.right);
+  }
+  collect(tree);
+
+  return cmds
+    .filter((c) => c.type === 'mark_done')
+    .map((c) => {
+      if (c.type === 'mark_done') return idToValue.get(c.nodeId) ?? -1;
+      return -1;
+    });
+}
+
+describe('inorderTraversal', () => {
+  it('visits nodes in sorted (in-order) sequence', () => {
+    const tree = buildBST([8, 4, 12, 2, 6, 10, 14]);
+    const state = makeTreeState(tree);
+    const cmds = inorderTraversalCommands(state);
+    const order = getVisitOrder(cmds, tree);
+    expect(order).toEqual([2, 4, 6, 8, 10, 12, 14]);
+  });
+
+  it('handles empty tree', () => {
+    const state = makeTreeState(null);
+    const cmds = inorderTraversalCommands(state);
+    expect(cmds).toHaveLength(0);
+  });
+
+  it('handles single node', () => {
+    const tree = buildBST([5]);
+    const state = makeTreeState(tree);
+    const cmds = inorderTraversalCommands(state);
+    const order = getVisitOrder(cmds, tree);
+    expect(order).toEqual([5]);
+  });
+
+  it('reducer does not mutate previous state', () => {
+    const tree = buildBST([4, 2, 6]);
+    const state = makeTreeState(tree);
+    const cmds = inorderTraversalCommands(state);
+    const s1 = treeReducer(state, cmds[0]);
+    expect(state.current).toBeNull();
+    expect(s1).not.toBe(state);
+  });
+
+  it('emits visit then mark_done for each node', () => {
+    const tree = buildBST([4, 2, 6]);
+    const state = makeTreeState(tree);
+    const cmds = inorderTraversalCommands(state);
+    const types = cmds.map((c) => c.type);
+    // Should alternate visit/mark_done for each node
+    for (let i = 0; i < types.length; i += 2) {
+      expect(types[i]).toBe('visit');
+      expect(types[i + 1]).toBe('mark_done');
+    }
+  });
+});

--- a/algo-compendium/_algorithms/tree/inorder.ts
+++ b/algo-compendium/_algorithms/tree/inorder.ts
@@ -1,0 +1,49 @@
+import { registerAlgorithm } from '../registry';
+import type { TreeCommand, TreeState } from './commands';
+import { makeTreeState, treeReducer } from './commands';
+import { buildBST } from './types';
+import type { TreeNode } from './types';
+
+export function inorderTraversalCommands(state: TreeState): TreeCommand[] {
+  const cmds: TreeCommand[] = [];
+
+  function traverse(node: TreeNode | null) {
+    if (!node) return;
+    traverse(node.left);
+    cmds.push({
+      type: 'visit',
+      nodeId: node.id,
+      description: `Visit node ${node.value}`,
+    });
+    cmds.push({
+      type: 'mark_done',
+      nodeId: node.id,
+      description: `Done with node ${node.value}`,
+    });
+    traverse(node.right);
+  }
+
+  traverse(state.tree);
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'In-order Traversal',
+  slug: 'inorder-traversal',
+  category: 'tree',
+  description:
+    'Visits nodes in Left → Root → Right order, producing sorted output for a BST.',
+  bestCase: 'O(n)',
+  averageCase: 'O(n)',
+  worstCase: 'O(n)',
+  spaceComplexity: 'O(h)',
+  pseudocode: `function inorder(node):
+  if node is null: return
+  inorder(node.left)
+  visit(node)
+  inorder(node.right)`,
+  visualizerType: 'tree',
+  defaultInput: makeTreeState(buildBST([8, 4, 12, 2, 6, 10, 14])),
+  run: inorderTraversalCommands,
+  reduce: treeReducer,
+});

--- a/algo-compendium/_algorithms/tree/level-order.test.ts
+++ b/algo-compendium/_algorithms/tree/level-order.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { levelOrderTraversalCommands } from './level-order';
+import { makeTreeState } from './commands';
+import { buildBST } from './types';
+import type { TreeCommand } from './commands';
+
+function getVisitOrder(cmds: TreeCommand[], tree: ReturnType<typeof buildBST>) {
+  const idToValue = new Map<string, number>();
+  function collect(node: ReturnType<typeof buildBST>) {
+    if (!node) return;
+    idToValue.set(node.id, node.value);
+    collect(node.left);
+    collect(node.right);
+  }
+  collect(tree);
+
+  return cmds
+    .filter((c) => c.type === 'mark_done')
+    .map((c) => {
+      if (c.type === 'mark_done') return idToValue.get(c.nodeId) ?? -1;
+      return -1;
+    });
+}
+
+describe('levelOrderTraversal', () => {
+  it('visits nodes level by level', () => {
+    const tree = buildBST([8, 4, 12, 2, 6, 10, 14]);
+    const state = makeTreeState(tree);
+    const cmds = levelOrderTraversalCommands(state);
+    const order = getVisitOrder(cmds, tree);
+    expect(order).toEqual([8, 4, 12, 2, 6, 10, 14]);
+  });
+
+  it('handles empty tree', () => {
+    const state = makeTreeState(null);
+    const cmds = levelOrderTraversalCommands(state);
+    expect(cmds).toHaveLength(0);
+  });
+
+  it('handles single node', () => {
+    const tree = buildBST([5]);
+    const state = makeTreeState(tree);
+    const cmds = levelOrderTraversalCommands(state);
+    const order = getVisitOrder(cmds, tree);
+    expect(order).toEqual([5]);
+  });
+
+  it('visits all nodes exactly once', () => {
+    const tree = buildBST([8, 4, 12, 2, 6]);
+    const state = makeTreeState(tree);
+    const cmds = levelOrderTraversalCommands(state);
+    const doneCmds = cmds.filter((c) => c.type === 'mark_done');
+    expect(doneCmds).toHaveLength(5);
+  });
+});

--- a/algo-compendium/_algorithms/tree/level-order.ts
+++ b/algo-compendium/_algorithms/tree/level-order.ts
@@ -1,0 +1,53 @@
+import { registerAlgorithm } from '../registry';
+import type { TreeCommand, TreeState } from './commands';
+import { makeTreeState, treeReducer } from './commands';
+import { buildBST } from './types';
+import type { TreeNode } from './types';
+
+export function levelOrderTraversalCommands(state: TreeState): TreeCommand[] {
+  const cmds: TreeCommand[] = [];
+  if (!state.tree) return cmds;
+
+  const queue: TreeNode[] = [state.tree];
+
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    cmds.push({
+      type: 'visit',
+      nodeId: node.id,
+      description: `Visit node ${node.value}`,
+    });
+    cmds.push({
+      type: 'mark_done',
+      nodeId: node.id,
+      description: `Done with node ${node.value}`,
+    });
+    if (node.left) queue.push(node.left);
+    if (node.right) queue.push(node.right);
+  }
+
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Level-order Traversal',
+  slug: 'level-order-traversal',
+  category: 'tree',
+  description:
+    'Visits nodes level by level using a queue (BFS). Explores all nodes at depth d before nodes at depth d+1.',
+  bestCase: 'O(n)',
+  averageCase: 'O(n)',
+  worstCase: 'O(n)',
+  spaceComplexity: 'O(w)',
+  pseudocode: `function levelOrder(root):
+  queue = [root]
+  while queue not empty:
+    node = queue.dequeue()
+    visit(node)
+    if node.left:  queue.enqueue(node.left)
+    if node.right: queue.enqueue(node.right)`,
+  visualizerType: 'tree',
+  defaultInput: makeTreeState(buildBST([8, 4, 12, 2, 6, 10, 14])),
+  run: levelOrderTraversalCommands,
+  reduce: treeReducer,
+});

--- a/algo-compendium/_algorithms/tree/postorder.test.ts
+++ b/algo-compendium/_algorithms/tree/postorder.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { postorderTraversalCommands } from './postorder';
+import { makeTreeState } from './commands';
+import { buildBST } from './types';
+import type { TreeCommand } from './commands';
+
+function getVisitOrder(cmds: TreeCommand[], tree: ReturnType<typeof buildBST>) {
+  const idToValue = new Map<string, number>();
+  function collect(node: ReturnType<typeof buildBST>) {
+    if (!node) return;
+    idToValue.set(node.id, node.value);
+    collect(node.left);
+    collect(node.right);
+  }
+  collect(tree);
+
+  return cmds
+    .filter((c) => c.type === 'mark_done')
+    .map((c) => {
+      if (c.type === 'mark_done') return idToValue.get(c.nodeId) ?? -1;
+      return -1;
+    });
+}
+
+describe('postorderTraversal', () => {
+  it('visits leaves first then root last', () => {
+    const tree = buildBST([8, 4, 12, 2, 6, 10, 14]);
+    const state = makeTreeState(tree);
+    const cmds = postorderTraversalCommands(state);
+    const order = getVisitOrder(cmds, tree);
+    expect(order).toEqual([2, 6, 4, 10, 14, 12, 8]);
+  });
+
+  it('handles empty tree', () => {
+    const state = makeTreeState(null);
+    const cmds = postorderTraversalCommands(state);
+    expect(cmds).toHaveLength(0);
+  });
+
+  it('handles single node', () => {
+    const tree = buildBST([5]);
+    const state = makeTreeState(tree);
+    const cmds = postorderTraversalCommands(state);
+    const order = getVisitOrder(cmds, tree);
+    expect(order).toEqual([5]);
+  });
+});

--- a/algo-compendium/_algorithms/tree/postorder.ts
+++ b/algo-compendium/_algorithms/tree/postorder.ts
@@ -1,0 +1,49 @@
+import { registerAlgorithm } from '../registry';
+import type { TreeCommand, TreeState } from './commands';
+import { makeTreeState, treeReducer } from './commands';
+import { buildBST } from './types';
+import type { TreeNode } from './types';
+
+export function postorderTraversalCommands(state: TreeState): TreeCommand[] {
+  const cmds: TreeCommand[] = [];
+
+  function traverse(node: TreeNode | null) {
+    if (!node) return;
+    traverse(node.left);
+    traverse(node.right);
+    cmds.push({
+      type: 'visit',
+      nodeId: node.id,
+      description: `Visit node ${node.value}`,
+    });
+    cmds.push({
+      type: 'mark_done',
+      nodeId: node.id,
+      description: `Done with node ${node.value}`,
+    });
+  }
+
+  traverse(state.tree);
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Post-order Traversal',
+  slug: 'postorder-traversal',
+  category: 'tree',
+  description:
+    'Visits nodes in Left → Right → Root order. Useful for deleting a tree or evaluating postfix expressions.',
+  bestCase: 'O(n)',
+  averageCase: 'O(n)',
+  worstCase: 'O(n)',
+  spaceComplexity: 'O(h)',
+  pseudocode: `function postorder(node):
+  if node is null: return
+  postorder(node.left)
+  postorder(node.right)
+  visit(node)`,
+  visualizerType: 'tree',
+  defaultInput: makeTreeState(buildBST([8, 4, 12, 2, 6, 10, 14])),
+  run: postorderTraversalCommands,
+  reduce: treeReducer,
+});

--- a/algo-compendium/_algorithms/tree/preorder.test.ts
+++ b/algo-compendium/_algorithms/tree/preorder.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { preorderTraversalCommands } from './preorder';
+import { makeTreeState } from './commands';
+import { buildBST } from './types';
+import type { TreeCommand } from './commands';
+
+function getVisitOrder(cmds: TreeCommand[], tree: ReturnType<typeof buildBST>) {
+  const idToValue = new Map<string, number>();
+  function collect(node: ReturnType<typeof buildBST>) {
+    if (!node) return;
+    idToValue.set(node.id, node.value);
+    collect(node.left);
+    collect(node.right);
+  }
+  collect(tree);
+
+  return cmds
+    .filter((c) => c.type === 'mark_done')
+    .map((c) => {
+      if (c.type === 'mark_done') return idToValue.get(c.nodeId) ?? -1;
+      return -1;
+    });
+}
+
+describe('preorderTraversal', () => {
+  it('visits root first then left subtree then right subtree', () => {
+    const tree = buildBST([8, 4, 12, 2, 6, 10, 14]);
+    const state = makeTreeState(tree);
+    const cmds = preorderTraversalCommands(state);
+    const order = getVisitOrder(cmds, tree);
+    expect(order).toEqual([8, 4, 2, 6, 12, 10, 14]);
+  });
+
+  it('handles empty tree', () => {
+    const state = makeTreeState(null);
+    const cmds = preorderTraversalCommands(state);
+    expect(cmds).toHaveLength(0);
+  });
+
+  it('handles single node', () => {
+    const tree = buildBST([5]);
+    const state = makeTreeState(tree);
+    const cmds = preorderTraversalCommands(state);
+    const order = getVisitOrder(cmds, tree);
+    expect(order).toEqual([5]);
+  });
+});

--- a/algo-compendium/_algorithms/tree/preorder.ts
+++ b/algo-compendium/_algorithms/tree/preorder.ts
@@ -1,0 +1,49 @@
+import { registerAlgorithm } from '../registry';
+import type { TreeCommand, TreeState } from './commands';
+import { makeTreeState, treeReducer } from './commands';
+import { buildBST } from './types';
+import type { TreeNode } from './types';
+
+export function preorderTraversalCommands(state: TreeState): TreeCommand[] {
+  const cmds: TreeCommand[] = [];
+
+  function traverse(node: TreeNode | null) {
+    if (!node) return;
+    cmds.push({
+      type: 'visit',
+      nodeId: node.id,
+      description: `Visit node ${node.value}`,
+    });
+    cmds.push({
+      type: 'mark_done',
+      nodeId: node.id,
+      description: `Done with node ${node.value}`,
+    });
+    traverse(node.left);
+    traverse(node.right);
+  }
+
+  traverse(state.tree);
+  return cmds;
+}
+
+registerAlgorithm({
+  name: 'Pre-order Traversal',
+  slug: 'preorder-traversal',
+  category: 'tree',
+  description:
+    'Visits nodes in Root → Left → Right order. Useful for creating a copy of the tree or prefix expression evaluation.',
+  bestCase: 'O(n)',
+  averageCase: 'O(n)',
+  worstCase: 'O(n)',
+  spaceComplexity: 'O(h)',
+  pseudocode: `function preorder(node):
+  if node is null: return
+  visit(node)
+  preorder(node.left)
+  preorder(node.right)`,
+  visualizerType: 'tree',
+  defaultInput: makeTreeState(buildBST([8, 4, 12, 2, 6, 10, 14])),
+  run: preorderTraversalCommands,
+  reduce: treeReducer,
+});

--- a/algo-compendium/_algorithms/tree/types.ts
+++ b/algo-compendium/_algorithms/tree/types.ts
@@ -1,0 +1,39 @@
+export type TreeNode = {
+  id: string; // unique id like "node-0", "node-1"
+  value: number;
+  left: TreeNode | null;
+  right: TreeNode | null;
+};
+
+export function makeNode(value: number, id: string): TreeNode {
+  return { id, value, left: null, right: null };
+}
+
+// Build a BST from array values for default inputs
+export function buildBST(values: number[]): TreeNode | null {
+  let root: TreeNode | null = null;
+  let counter = 0;
+  for (const val of values) {
+    root = bstInsertNode(root, val, () => `n${counter++}`);
+  }
+  return root;
+}
+
+export function bstInsertNode(
+  root: TreeNode | null,
+  value: number,
+  makeId: () => string
+): TreeNode {
+  if (!root) return makeNode(value, makeId());
+  if (value < root.value)
+    return { ...root, left: bstInsertNode(root.left, value, makeId) };
+  if (value > root.value)
+    return { ...root, right: bstInsertNode(root.right, value, makeId) };
+  return root; // duplicate, ignore
+}
+
+// Flatten tree to array of node values (pre-order) for easy testing
+export function flattenTree(root: TreeNode | null): number[] {
+  if (!root) return [];
+  return [root.value, ...flattenTree(root.left), ...flattenTree(root.right)];
+}

--- a/algo-compendium/_components/AlgorithmIcon.tsx
+++ b/algo-compendium/_components/AlgorithmIcon.tsx
@@ -1,0 +1,15 @@
+import type { AlgorithmCategory } from '../_algorithms/_shared/types';
+import { CategoryIcon } from './CategoryIcon';
+
+export function AlgorithmIcon({
+  category,
+  slug: _slug, // reserved for future per-algorithm icons
+  className,
+}: {
+  category: AlgorithmCategory;
+  slug: string;
+  className?: string;
+}) {
+  void _slug;
+  return <CategoryIcon category={category} className={className} />;
+}

--- a/algo-compendium/_components/CategoryIcon.tsx
+++ b/algo-compendium/_components/CategoryIcon.tsx
@@ -1,0 +1,124 @@
+import type { ReactElement } from 'react';
+import type { AlgorithmCategory } from '../_algorithms/_shared/types';
+
+const ICONS: Record<AlgorithmCategory, ReactElement> = {
+  sorting: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      className="w-5 h-5"
+    >
+      <path d="M3 6h18M7 12h10M11 18h2" strokeLinecap="round" />
+    </svg>
+  ),
+  searching: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      className="w-5 h-5"
+    >
+      <circle cx="11" cy="11" r="8" />
+      <path d="m21 21-4.35-4.35" strokeLinecap="round" />
+    </svg>
+  ),
+  graph: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      className="w-5 h-5"
+    >
+      <circle cx="5" cy="12" r="2" />
+      <circle cx="19" cy="5" r="2" />
+      <circle cx="19" cy="19" r="2" />
+      <path d="M7 12h10M17 6.5l-10 4M17 17.5l-10-4" />
+    </svg>
+  ),
+  tree: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      className="w-5 h-5"
+    >
+      <circle cx="12" cy="4" r="2" />
+      <circle cx="6" cy="16" r="2" />
+      <circle cx="18" cy="16" r="2" />
+      <path d="M12 6v4M10 14l-2.5-4M14 14l2.5-4" />
+    </svg>
+  ),
+  'dynamic-programming': (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      className="w-5 h-5"
+    >
+      <rect x="3" y="3" width="7" height="7" />
+      <rect x="14" y="3" width="7" height="7" />
+      <rect x="3" y="14" width="7" height="7" />
+      <rect x="14" y="14" width="7" height="7" />
+    </svg>
+  ),
+  'string-matching': (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      className="w-5 h-5"
+    >
+      <path d="M4 7h16M4 12h10M4 17h6" strokeLinecap="round" />
+      <path d="M17 14l2 2 4-4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  ),
+  backtracking: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      className="w-5 h-5"
+    >
+      <path
+        d="M12 4v8M8 8l4-4 4 4M8 16l4 4 4-4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  ),
+  math: (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      className="w-5 h-5"
+    >
+      <path
+        d="M4 19 20 5M15 5h5v5M4 9h5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  ),
+};
+
+export function CategoryIcon({
+  category,
+  className,
+}: {
+  category: AlgorithmCategory;
+  className?: string;
+}) {
+  const icon = ICONS[category];
+  if (!icon) return null;
+  return <span className={className}>{icon}</span>;
+}

--- a/algo-compendium/_components/Controls.tsx
+++ b/algo-compendium/_components/Controls.tsx
@@ -1,0 +1,167 @@
+import { useState, useEffect } from 'react';
+import { useI18n } from '../app/_i18n';
+
+type ControlsProps = {
+  index: number;
+  totalCommands: number;
+  isPlaying: boolean;
+  speed: number;
+  description?: string;
+  inputValue?: string;
+  onPlay: () => void;
+  onPause: () => void;
+  onStepBack: () => void;
+  onStepForward: () => void;
+  onReset: () => void;
+  onSpeedChange: (speed: number) => void;
+  onJumpTo: (index: number) => void;
+  onRandomize?: () => void;
+  onCustomInput?: (value: string) => void;
+  customInputPlaceholder?: string;
+};
+
+export function Controls({
+  index,
+  totalCommands,
+  isPlaying,
+  speed,
+  description,
+  inputValue,
+  onPlay,
+  onPause,
+  onStepBack,
+  onStepForward,
+  onReset,
+  onSpeedChange,
+  onJumpTo,
+  onRandomize,
+  onCustomInput,
+  customInputPlaceholder = 'Custom input…',
+}: ControlsProps) {
+  const { t } = useI18n();
+  const [customValue, setCustomValue] = useState(inputValue ?? '');
+
+  useEffect(() => {
+    if (inputValue !== undefined) setCustomValue(inputValue);
+  }, [inputValue]);
+
+  const progressValue = Math.max(0, index);
+  const progressMax = Math.max(0, totalCommands - 1);
+
+  return (
+    <div className="controls-wrapper">
+      {/* Playback buttons + speed */}
+      <div className="controls-row">
+        {isPlaying ? (
+          <button onClick={onPause} className="btn-primary" aria-label="Pause">
+            {t('controls.pause')}
+          </button>
+        ) : (
+          <button
+            onClick={onPlay}
+            disabled={totalCommands === 0}
+            className="btn-primary"
+            aria-label="Play"
+          >
+            {t('controls.play')}
+          </button>
+        )}
+
+        <button
+          onClick={onStepBack}
+          disabled={index <= -1}
+          className="btn-secondary"
+          aria-label="Step back"
+        >
+          ◀
+        </button>
+
+        <button
+          onClick={onStepForward}
+          disabled={index >= totalCommands - 1}
+          className="btn-secondary"
+          aria-label="Step forward"
+        >
+          ▶
+        </button>
+
+        <button onClick={onReset} className="btn-secondary" aria-label="Reset">
+          {t('controls.reset')}
+        </button>
+
+        <div className="flex items-center gap-1.5 ml-auto">
+          <label className="text-xs whitespace-nowrap text-gray-500 dark:text-gray-400">
+            {t('controls.speed')}: {speed}x
+          </label>
+          <input
+            type="range"
+            min={1}
+            max={20}
+            step={1}
+            value={speed}
+            onChange={(e) => onSpeedChange(Number(e.target.value))}
+            className="w-24 accent-[var(--color-turquoise)]"
+            aria-label="Playback speed"
+          />
+        </div>
+      </div>
+
+      {/* Progress bar */}
+      <div className="controls-row">
+        <span className="text-xs font-medium whitespace-nowrap text-gray-500 dark:text-gray-400">
+          {t('controls.steps')}
+        </span>
+        <span className="text-xs tabular-nums w-8 text-right text-gray-400 dark:text-gray-500">
+          {index + 1}
+        </span>
+        <input
+          type="range"
+          min={0}
+          max={progressMax}
+          value={progressValue}
+          onChange={(e) => onJumpTo(Number(e.target.value))}
+          disabled={totalCommands === 0}
+          className="flex-1 accent-[var(--color-turquoise)] disabled:opacity-40"
+          aria-label="Progress"
+        />
+        <span className="text-xs tabular-nums w-8 text-gray-400 dark:text-gray-500">
+          {totalCommands}
+        </span>
+      </div>
+
+      {/* Randomize / custom input */}
+      {(onRandomize || onCustomInput) && (
+        <div className="controls-row">
+          {onRandomize && (
+            <button onClick={onRandomize} className="btn-secondary">
+              {t('controls.randomize')}
+            </button>
+          )}
+          {onCustomInput && (
+            <div className="flex items-center gap-1 flex-1">
+              <input
+                type="text"
+                value={customValue}
+                onChange={(e) => setCustomValue(e.target.value)}
+                placeholder={customInputPlaceholder}
+                className="flex-1 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-200 focus:outline-none focus:border-[var(--color-turquoise)]"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') onCustomInput(customValue);
+                }}
+              />
+              <button
+                onClick={() => onCustomInput(customValue)}
+                className="btn-primary"
+              >
+                {t('controls.apply')}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Step description */}
+      {description && <p className="controls-description">{description}</p>}
+    </div>
+  );
+}

--- a/algo-compendium/_components/MetadataPanel.tsx
+++ b/algo-compendium/_components/MetadataPanel.tsx
@@ -1,0 +1,58 @@
+import type { AlgorithmMeta } from '../_algorithms/_shared/types';
+import { Badge } from './primitives/Badge';
+import { useI18n } from '../app/_i18n';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function MetadataPanel({ meta }: { meta: AlgorithmMeta<any, any> }) {
+  const { t } = useI18n();
+
+  return (
+    <div className="space-y-3">
+      <table className="w-full text-sm">
+        <tbody>
+          <tr>
+            <td className="text-gray-500 dark:text-gray-400 pr-4">
+              {t('complexity.best')}
+            </td>
+            <td className="font-mono dark:text-gray-200">{meta.bestCase}</td>
+          </tr>
+          <tr>
+            <td className="text-gray-500 dark:text-gray-400 pr-4">
+              {t('complexity.average')}
+            </td>
+            <td className="font-mono dark:text-gray-200">{meta.averageCase}</td>
+          </tr>
+          <tr>
+            <td className="text-gray-500 dark:text-gray-400 pr-4">
+              {t('complexity.worst')}
+            </td>
+            <td className="font-mono dark:text-gray-200">{meta.worstCase}</td>
+          </tr>
+          <tr>
+            <td className="text-gray-500 dark:text-gray-400 pr-4">
+              {t('complexity.space')}
+            </td>
+            <td className="font-mono dark:text-gray-200">
+              {meta.spaceComplexity}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div className="flex gap-2 flex-wrap">
+        {meta.stable !== undefined && (
+          <Badge variant={meta.stable ? 'stable' : 'unstable'}>
+            {meta.stable ? t('complexity.stable') : t('complexity.unstable')}
+          </Badge>
+        )}
+        {meta.inPlace !== undefined && (
+          <Badge variant={meta.inPlace ? 'in-place' : 'extra-space'}>
+            {meta.inPlace
+              ? t('complexity.in_place')
+              : t('complexity.extra_space')}
+          </Badge>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/algo-compendium/_components/composed/CollapsibleSection.tsx
+++ b/algo-compendium/_components/composed/CollapsibleSection.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react';
+
+type Props = {
+  title: string;
+  icon?: ReactNode;
+  open: boolean;
+  onToggle: () => void;
+  children: ReactNode;
+  bodyClass?: string;
+};
+
+export function CollapsibleSection({
+  title,
+  icon,
+  open,
+  onToggle,
+  children,
+  bodyClass = '',
+}: Props) {
+  return (
+    <div className="card-section">
+      <button onClick={onToggle} className="section-toggle">
+        <span className="section-title">
+          {icon}
+          {title}
+        </span>
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          className={`section-chevron ${open ? '' : '-rotate-90'}`}
+        >
+          <path d="M6 9l6 6 6-6" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+      {open && <div className={`section-body ${bodyClass}`}>{children}</div>}
+    </div>
+  );
+}

--- a/algo-compendium/_components/composed/LegendRow.tsx
+++ b/algo-compendium/_components/composed/LegendRow.tsx
@@ -1,0 +1,20 @@
+import { LegendItem } from '../primitives/LegendItem';
+
+export type LegendEntry = {
+  dotClass?: string;
+  dotStyle?: React.CSSProperties;
+  label: string;
+  shape?: 'square' | 'circle';
+};
+
+type Props = { items: LegendEntry[] };
+
+export function LegendRow({ items }: Props) {
+  return (
+    <div className="viz-legend">
+      {items.map((item) => (
+        <LegendItem key={item.label} {...item} />
+      ))}
+    </div>
+  );
+}

--- a/algo-compendium/_components/composed/StaticSection.tsx
+++ b/algo-compendium/_components/composed/StaticSection.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+
+type Props = {
+  title: string;
+  icon?: ReactNode;
+  children: ReactNode;
+};
+
+export function StaticSection({ title, icon, children }: Props) {
+  return (
+    <div className="card-section">
+      <div className="section-header-row">
+        {icon}
+        <span className="section-header-title">{title}</span>
+      </div>
+      <div className="section-content">{children}</div>
+    </div>
+  );
+}

--- a/algo-compendium/_components/composed/TargetIndicator.tsx
+++ b/algo-compendium/_components/composed/TargetIndicator.tsx
@@ -1,0 +1,19 @@
+type Props = {
+  label: string;
+  value: number | string;
+  foundMessage?: string | null;
+};
+
+export function TargetIndicator({ label, value, foundMessage }: Props) {
+  return (
+    <div className="text-sm font-medium text-gray-600 dark:text-gray-300">
+      {label}:{' '}
+      <span className="font-bold text-[var(--color-turquoise-dark)]">
+        {value}
+      </span>
+      {foundMessage && (
+        <span className="ml-3 text-green-500 font-medium">{foundMessage}</span>
+      )}
+    </div>
+  );
+}

--- a/algo-compendium/_components/hooks/useAlgorithmPlayer.ts
+++ b/algo-compendium/_components/hooks/useAlgorithmPlayer.ts
@@ -1,0 +1,99 @@
+import { useState, useMemo, useEffect, useCallback, useRef } from 'react';
+
+export type PlayerState<S> = {
+  currentState: S;
+  index: number;
+  totalCommands: number;
+  isPlaying: boolean;
+  speed: number;
+  stepForward: () => void;
+  stepBack: () => void;
+  play: () => void;
+  pause: () => void;
+  reset: () => void;
+  setSpeed: (speed: number) => void;
+  jumpTo: (index: number) => void;
+};
+
+export function useAlgorithmPlayer<C, S>(
+  initialState: S,
+  commands: C[],
+  reduce: (state: S, cmd: C) => S
+): PlayerState<S> {
+  const [index, setIndex] = useState(-1); // -1 = initial state, no commands applied
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [speed, setSpeedState] = useState(1);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Compute current state by replaying commands 0..index onto initialState
+  const currentState = useMemo(
+    () =>
+      commands.slice(0, Math.max(0, index + 1)).reduce(reduce, initialState),
+    [initialState, commands, reduce, index]
+  );
+
+  const stepForward = useCallback(() => {
+    setIndex((i) => Math.min(i + 1, commands.length - 1));
+  }, [commands.length]);
+
+  const stepBack = useCallback(() => {
+    setIndex((i) => Math.max(i - 1, -1));
+  }, []);
+
+  const play = useCallback(() => setIsPlaying(true), []);
+  const pause = useCallback(() => setIsPlaying(false), []);
+
+  const reset = useCallback(() => {
+    setIsPlaying(false);
+    setIndex(-1);
+  }, []);
+
+  const setSpeed = useCallback((s: number) => setSpeedState(s), []);
+
+  const jumpTo = useCallback(
+    (i: number) => setIndex(Math.max(-1, Math.min(i, commands.length - 1))),
+    [commands.length]
+  );
+
+  // Auto-advance when playing
+  useEffect(() => {
+    if (!isPlaying) {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      return;
+    }
+    const delay = Math.round(600 / speed);
+    intervalRef.current = setInterval(() => {
+      setIndex((i) => {
+        if (i >= commands.length - 1) {
+          setIsPlaying(false);
+          return i;
+        }
+        return i + 1;
+      });
+    }, delay);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [isPlaying, speed, commands.length]);
+
+  // Reset when commands change (new input)
+  useEffect(() => {
+    setIndex(-1);
+    setIsPlaying(false);
+  }, [commands]);
+
+  return {
+    currentState,
+    index,
+    totalCommands: commands.length,
+    isPlaying,
+    speed,
+    stepForward,
+    stepBack,
+    play,
+    pause,
+    reset,
+    setSpeed,
+    jumpTo,
+  };
+}

--- a/algo-compendium/_components/primitives/Badge.tsx
+++ b/algo-compendium/_components/primitives/Badge.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+
+type Variant = 'stable' | 'unstable' | 'in-place' | 'extra-space';
+
+const VARIANT_CLASS: Record<Variant, string> = {
+  stable: 'badge-stable',
+  unstable: 'badge-unstable',
+  'in-place': 'badge-in-place',
+  'extra-space': 'badge-extra-space',
+};
+
+type Props = { variant: Variant; children: ReactNode };
+
+export function Badge({ variant, children }: Props) {
+  return <span className={VARIANT_CLASS[variant]}>{children}</span>;
+}

--- a/algo-compendium/_components/primitives/LegendItem.tsx
+++ b/algo-compendium/_components/primitives/LegendItem.tsx
@@ -1,0 +1,23 @@
+type Props = {
+  dotClass?: string;
+  dotStyle?: React.CSSProperties;
+  label: string;
+  shape?: 'square' | 'circle';
+};
+
+export function LegendItem({
+  dotClass = '',
+  dotStyle,
+  label,
+  shape = 'square',
+}: Props) {
+  return (
+    <span className="flex items-center gap-1">
+      <span
+        className={`inline-block w-3 h-3 ${shape === 'circle' ? 'rounded-full' : 'rounded'} ${dotClass}`}
+        style={dotStyle}
+      />
+      {label}
+    </span>
+  );
+}

--- a/algo-compendium/_visualizers/ArrayVisualizer.tsx
+++ b/algo-compendium/_visualizers/ArrayVisualizer.tsx
@@ -1,0 +1,322 @@
+import { useCallback, useState, useEffect } from 'react';
+import { useAlgorithmPlayer } from '../_components/hooks/useAlgorithmPlayer';
+import { Controls } from '../_components/Controls';
+import { LegendRow } from '../_components/composed/LegendRow';
+import { TargetIndicator } from '../_components/composed/TargetIndicator';
+import { useI18n } from '../app/_i18n';
+import type { SortCommand, SortState } from '../_algorithms/sorting/commands';
+import { makeSortState, sortReducer } from '../_algorithms/sorting/commands';
+import type {
+  SearchCommand,
+  SearchState,
+} from '../_algorithms/searching/commands';
+import {
+  makeSearchState,
+  searchReducer,
+} from '../_algorithms/searching/commands';
+
+// ─── Sort mode ───────────────────────────────────────────────────────────────
+
+type SortProps = {
+  mode: 'sort';
+  commands: SortCommand[];
+  initialState: SortState;
+  onNewCommands: (commands: SortCommand[], newState: SortState) => void;
+  generateCommands: (arr: number[]) => SortCommand[];
+};
+
+// ─── Search mode ─────────────────────────────────────────────────────────────
+
+type SearchProps = {
+  mode: 'search';
+  commands: SearchCommand[];
+  initialState: SearchState;
+  onNewCommands: (commands: SearchCommand[], newState: SearchState) => void;
+  generateCommands: (arr: number[], target: number) => SearchCommand[];
+};
+
+type Props = SortProps | SearchProps;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function ArrayVisualizer(props: Props) {
+  if (props.mode === 'search') {
+    return <SearchArrayVisualizer {...props} />;
+  }
+  return <SortArrayVisualizer {...props} />;
+}
+
+// ─── Sort visualizer ─────────────────────────────────────────────────────────
+
+function SortArrayVisualizer({
+  commands,
+  initialState,
+  onNewCommands,
+  generateCommands,
+}: Omit<SortProps, 'mode'>) {
+  const { t } = useI18n();
+  const player = useAlgorithmPlayer(initialState, commands, sortReducer);
+  const [inputValue, setInputValue] = useState(() =>
+    initialState.array.join(', ')
+  );
+
+  useEffect(() => {
+    setInputValue(initialState.array.join(', '));
+  }, [initialState]);
+
+  const handleRandomize = useCallback(() => {
+    const arr = Array.from(
+      { length: 20 },
+      () => Math.floor(Math.random() * 90) + 10
+    );
+    setInputValue(arr.join(', '));
+    const newState = makeSortState(arr);
+    const newCommands = generateCommands(arr);
+    onNewCommands(newCommands, newState);
+  }, [generateCommands, onNewCommands]);
+
+  const handleCustomInput = useCallback(
+    (value: string) => {
+      const arr = value
+        .split(',')
+        .map((s) => parseInt(s.trim(), 10))
+        .filter((n) => !isNaN(n) && n > 0 && n <= 1000);
+      if (arr.length < 2) return;
+      const newState = makeSortState(arr);
+      const newCommands = generateCommands(arr);
+      onNewCommands(newCommands, newState);
+    },
+    [generateCommands, onNewCommands]
+  );
+
+  const { currentState } = player;
+  const maxVal = Math.max(...currentState.array, 1);
+
+  return (
+    <div className="flex flex-col gap-4 w-full">
+      {/* Bar chart */}
+      <div className="flex items-end gap-1 h-48 viz-surface p-3">
+        {currentState.array.map((val, i) => {
+          let color = 'bg-gray-300';
+          if (currentState.pivot === i) color = 'bg-purple-500';
+          else if (currentState.swapping.includes(i)) color = 'bg-orange-400';
+          else if (currentState.comparing.includes(i)) color = 'bg-yellow-400';
+          else if (currentState.sorted.includes(i))
+            color = 'bg-[var(--color-turquoise)]';
+          const height = Math.max(4, Math.round((val / maxVal) * 100));
+          return (
+            <div
+              key={i}
+              className={`flex-1 rounded-t transition-all duration-100 ${color}`}
+              style={{ height: `${height}%` }}
+              title={String(val)}
+            />
+          );
+        })}
+      </div>
+
+      <LegendRow
+        items={[
+          {
+            dotClass: 'bg-gray-300',
+            label: t('visualizer.sort_legend.unsorted'),
+          },
+          {
+            dotClass: 'bg-yellow-400',
+            label: t('visualizer.sort_legend.comparing'),
+          },
+          {
+            dotClass: 'bg-orange-400',
+            label: t('visualizer.sort_legend.swapping'),
+          },
+          {
+            dotClass: 'bg-purple-500',
+            label: t('visualizer.sort_legend.pivot'),
+          },
+          {
+            dotClass: 'bg-[var(--color-turquoise)]',
+            label: t('visualizer.sort_legend.sorted'),
+          },
+        ]}
+      />
+
+      {/* Controls */}
+      <Controls
+        index={player.index}
+        totalCommands={player.totalCommands}
+        isPlaying={player.isPlaying}
+        speed={player.speed}
+        description={currentState.description}
+        onPlay={player.play}
+        onPause={player.pause}
+        onStepBack={player.stepBack}
+        onStepForward={player.stepForward}
+        onReset={player.reset}
+        onSpeedChange={player.setSpeed}
+        onJumpTo={player.jumpTo}
+        inputValue={inputValue}
+        onRandomize={handleRandomize}
+        onCustomInput={handleCustomInput}
+        customInputPlaceholder="e.g. 64,34,25,12,22"
+      />
+    </div>
+  );
+}
+
+// ─── Search visualizer ───────────────────────────────────────────────────────
+
+function SearchArrayVisualizer({
+  commands,
+  initialState,
+  onNewCommands,
+  generateCommands,
+}: Omit<SearchProps, 'mode'>) {
+  const { t } = useI18n();
+  const player = useAlgorithmPlayer(initialState, commands, searchReducer);
+  const [inputValue, setInputValue] = useState(
+    () => `${initialState.target};${initialState.array.join(', ')}`
+  );
+
+  useEffect(() => {
+    setInputValue(`${initialState.target};${initialState.array.join(', ')}`);
+  }, [initialState]);
+
+  const handleRandomize = useCallback(() => {
+    // Generate a sorted random array for search algorithms
+    const arr = Array.from(
+      { length: 10 },
+      () => Math.floor(Math.random() * 90) + 10
+    )
+      .sort((a, b) => a - b)
+      // Deduplicate
+      .filter((v, i, a) => i === 0 || v !== a[i - 1]);
+    // Pick a random target that exists in the array
+    const target = arr[Math.floor(Math.random() * arr.length)];
+    setInputValue(`${target};${arr.join(', ')}`);
+    const newState = makeSearchState(arr, target);
+    const newCommands = generateCommands(arr, target);
+    onNewCommands(newCommands, newState);
+  }, [generateCommands, onNewCommands]);
+
+  const handleCustomInput = useCallback(
+    (value: string) => {
+      // Format: "target;v1,v2,v3" or just "v1,v2,v3" (picks middle as target)
+      const parts = value.split(';');
+      let arr: number[];
+      let target: number;
+      if (parts.length >= 2) {
+        arr = parts[1]
+          .split(',')
+          .map((s) => parseInt(s.trim(), 10))
+          .filter((n) => !isNaN(n) && n > 0 && n <= 1000)
+          .sort((a, b) => a - b);
+        target = parseInt(parts[0].trim(), 10);
+      } else {
+        arr = parts[0]
+          .split(',')
+          .map((s) => parseInt(s.trim(), 10))
+          .filter((n) => !isNaN(n) && n > 0 && n <= 1000)
+          .sort((a, b) => a - b);
+        target = arr[Math.floor(arr.length / 2)] ?? arr[0];
+      }
+      if (arr.length < 1 || isNaN(target)) return;
+      const newState = makeSearchState(arr, target);
+      const newCommands = generateCommands(arr, target);
+      onNewCommands(newCommands, newState);
+    },
+    [generateCommands, onNewCommands]
+  );
+
+  const { currentState } = player;
+  const maxVal = Math.max(...currentState.array, 1);
+
+  return (
+    <div className="flex flex-col gap-4 w-full">
+      <TargetIndicator
+        label={t('visualizer.search_legend.target')}
+        value={currentState.target}
+        foundMessage={
+          currentState.found !== null
+            ? `${t('visualizer.search_legend.found_at_index')} ${currentState.found}`
+            : null
+        }
+      />
+
+      {/* Bar chart */}
+      <div className="flex items-end gap-1 h-48 viz-surface p-3">
+        {currentState.array.map((val, i) => {
+          let color = 'bg-gray-300';
+          if (currentState.found === i) {
+            color = 'bg-green-500';
+          } else if (currentState.mid === i) {
+            color = 'bg-purple-500';
+          } else if (currentState.current === i) {
+            color = 'bg-yellow-400';
+          } else if (currentState.eliminated.includes(i)) {
+            color = 'bg-gray-100';
+          } else if (currentState.low === i || currentState.high === i) {
+            color = 'bg-orange-300';
+          }
+          const height = Math.max(4, Math.round((val / maxVal) * 100));
+          return (
+            <div
+              key={i}
+              className={`flex-1 rounded-t transition-all duration-100 ${color}`}
+              style={{ height: `${height}%` }}
+              title={`[${i}] = ${val}`}
+            />
+          );
+        })}
+      </div>
+
+      <LegendRow
+        items={[
+          {
+            dotClass: 'bg-gray-300',
+            label: t('visualizer.search_legend.unsearched'),
+          },
+          {
+            dotClass: 'bg-yellow-400',
+            label: t('visualizer.search_legend.current'),
+          },
+          {
+            dotClass: 'bg-purple-500',
+            label: t('visualizer.search_legend.midpoint'),
+          },
+          {
+            dotClass: 'bg-orange-300',
+            label: t('visualizer.search_legend.bounds'),
+          },
+          {
+            dotClass: 'bg-gray-100 border border-gray-300',
+            label: t('visualizer.search_legend.eliminated'),
+          },
+          {
+            dotClass: 'bg-green-500',
+            label: t('visualizer.search_legend.found'),
+          },
+        ]}
+      />
+
+      {/* Controls */}
+      <Controls
+        index={player.index}
+        totalCommands={player.totalCommands}
+        isPlaying={player.isPlaying}
+        speed={player.speed}
+        description={currentState.description}
+        onPlay={player.play}
+        onPause={player.pause}
+        onStepBack={player.stepBack}
+        onStepForward={player.stepForward}
+        onReset={player.reset}
+        onSpeedChange={player.setSpeed}
+        onJumpTo={player.jumpTo}
+        inputValue={inputValue}
+        onRandomize={handleRandomize}
+        onCustomInput={handleCustomInput}
+        customInputPlaceholder="e.g. 45;11,21,34,39,45,56 or just 11,21,34,39,45,56"
+      />
+    </div>
+  );
+}

--- a/algo-compendium/_visualizers/GraphVisualizer.tsx
+++ b/algo-compendium/_visualizers/GraphVisualizer.tsx
@@ -1,0 +1,212 @@
+import { useAlgorithmPlayer } from '../_components/hooks/useAlgorithmPlayer';
+import { Controls } from '../_components/Controls';
+import type { GraphState, GraphCommand } from '../_algorithms/graph/commands';
+import { graphReducer } from '../_algorithms/graph/commands';
+
+const SVG_W = 500;
+const SVG_H = 300;
+
+export function GraphVisualizer({
+  commands,
+  initialState,
+}: {
+  commands: GraphCommand[];
+  initialState: GraphState;
+}) {
+  const player = useAlgorithmPlayer(initialState, commands, graphReducer);
+  const { currentState } = player;
+  const { graph } = currentState;
+
+  const sx = (x: number) => (x / 100) * (SVG_W - 60) + 30;
+  const sy = (y: number) => (y / 100) * (SVG_H - 60) + 30;
+
+  function getEdgeColor(from: string, to: string): string {
+    if (
+      currentState.mstEdges.some(
+        ([f, t]) => (f === from && t === to) || (f === to && t === from)
+      )
+    )
+      return 'var(--color-turquoise)';
+    if (currentState.path.length > 1) {
+      const pathEdges = currentState.path
+        .slice(0, -1)
+        .map((n, i) => [n, currentState.path[i + 1]]);
+      if (pathEdges.some(([f, t]) => f === from && t === to)) return '#22c55e';
+    }
+    if (currentState.visitedEdges.some(([f, t]) => f === from && t === to))
+      return '#fbbf24';
+    return '#d1d5db';
+  }
+
+  function getNodeColors(nodeId: string): { fill: string; stroke: string } {
+    if (currentState.current === nodeId)
+      return { fill: '#fbbf24', stroke: '#f59e0b' };
+    if (currentState.path.includes(nodeId))
+      return { fill: '#22c55e', stroke: '#16a34a' };
+    if (currentState.finalized.includes(nodeId))
+      return {
+        fill: 'var(--color-turquoise)',
+        stroke: 'var(--color-turquoise-dark)',
+      };
+    if (currentState.visited.includes(nodeId))
+      return { fill: '#a5f3fc', stroke: '#0ea5e9' };
+    return { fill: '#e5e7eb', stroke: '#9ca3af' };
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="bg-gray-50 rounded-lg overflow-x-auto">
+        <svg
+          width={SVG_W}
+          height={SVG_H}
+          viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+          aria-label="Graph visualization"
+        >
+          <defs>
+            <marker
+              id="graph-arrow"
+              markerWidth="8"
+              markerHeight="6"
+              refX="7"
+              refY="3"
+              orient="auto"
+            >
+              <polygon points="0 0, 8 3, 0 6" fill="#9ca3af" />
+            </marker>
+          </defs>
+
+          {/* Edges */}
+          {graph.edges.map((edge, i) => {
+            const fromNode = graph.nodes.find((n) => n.id === edge.from);
+            const toNode = graph.nodes.find((n) => n.id === edge.to);
+            if (!fromNode || !toNode) return null;
+            const x1 = sx(fromNode.x);
+            const y1 = sy(fromNode.y);
+            const x2 = sx(toNode.x);
+            const y2 = sy(toNode.y);
+            const color = getEdgeColor(edge.from, edge.to);
+            const mx = (x1 + x2) / 2;
+            const my = (y1 + y2) / 2;
+            return (
+              <g key={i}>
+                <line
+                  x1={x1}
+                  y1={y1}
+                  x2={x2}
+                  y2={y2}
+                  stroke={color}
+                  strokeWidth={2}
+                  markerEnd={graph.directed ? 'url(#graph-arrow)' : undefined}
+                />
+                {edge.weight !== undefined && (
+                  <text
+                    x={mx}
+                    y={my - 4}
+                    textAnchor="middle"
+                    fontSize={10}
+                    fill="#6b7280"
+                  >
+                    {edge.weight}
+                  </text>
+                )}
+              </g>
+            );
+          })}
+
+          {/* Nodes */}
+          {graph.nodes.map((node) => {
+            const { fill, stroke } = getNodeColors(node.id);
+            const cx = sx(node.x);
+            const cy = sy(node.y);
+            const dist = currentState.distances[node.id];
+            return (
+              <g key={node.id}>
+                <circle
+                  cx={cx}
+                  cy={cy}
+                  r={18}
+                  fill={fill}
+                  stroke={stroke}
+                  strokeWidth={2}
+                />
+                <text
+                  x={cx}
+                  y={cy + 4}
+                  textAnchor="middle"
+                  fontSize={11}
+                  fill="#374151"
+                  fontWeight="600"
+                >
+                  {node.label}
+                </text>
+                {dist !== undefined && dist !== Infinity && (
+                  <text
+                    x={cx}
+                    y={cy - 24}
+                    textAnchor="middle"
+                    fontSize={9}
+                    fill="#6b7280"
+                  >
+                    {dist}
+                  </text>
+                )}
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+
+      <Controls
+        index={player.index}
+        totalCommands={player.totalCommands}
+        isPlaying={player.isPlaying}
+        speed={player.speed}
+        description={currentState.description}
+        onPlay={player.play}
+        onPause={player.pause}
+        onStepBack={player.stepBack}
+        onStepForward={player.stepForward}
+        onReset={player.reset}
+        onSpeedChange={player.setSpeed}
+        onJumpTo={player.jumpTo}
+      />
+
+      {/* Legend */}
+      <div className="flex items-center gap-4 flex-wrap text-xs text-gray-500">
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded-full bg-gray-200 border border-gray-400" />
+          Unvisited
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded-full bg-yellow-400 border border-yellow-500" />
+          Current
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded-full bg-cyan-200 border border-cyan-500" />
+          Visited
+        </span>
+        <span className="flex items-center gap-1">
+          <span
+            className="inline-block w-3 h-3 rounded-full border"
+            style={{
+              background: 'var(--color-turquoise)',
+              borderColor: 'var(--color-turquoise-dark)',
+            }}
+          />
+          Finalized
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block w-3 h-3 rounded-full bg-green-500 border border-green-600" />
+          Path / MST
+        </span>
+      </div>
+
+      {currentState.result.length > 0 && (
+        <div className="text-sm text-gray-600">
+          <span className="font-medium">Topological Order:</span>{' '}
+          {currentState.result.join(' → ')}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/algo-compendium/_visualizers/GridVisualizer.tsx
+++ b/algo-compendium/_visualizers/GridVisualizer.tsx
@@ -1,0 +1,95 @@
+import { useAlgorithmPlayer } from '../_components/hooks/useAlgorithmPlayer';
+import { Controls } from '../_components/Controls';
+import { useI18n } from '../app/_i18n';
+import type {
+  GridState,
+  GridCommand,
+} from '../_algorithms/dynamic-programming/commands';
+import { gridReducer } from '../_algorithms/dynamic-programming/commands';
+
+type Props = {
+  commands: GridCommand[];
+  initialState: GridState;
+  reduce?: (state: GridState, cmd: GridCommand) => GridState;
+};
+
+export function GridVisualizer({ commands, initialState, reduce }: Props) {
+  const { t } = useI18n();
+  const player = useAlgorithmPlayer(
+    initialState,
+    commands,
+    reduce ?? gridReducer
+  );
+  const { currentState } = player;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="viz-surface p-3 overflow-auto max-h-64">
+        <table className="text-xs border-collapse">
+          {/* Column headers */}
+          <thead>
+            <tr>
+              <th className="w-8" />
+              {currentState.colLabels.map((label, c) => (
+                <th
+                  key={c}
+                  className="px-2 py-1 text-gray-500 dark:text-gray-300 font-normal text-center border border-gray-200 dark:border-gray-600 bg-gray-100 dark:bg-gray-700 min-w-8"
+                >
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {currentState.grid.map((row, r) => (
+              <tr key={r}>
+                <td className="px-2 py-1 text-gray-500 dark:text-gray-300 border border-gray-200 dark:border-gray-600 bg-gray-100 dark:bg-gray-700 text-center">
+                  {currentState.rowLabels[r]}
+                </td>
+                {row.map((cell, c) => {
+                  const isHighlighted =
+                    currentState.highlighted?.[0] === r &&
+                    currentState.highlighted?.[1] === c;
+                  const isTrace = currentState.tracePath.some(
+                    ([tr, tc]) => tr === r && tc === c
+                  );
+                  let bg = 'bg-white dark:bg-gray-800';
+                  if (isTrace) bg = 'bg-[var(--color-turquoise-light)]';
+                  else if (isHighlighted) bg = 'bg-yellow-200';
+                  else if (cell.computed) bg = 'bg-blue-50';
+                  return (
+                    <td
+                      key={c}
+                      className={`px-2 py-1 border border-gray-200 dark:border-gray-600 text-center font-mono dark:text-gray-200 ${bg} transition-colors`}
+                    >
+                      {cell.value !== null ? cell.value : '–'}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {currentState.result !== null && (
+        <div className="text-sm font-medium text-[var(--color-turquoise-dark)]">
+          {t('visualizer.grid.result_label')} {currentState.result}
+        </div>
+      )}
+      <Controls
+        index={player.index}
+        totalCommands={player.totalCommands}
+        isPlaying={player.isPlaying}
+        speed={player.speed}
+        description={currentState.description}
+        onPlay={player.play}
+        onPause={player.pause}
+        onStepBack={player.stepBack}
+        onStepForward={player.stepForward}
+        onReset={player.reset}
+        onSpeedChange={player.setSpeed}
+        onJumpTo={player.jumpTo}
+      />
+    </div>
+  );
+}

--- a/algo-compendium/_visualizers/MathVisualizer.tsx
+++ b/algo-compendium/_visualizers/MathVisualizer.tsx
@@ -1,0 +1,127 @@
+import { useAlgorithmPlayer } from '../_components/hooks/useAlgorithmPlayer';
+import { Controls } from '../_components/Controls';
+import type { MathState, MathCommand } from '../_algorithms/math/commands';
+import { mathReducer } from '../_algorithms/math/commands';
+import { useI18n } from '../app/_i18n';
+
+type Props = { commands: MathCommand[]; initialState: MathState };
+
+export function MathVisualizer({ commands, initialState }: Props) {
+  const { t } = useI18n();
+  const player = useAlgorithmPlayer(initialState, commands, mathReducer);
+  const { currentState } = player;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Sieve grid: when numbers.length > 0 */}
+      {currentState.numbers.length > 0 && (
+        <div className="viz-surface p-3">
+          <div className="flex flex-wrap gap-1">
+            {currentState.numbers.map((num, i) => {
+              let bg =
+                'bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600';
+              if (num < 2)
+                bg =
+                  'bg-gray-200 dark:bg-gray-700 border border-gray-300 dark:border-gray-600';
+              else if (currentState.highlighted === i)
+                bg = 'bg-yellow-300 border border-yellow-400';
+              else if (currentState.primes.includes(i))
+                bg =
+                  'bg-[var(--color-turquoise)] border-transparent text-white';
+              else if (currentState.composites.includes(i))
+                bg = 'bg-red-100 border border-red-200 text-gray-400';
+              return (
+                <div
+                  key={i}
+                  className={`w-10 h-10 flex items-center justify-center rounded text-sm font-mono font-medium ${bg}`}
+                >
+                  {num}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Step list: when steps.length > 0 */}
+      {currentState.steps.length > 0 && (
+        <div className="viz-surface p-3">
+          <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2">
+            {t('visualizer.math.steps_label')}
+          </div>
+          <div className="space-y-1">
+            {currentState.steps.map((step, i) => (
+              <div
+                key={i}
+                className="text-sm font-mono text-gray-700 dark:text-gray-300"
+              >
+                gcd({step.a}, {step.b}) — remainder: {step.remainder}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Sequence display: when sequence.length > 0 */}
+      {currentState.sequence.length > 0 && (
+        <div className="viz-surface p-3">
+          <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2">
+            {t('visualizer.math.sequence_label')}
+          </div>
+          <div className="flex gap-2 flex-wrap">
+            {currentState.sequence.map((val, i) => (
+              <div key={i} className="flex flex-col items-center">
+                <div className="w-10 h-10 flex items-center justify-center bg-[var(--color-turquoise-light)] rounded font-mono text-sm font-medium">
+                  {val}
+                </div>
+                <div className="text-xs text-gray-400 dark:text-gray-400 mt-0.5">
+                  F({i})
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Binary steps: when binarySteps.length > 0 */}
+      {currentState.binarySteps.length > 0 && (
+        <div className="viz-surface p-3">
+          <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2">
+            {t('visualizer.math.binary_steps_label')}
+          </div>
+          <div className="space-y-1">
+            {currentState.binarySteps.map((s, i) => (
+              <div
+                key={i}
+                className="text-sm font-mono text-gray-700 dark:text-gray-300"
+              >
+                bit={s.bit} current={s.current} result={s.result}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {currentState.result !== null && (
+        <div className="text-sm font-medium text-[var(--color-turquoise-dark)]">
+          {t('visualizer.math.result_label')} {currentState.result}
+        </div>
+      )}
+
+      <Controls
+        index={player.index}
+        totalCommands={player.totalCommands}
+        isPlaying={player.isPlaying}
+        speed={player.speed}
+        description={currentState.description}
+        onPlay={player.play}
+        onPause={player.pause}
+        onStepBack={player.stepBack}
+        onStepForward={player.stepForward}
+        onReset={player.reset}
+        onSpeedChange={player.setSpeed}
+        onJumpTo={player.jumpTo}
+      />
+    </div>
+  );
+}

--- a/algo-compendium/_visualizers/StringVisualizer.tsx
+++ b/algo-compendium/_visualizers/StringVisualizer.tsx
@@ -1,0 +1,117 @@
+import { useAlgorithmPlayer } from '../_components/hooks/useAlgorithmPlayer';
+import { Controls } from '../_components/Controls';
+import type {
+  StringState,
+  StringCommand,
+} from '../_algorithms/string-matching/commands';
+import { stringReducer } from '../_algorithms/string-matching/commands';
+import { useI18n } from '../app/_i18n';
+
+type Props = { commands: StringCommand[]; initialState: StringState };
+
+export function StringVisualizer({ commands, initialState }: Props) {
+  const { t } = useI18n();
+  const player = useAlgorithmPlayer(initialState, commands, stringReducer);
+  const { currentState } = player;
+
+  function getCharBg(i: number): string {
+    if (
+      currentState.foundAt.some(
+        (at) => i >= at && i < at + currentState.pattern.length
+      )
+    )
+      return 'bg-[var(--color-turquoise)] text-white';
+    if (currentState.matchedChars.includes(i)) return 'bg-green-300';
+    if (currentState.mismatchedChars.includes(i)) return 'bg-red-300';
+    if (currentState.currentTextIndex === i) return 'bg-yellow-300';
+    return 'bg-gray-100 dark:bg-gray-700';
+  }
+
+  function getPatternCharBg(j: number): string {
+    if (currentState.currentPatternIndex === j) return 'bg-yellow-300';
+    return 'bg-blue-100 dark:bg-blue-900';
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="viz-surface p-4 overflow-x-auto">
+        {/* Text row */}
+        <div className="mb-2">
+          <div className="text-xs text-gray-400 dark:text-gray-500 mb-1">
+            {t('visualizer.string.text_label')}
+          </div>
+          <div className="flex gap-1">
+            {currentState.text.split('').map((char, i) => (
+              <div
+                key={i}
+                className={`w-8 h-8 flex items-center justify-center rounded font-mono text-sm font-medium transition-colors ${getCharBg(i)}`}
+              >
+                {char}
+              </div>
+            ))}
+          </div>
+          <div className="flex gap-1 mt-0.5">
+            {currentState.text.split('').map((_, i) => (
+              <div
+                key={i}
+                className="w-8 text-center text-xs text-gray-400 dark:text-gray-500"
+              >
+                {i}
+              </div>
+            ))}
+          </div>
+        </div>
+        {/* Pattern row — offset by currentState.offset */}
+        <div>
+          <div className="text-xs text-gray-400 dark:text-gray-500 mb-1">
+            {t('visualizer.string.pattern_label')} {currentState.offset})
+          </div>
+          <div
+            className="flex gap-1"
+            style={{ marginLeft: currentState.offset * 36 }}
+          >
+            {currentState.pattern.split('').map((char, j) => (
+              <div
+                key={j}
+                className={`w-8 h-8 flex items-center justify-center rounded font-mono text-sm font-medium ${getPatternCharBg(j)}`}
+              >
+                {char}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+      {currentState.foundAt.length > 0 && (
+        <div className="text-sm text-[var(--color-turquoise-dark)] font-medium">
+          {t('visualizer.string.found_at')} {currentState.foundAt.join(', ')}
+        </div>
+      )}
+      {/* Show failure table if available (KMP) */}
+      {currentState.failureTable.length > 0 && (
+        <div className="text-xs text-gray-500 dark:text-gray-400">
+          Failure table: [{currentState.failureTable.join(', ')}]
+        </div>
+      )}
+      {currentState.textHash !== null && (
+        <div className="text-xs text-gray-500 dark:text-gray-400">
+          Text window hash: {currentState.textHash} | Pattern hash:{' '}
+          {currentState.patternHash}
+        </div>
+      )}
+      <Controls
+        index={player.index}
+        totalCommands={player.totalCommands}
+        isPlaying={player.isPlaying}
+        speed={player.speed}
+        description={currentState.description}
+        onPlay={player.play}
+        onPause={player.pause}
+        onStepBack={player.stepBack}
+        onStepForward={player.stepForward}
+        onReset={player.reset}
+        onSpeedChange={player.setSpeed}
+        onJumpTo={player.jumpTo}
+      />
+    </div>
+  );
+}

--- a/algo-compendium/_visualizers/TreeVisualizer.tsx
+++ b/algo-compendium/_visualizers/TreeVisualizer.tsx
@@ -1,0 +1,213 @@
+import { useAlgorithmPlayer } from '../_components/hooks/useAlgorithmPlayer';
+import { Controls } from '../_components/Controls';
+import { LegendRow } from '../_components/composed/LegendRow';
+import { TargetIndicator } from '../_components/composed/TargetIndicator';
+import type { TreeState, TreeCommand } from '../_algorithms/tree/commands';
+import { treeReducer } from '../_algorithms/tree/commands';
+import type { TreeNode } from '../_algorithms/tree/types';
+
+// Tree layout: assign x/y positions via in-order traversal
+type NodeLayout = { id: string; value: number; x: number; y: number };
+
+function layoutTree(root: TreeNode | null): NodeLayout[] {
+  const nodes: NodeLayout[] = [];
+  let xCounter = 0;
+
+  function traverse(node: TreeNode | null, depth: number) {
+    if (!node) return;
+    traverse(node.left, depth + 1);
+    const x = xCounter++;
+    nodes.push({ id: node.id, value: node.value, x, y: depth });
+    traverse(node.right, depth + 1);
+  }
+
+  traverse(root, 0);
+  return nodes;
+}
+
+type EdgeDef = { x1: number; y1: number; x2: number; y2: number };
+
+function buildEdgesFromTree(
+  node: TreeNode | null,
+  layout: NodeLayout[],
+  xSpacing: number,
+  ySpacing: number,
+  offsetX: number,
+  offsetY: number,
+  edges: EdgeDef[]
+) {
+  if (!node) return;
+  const parentLayout = layout.find((n) => n.id === node.id);
+  if (!parentLayout) return;
+  for (const child of [node.left, node.right].filter(Boolean) as TreeNode[]) {
+    const childLayout = layout.find((n) => n.id === child.id);
+    if (childLayout) {
+      edges.push({
+        x1: parentLayout.x * xSpacing + offsetX,
+        y1: parentLayout.y * ySpacing + offsetY,
+        x2: childLayout.x * xSpacing + offsetX,
+        y2: childLayout.y * ySpacing + offsetY,
+      });
+    }
+    buildEdgesFromTree(
+      child,
+      layout,
+      xSpacing,
+      ySpacing,
+      offsetX,
+      offsetY,
+      edges
+    );
+  }
+}
+
+type Props = {
+  commands: TreeCommand[];
+  initialState: TreeState;
+};
+
+export function TreeVisualizer({ commands, initialState }: Props) {
+  const player = useAlgorithmPlayer(initialState, commands, treeReducer);
+  const { currentState } = player;
+
+  const layout = layoutTree(currentState.tree);
+  const SVG_W = 500;
+  const SVG_H = 300;
+  const xSpacing =
+    layout.length > 0
+      ? Math.min(60, (SVG_W - 40) / Math.max(layout.length, 1))
+      : 60;
+  const ySpacing = 60;
+  const offsetX = 20 + xSpacing / 2;
+  const offsetY = 30;
+
+  const edges: EdgeDef[] = [];
+  buildEdgesFromTree(
+    currentState.tree,
+    layout,
+    xSpacing,
+    ySpacing,
+    offsetX,
+    offsetY,
+    edges
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      {currentState.targetValue !== undefined && (
+        <TargetIndicator
+          label="Target"
+          value={currentState.targetValue}
+          foundMessage={currentState.found ? 'Found!' : null}
+        />
+      )}
+
+      {/* SVG Tree */}
+      <div className="bg-gray-50 rounded-lg p-2 overflow-x-auto">
+        <svg
+          width={SVG_W}
+          height={SVG_H}
+          viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+          aria-label="Tree visualization"
+        >
+          {/* Edges */}
+          {edges.map((e, i) => (
+            <line
+              key={i}
+              x1={e.x1}
+              y1={e.y1}
+              x2={e.x2}
+              y2={e.y2}
+              stroke="#d1d5db"
+              strokeWidth={1.5}
+            />
+          ))}
+
+          {/* Nodes */}
+          {layout.map((node) => {
+            const cx = node.x * xSpacing + offsetX;
+            const cy = node.y * ySpacing + offsetY;
+            let fill = '#e5e7eb'; // gray-200
+            let stroke = '#9ca3af'; // gray-400
+            if (currentState.found === node.id) {
+              fill = '#22c55e';
+              stroke = '#16a34a';
+            } else if (currentState.current === node.id) {
+              fill = '#fbbf24';
+              stroke = '#f59e0b';
+            } else if (currentState.visited.includes(node.id)) {
+              fill = 'var(--color-turquoise)';
+              stroke = 'var(--color-turquoise-dark)';
+            }
+            return (
+              <g key={node.id}>
+                <circle
+                  cx={cx}
+                  cy={cy}
+                  r={18}
+                  fill={fill}
+                  stroke={stroke}
+                  strokeWidth={2}
+                />
+                <text
+                  x={cx}
+                  y={cy + 4}
+                  textAnchor="middle"
+                  fontSize={12}
+                  fill="#374151"
+                  fontWeight="600"
+                >
+                  {node.value}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+
+      <LegendRow
+        items={[
+          {
+            dotClass: 'bg-gray-200 border border-gray-400',
+            label: 'Unvisited',
+            shape: 'circle',
+          },
+          {
+            dotClass: 'bg-yellow-400 border border-yellow-500',
+            label: 'Current',
+            shape: 'circle',
+          },
+          {
+            dotStyle: {
+              background: 'var(--color-turquoise)',
+              borderColor: 'var(--color-turquoise-dark)',
+            },
+            dotClass: 'border',
+            label: 'Visited',
+            shape: 'circle',
+          },
+          {
+            dotClass: 'bg-green-500 border border-green-600',
+            label: 'Found',
+            shape: 'circle',
+          },
+        ]}
+      />
+
+      <Controls
+        index={player.index}
+        totalCommands={player.totalCommands}
+        isPlaying={player.isPlaying}
+        speed={player.speed}
+        description={currentState.description}
+        onPlay={player.play}
+        onPause={player.pause}
+        onStepBack={player.stepBack}
+        onStepForward={player.stepForward}
+        onReset={player.reset}
+        onSpeedChange={player.setSpeed}
+        onJumpTo={player.jumpTo}
+      />
+    </div>
+  );
+}

--- a/algo-compendium/app/AlgorithmDetail.tsx
+++ b/algo-compendium/app/AlgorithmDetail.tsx
@@ -1,0 +1,355 @@
+import { useState, useCallback } from 'react';
+import { useParams, useLocation, Link } from 'react-router-dom';
+import { useI18n, tOr } from './_i18n';
+import type { AlgorithmCategory } from '../_algorithms/_shared/types';
+import { getAlgorithm } from '../_algorithms/registry';
+import { AlgorithmIcon } from '../_components/AlgorithmIcon';
+import { MetadataPanel } from '../_components/MetadataPanel';
+import { CollapsibleSection } from '../_components/composed/CollapsibleSection';
+import { StaticSection } from '../_components/composed/StaticSection';
+import { ArrayVisualizer } from '../_visualizers/ArrayVisualizer';
+import { TreeVisualizer } from '../_visualizers/TreeVisualizer';
+import { GraphVisualizer } from '../_visualizers/GraphVisualizer';
+import { GridVisualizer } from '../_visualizers/GridVisualizer';
+import { StringVisualizer } from '../_visualizers/StringVisualizer';
+import { MathVisualizer } from '../_visualizers/MathVisualizer';
+import type { MathCommand, MathState } from '../_algorithms/math/commands';
+import type { SortCommand, SortState } from '../_algorithms/sorting/commands';
+import { makeSortState } from '../_algorithms/sorting/commands';
+import type {
+  SearchCommand,
+  SearchState,
+} from '../_algorithms/searching/commands';
+import { makeSearchState } from '../_algorithms/searching/commands';
+import type { TreeCommand, TreeState } from '../_algorithms/tree/commands';
+import type { GraphCommand, GraphState } from '../_algorithms/graph/commands';
+import type {
+  GridCommand,
+  GridState,
+} from '../_algorithms/dynamic-programming/commands';
+import type {
+  StringCommand,
+  StringState,
+} from '../_algorithms/string-matching/commands';
+
+export function AlgorithmDetail() {
+  const { t } = useI18n();
+  const { slug } = useParams<{ slug: string }>();
+  const location = useLocation();
+  const category = location.pathname.split('/').filter(Boolean)[0];
+  const [detailsOpen, setDetailsOpen] = useState(false);
+
+  if (!category || !slug) {
+    return <NotFoundMessage t={t} />;
+  }
+
+  const algo = getAlgorithm(category as AlgorithmCategory, slug);
+
+  if (!algo) {
+    return <NotFoundMessage t={t} />;
+  }
+
+  const algoName = tOr(t, `algorithms.${algo.slug}.name`, algo.name);
+  const algoDescription = tOr(
+    t,
+    `algorithms.${algo.slug}.description`,
+    algo.description
+  );
+  const categoryName = tOr(
+    t,
+    `categories.${algo.category}.name`,
+    algo.category
+  );
+
+  return (
+    <div className="page-container dark:text-gray-100">
+      {/* Header */}
+      <div className="flex items-start gap-4">
+        <span className="text-[var(--color-turquoise)] mt-1">
+          <AlgorithmIcon
+            category={algo.category}
+            slug={algo.slug}
+            className="[&_svg]:w-8 [&_svg]:h-8"
+          />
+        </span>
+        <div className="flex-1">
+          <div className="flex items-center gap-3 flex-wrap">
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+              {algoName}
+            </h1>
+            <Link
+              to={`/${algo.category}`}
+              className="px-2.5 py-0.5 rounded-full text-sm font-medium bg-[var(--color-turquoise-light)]/30 text-[var(--color-turquoise-dark)] hover:bg-[var(--color-turquoise-light)]/50 transition-colors"
+            >
+              {categoryName}
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <CollapsibleSection
+        title={t('detail.overview')}
+        icon={
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            className="icon-accent"
+          >
+            <path
+              d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        }
+        open={detailsOpen}
+        onToggle={() => setDetailsOpen((v) => !v)}
+        bodyClass="space-y-4"
+      >
+        <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed">
+          {algoDescription}
+        </p>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <p className="label-caps">{t('detail.complexity')}</p>
+            <MetadataPanel meta={algo} />
+          </div>
+          <div>
+            <p className="label-caps">{t('detail.pseudocode')}</p>
+            <pre className="text-sm font-mono text-gray-700 dark:text-gray-200 viz-surface p-4 whitespace-pre-wrap overflow-x-auto leading-relaxed">
+              {algo.pseudocode}
+            </pre>
+          </div>
+        </div>
+      </CollapsibleSection>
+
+      <StaticSection
+        title={t('detail.visualizer')}
+        icon={
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            className="icon-accent"
+          >
+            <path
+              d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        }
+      >
+        {algo.visualizerType === 'array' && algo.category === 'searching' ? (
+          <SearchArrayVisualizerWrapper algo={algo} />
+        ) : algo.visualizerType === 'array' ? (
+          <ArrayVisualizerWrapper algo={algo} />
+        ) : algo.visualizerType === 'tree' ? (
+          <TreeVisualizerWrapper algo={algo} />
+        ) : algo.visualizerType === 'graph' ? (
+          <GraphVisualizerWrapper algo={algo} />
+        ) : algo.visualizerType === 'grid' ? (
+          <GridVisualizerWrapper algo={algo} />
+        ) : algo.visualizerType === 'string' ? (
+          <StringVisualizerWrapper algo={algo} />
+        ) : algo.visualizerType === 'math' ? (
+          <MathVisualizerWrapper algo={algo} />
+        ) : (
+          <div className="flex flex-col items-center justify-center min-h-48 text-center gap-2">
+            <p className="text-gray-400 font-medium">
+              {t('visualizer.coming_soon')}
+            </p>
+          </div>
+        )}
+      </StaticSection>
+    </div>
+  );
+}
+
+// Wrapper component that manages commands/state for the ArrayVisualizer
+function ArrayVisualizerWrapper({
+  algo,
+}: {
+  algo: NonNullable<ReturnType<typeof getAlgorithm>>;
+}) {
+  const [commands, setCommands] = useState<SortCommand[]>(
+    () => algo.run(algo.defaultInput) as SortCommand[]
+  );
+  const [initialState, setInitialState] = useState<SortState>(
+    () => algo.defaultInput as SortState
+  );
+
+  const handleNewCommands = useCallback(
+    (newCommands: SortCommand[], newState: SortState) => {
+      setCommands(newCommands);
+      setInitialState(newState);
+    },
+    []
+  );
+
+  const generateCommands = useCallback(
+    (arr: number[]) => {
+      return algo.run(makeSortState(arr)) as SortCommand[];
+    },
+    [algo]
+  );
+
+  return (
+    <ArrayVisualizer
+      mode="sort"
+      commands={commands}
+      initialState={initialState}
+      onNewCommands={handleNewCommands}
+      generateCommands={generateCommands}
+    />
+  );
+}
+
+// Wrapper component that manages commands/state for the search ArrayVisualizer
+function SearchArrayVisualizerWrapper({
+  algo,
+}: {
+  algo: NonNullable<ReturnType<typeof getAlgorithm>>;
+}) {
+  const [commands, setCommands] = useState<SearchCommand[]>(
+    () => algo.run(algo.defaultInput) as SearchCommand[]
+  );
+  const [initialState, setInitialState] = useState<SearchState>(
+    () => algo.defaultInput as SearchState
+  );
+
+  const handleNewCommands = useCallback(
+    (newCommands: SearchCommand[], newState: SearchState) => {
+      setCommands(newCommands);
+      setInitialState(newState);
+    },
+    []
+  );
+
+  const generateCommands = useCallback(
+    (arr: number[], target: number) => {
+      return algo.run(makeSearchState(arr, target)) as SearchCommand[];
+    },
+    [algo]
+  );
+
+  return (
+    <ArrayVisualizer
+      mode="search"
+      commands={commands}
+      initialState={initialState}
+      onNewCommands={handleNewCommands}
+      generateCommands={generateCommands}
+    />
+  );
+}
+
+// Wrapper component for the TreeVisualizer
+function TreeVisualizerWrapper({
+  algo,
+}: {
+  algo: NonNullable<ReturnType<typeof getAlgorithm>>;
+}) {
+  const [commands] = useState<TreeCommand[]>(
+    () => algo.run(algo.defaultInput) as TreeCommand[]
+  );
+  const [initialState] = useState<TreeState>(
+    () => algo.defaultInput as TreeState
+  );
+
+  return <TreeVisualizer commands={commands} initialState={initialState} />;
+}
+
+// Wrapper component for the GraphVisualizer
+function GraphVisualizerWrapper({
+  algo,
+}: {
+  algo: NonNullable<ReturnType<typeof getAlgorithm>>;
+}) {
+  const [commands] = useState<GraphCommand[]>(
+    () => algo.run(algo.defaultInput) as GraphCommand[]
+  );
+  const [initialState] = useState<GraphState>(
+    () => algo.defaultInput as GraphState
+  );
+
+  return <GraphVisualizer commands={commands} initialState={initialState} />;
+}
+
+// Wrapper component for the GridVisualizer
+function GridVisualizerWrapper({
+  algo,
+}: {
+  algo: NonNullable<ReturnType<typeof getAlgorithm>>;
+}) {
+  const [commands] = useState<GridCommand[]>(
+    () => algo.run(algo.defaultInput) as GridCommand[]
+  );
+  const [initialState] = useState<GridState>(
+    () => algo.defaultInput as GridState
+  );
+
+  return (
+    <GridVisualizer
+      commands={commands}
+      initialState={initialState}
+      reduce={algo.reduce as (state: GridState, cmd: GridCommand) => GridState}
+    />
+  );
+}
+
+// Wrapper component for the StringVisualizer
+function StringVisualizerWrapper({
+  algo,
+}: {
+  algo: NonNullable<ReturnType<typeof getAlgorithm>>;
+}) {
+  const [commands] = useState<StringCommand[]>(
+    () => algo.run(algo.defaultInput) as StringCommand[]
+  );
+  const [initialState] = useState<StringState>(
+    () => algo.defaultInput as StringState
+  );
+
+  return <StringVisualizer commands={commands} initialState={initialState} />;
+}
+
+// Wrapper component for the MathVisualizer
+function MathVisualizerWrapper({
+  algo,
+}: {
+  algo: NonNullable<ReturnType<typeof getAlgorithm>>;
+}) {
+  const [commands] = useState<MathCommand[]>(
+    () => algo.run(algo.defaultInput) as MathCommand[]
+  );
+  const [initialState] = useState<MathState>(
+    () => algo.defaultInput as MathState
+  );
+
+  return <MathVisualizer commands={commands} initialState={initialState} />;
+}
+
+function NotFoundMessage({ t }: { t: (k: string) => string }) {
+  return (
+    <div className="flex flex-col items-center justify-center h-full py-20 text-center">
+      <h1 className="text-2xl font-bold text-gray-800 dark:text-gray-100 mb-3">
+        {t('detail.not_found')}
+      </h1>
+      <p className="text-gray-500 dark:text-gray-400 mb-6">
+        {t('detail.not_found_desc')}
+      </p>
+      <Link to="/" className="text-[var(--color-turquoise)] hover:underline">
+        {t('detail.back_home')}
+      </Link>
+    </div>
+  );
+}

--- a/algo-compendium/app/CategoryList.tsx
+++ b/algo-compendium/app/CategoryList.tsx
@@ -1,0 +1,59 @@
+import { Link } from 'react-router-dom';
+import type { AlgorithmCategory } from '../_algorithms/_shared/types';
+import { getAlgorithmsByCategory } from '../_algorithms/registry';
+import { AlgorithmIcon } from '../_components/AlgorithmIcon';
+import { useI18n, tOr } from './_i18n';
+
+export function CategoryList({ category }: { category: AlgorithmCategory }) {
+  const { t } = useI18n();
+  const algorithms = getAlgorithmsByCategory(category);
+
+  return (
+    <div className="page-container-narrow">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+          {t(`categories.${category}.name`)}
+        </h1>
+        <p className="text-gray-500 dark:text-gray-400">
+          {t(`categories.${category}.description`)}
+        </p>
+      </div>
+
+      {algorithms.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-20 text-center">
+          <p className="text-gray-400 dark:text-gray-500 text-lg">
+            {t('category_list.coming_soon')}
+          </p>
+          <p className="text-gray-300 dark:text-gray-600 text-sm mt-1">
+            {t('category_list.coming_soon_desc')}
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {algorithms.map((algo) => (
+            <Link
+              key={algo.slug}
+              to={`/${category}/${algo.slug}`}
+              className="card-link group"
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-[var(--color-turquoise)] group-hover:text-[var(--color-turquoise-dark)] transition-colors">
+                  <AlgorithmIcon category={algo.category} slug={algo.slug} />
+                </span>
+                <h2 className="font-semibold text-gray-800 dark:text-gray-100 group-hover:text-[var(--color-turquoise)] transition-colors">
+                  {tOr(t, `algorithms.${algo.slug}.name`, algo.name)}
+                </h2>
+              </div>
+              <p className="font-mono text-sm text-gray-400 dark:text-gray-500 flex items-baseline gap-1.5">
+                <span className="label-caps-inline">
+                  {t('category_list.avg_label')}
+                </span>
+                {algo.averageCase}
+              </p>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/algo-compendium/app/Home.tsx
+++ b/algo-compendium/app/Home.tsx
@@ -1,0 +1,59 @@
+import { Link } from 'react-router-dom';
+import { CategoryIcon } from '../_components/CategoryIcon';
+import type { AlgorithmCategory } from '../_algorithms/_shared/types';
+import { getAlgorithmsByCategory } from '../_algorithms/registry';
+import { useI18n } from './_i18n';
+
+const CATEGORY_SLUGS: AlgorithmCategory[] = [
+  'sorting',
+  'searching',
+  'graph',
+  'tree',
+  'dynamic-programming',
+  'string-matching',
+  'backtracking',
+  'math',
+];
+
+export function Home() {
+  const { t } = useI18n();
+
+  return (
+    <div className="page-container">
+      <div className="text-center">
+        <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-3">
+          {t('site.title')}
+        </h1>
+        <p className="text-lg text-gray-500 dark:text-gray-400">
+          {t('site.subtitle')}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        {CATEGORY_SLUGS.map((slug) => {
+          const count = getAlgorithmsByCategory(slug).length;
+          return (
+            <Link key={slug} to={`/${slug}`} className="card-link group">
+              <div className="flex items-center justify-between">
+                <span className="text-[var(--color-turquoise)] group-hover:text-[var(--color-turquoise-dark)] transition-colors">
+                  <CategoryIcon category={slug} />
+                </span>
+                <span className="text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-300 px-2 py-0.5 rounded-full">
+                  {count}
+                </span>
+              </div>
+              <div>
+                <h2 className="font-semibold text-gray-800 dark:text-gray-100 group-hover:text-[var(--color-turquoise)] transition-colors">
+                  {t(`categories.${slug}.name`)}
+                </h2>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 leading-snug">
+                  {t(`categories.${slug}.description`)}
+                </p>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/algo-compendium/app/Layout.tsx
+++ b/algo-compendium/app/Layout.tsx
@@ -1,0 +1,230 @@
+import { useState, useEffect } from 'react';
+import { Outlet, NavLink, Link, useLocation } from 'react-router-dom';
+import { CategoryIcon } from '../_components/CategoryIcon';
+import type { AlgorithmCategory } from '../_algorithms/_shared/types';
+import { useI18n, useTheme, type Language } from './_i18n';
+
+const SIDEBAR_KEY = 'algo-sidebar-collapsed';
+
+type NavCategory = {
+  slug: AlgorithmCategory;
+  nameKey: string;
+};
+
+const NAV_CATEGORIES: NavCategory[] = [
+  { slug: 'sorting', nameKey: 'categories.sorting.name' },
+  { slug: 'searching', nameKey: 'categories.searching.name' },
+  { slug: 'graph', nameKey: 'categories.graph.name' },
+  { slug: 'tree', nameKey: 'categories.tree.name' },
+  {
+    slug: 'dynamic-programming',
+    nameKey: 'categories.dynamic-programming.name',
+  },
+  { slug: 'string-matching', nameKey: 'categories.string-matching.name' },
+  { slug: 'backtracking', nameKey: 'categories.backtracking.name' },
+  { slug: 'math', nameKey: 'categories.math.name' },
+];
+
+const LANGUAGES: { value: Language; flag: string }[] = [
+  { value: 'en', flag: '🇬🇧' },
+  { value: 'id', flag: '🇮🇩' },
+];
+
+export function Layout() {
+  const { t, language, setLanguage } = useI18n();
+  const { theme, toggleTheme } = useTheme();
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(SIDEBAR_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
+
+  const location = useLocation();
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(SIDEBAR_KEY, String(collapsed));
+    } catch {
+      // ignore
+    }
+  }, [collapsed]);
+
+  return (
+    <div className="flex h-screen overflow-hidden bg-gray-50 dark:bg-gray-900">
+      {/* Sidebar */}
+      <aside
+        className={`flex flex-col bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 shadow-sm transition-all duration-200 flex-shrink-0 ${
+          collapsed ? 'w-14' : 'w-64'
+        }`}
+      >
+        {/* Title — links to home */}
+        <Link
+          to="/"
+          className="flex items-center gap-2 px-3 py-4 min-h-14 border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700 transition-colors"
+          title={t('nav.home_tooltip')}
+        >
+          <span className="flex-shrink-0 text-[var(--color-turquoise)]">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              className="w-6 h-6"
+            >
+              <path
+                d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </span>
+          {!collapsed && (
+            <span className="text-sm font-semibold text-gray-800 dark:text-gray-100 truncate leading-tight">
+              {t('site.title')}
+            </span>
+          )}
+        </Link>
+
+        {/* Navigation */}
+        <nav className="flex-1 overflow-y-auto py-2">
+          {NAV_CATEGORIES.map((cat) => {
+            const isActive =
+              location.pathname === `/${cat.slug}` ||
+              location.pathname.startsWith(`/${cat.slug}/`);
+
+            return (
+              <div key={cat.slug} className="relative group">
+                <NavLink
+                  to={`/${cat.slug}`}
+                  className={({ isActive: navActive }) =>
+                    navActive || isActive
+                      ? 'nav-link-active'
+                      : 'nav-link-inactive'
+                  }
+                >
+                  <span className="flex-shrink-0">
+                    <CategoryIcon category={cat.slug} />
+                  </span>
+                  {!collapsed && (
+                    <span className="truncate">{t(cat.nameKey)}</span>
+                  )}
+                </NavLink>
+
+                {/* Collapsed tooltip */}
+                {collapsed && (
+                  <div className="absolute left-full top-1/2 -translate-y-1/2 ml-2 px-2 py-1 bg-gray-800 text-white text-xs rounded whitespace-nowrap pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity z-50">
+                    {t(cat.nameKey)}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </nav>
+
+        {/* Footer: language selector + theme + collapse */}
+        <div className="border-t border-gray-100 dark:border-gray-700 p-2 space-y-1">
+          {/* Language buttons */}
+          <div
+            className={`flex items-center gap-1 px-1 ${collapsed ? 'justify-center' : ''}`}
+          >
+            {LANGUAGES.map(({ value, flag }) => (
+              <button
+                key={value}
+                onClick={() => setLanguage(value)}
+                title={t(`language.${value}`)}
+                className={`flex items-center gap-1 px-2 py-1 rounded text-xs font-medium transition-colors ${
+                  language === value
+                    ? 'bg-[var(--color-turquoise)] text-white'
+                    : 'btn-sidebar-action px-2 py-1 w-auto'
+                }`}
+              >
+                <span>{flag}</span>
+                {!collapsed && <span>{value.toUpperCase()}</span>}
+              </button>
+            ))}
+          </div>
+
+          {/* Theme toggle */}
+          <button
+            onClick={toggleTheme}
+            className="btn-sidebar-action"
+            aria-label={
+              theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
+            }
+          >
+            {theme === 'dark' ? (
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                className="w-4 h-4"
+              >
+                <circle
+                  cx={12}
+                  cy={12}
+                  r={5}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            ) : (
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                className="w-4 h-4"
+              >
+                <path
+                  d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            )}
+            {!collapsed && (
+              <span className="text-xs">
+                {theme === 'dark' ? 'Light' : 'Dark'}
+              </span>
+            )}
+          </button>
+
+          {/* Collapse toggle */}
+          <button
+            onClick={() => setCollapsed((v) => !v)}
+            className="btn-sidebar-action"
+            aria-label={collapsed ? t('nav.expand') : t('nav.collapse')}
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              className={`w-4 h-4 transition-transform ${collapsed ? 'rotate-180' : ''}`}
+            >
+              <path
+                d="M15 18l-6-6 6-6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            {!collapsed && <span className="text-xs">{t('nav.collapse')}</span>}
+          </button>
+        </div>
+      </aside>
+
+      {/* Main content */}
+      <main className="flex-1 overflow-y-auto dark:bg-gray-900">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/algo-compendium/app/NotFound.tsx
+++ b/algo-compendium/app/NotFound.tsx
@@ -1,0 +1,13 @@
+import { Link } from 'react-router-dom';
+
+export function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full py-20 text-center">
+      <h1 className="text-4xl font-bold text-gray-800 mb-4">404</h1>
+      <p className="text-gray-500 mb-6">Page not found.</p>
+      <Link to="/" className="text-[var(--color-turquoise)] hover:underline">
+        ← Back to home
+      </Link>
+    </div>
+  );
+}

--- a/algo-compendium/app/_i18n/en.json
+++ b/algo-compendium/app/_i18n/en.json
@@ -1,0 +1,376 @@
+{
+  "site": {
+    "title": "Algorithm Compendium",
+    "subtitle": "Interactive visualizations and explanations for classic algorithms"
+  },
+  "nav": {
+    "collapse": "Collapse",
+    "expand": "Expand sidebar",
+    "home_tooltip": "Go to home"
+  },
+  "language": {
+    "label": "Language",
+    "en": "English",
+    "id": "Indonesian"
+  },
+  "home": {
+    "algorithms": "algorithms"
+  },
+  "categories": {
+    "sorting": {
+      "name": "Sorting",
+      "description": "Algorithms that order elements by comparison or counting methods."
+    },
+    "searching": {
+      "name": "Searching",
+      "description": "Algorithms that locate elements within data structures."
+    },
+    "graph": {
+      "name": "Graph",
+      "description": "Algorithms that traverse and find paths in networks."
+    },
+    "tree": {
+      "name": "Tree",
+      "description": "Algorithms that traverse and manipulate tree structures."
+    },
+    "dynamic-programming": {
+      "name": "Dynamic Programming",
+      "description": "Algorithms that solve overlapping subproblems optimally."
+    },
+    "string-matching": {
+      "name": "String Matching",
+      "description": "Algorithms that find patterns within text efficiently."
+    },
+    "backtracking": {
+      "name": "Backtracking",
+      "description": "Algorithms that explore solution spaces systematically."
+    },
+    "math": {
+      "name": "Mathematics",
+      "description": "Classic mathematical algorithms and number theory."
+    }
+  },
+  "category_list": {
+    "coming_soon": "Coming soon",
+    "coming_soon_desc": "Algorithms for this category are being added.",
+    "avg_label": "Avg"
+  },
+  "detail": {
+    "overview": "Overview",
+    "complexity": "Complexity",
+    "pseudocode": "Pseudocode",
+    "visualizer": "Visualizer",
+    "not_found": "Algorithm not found",
+    "not_found_desc": "This algorithm doesn't exist or hasn't been added yet.",
+    "back_home": "← Back to home"
+  },
+  "complexity": {
+    "best": "Best",
+    "average": "Average",
+    "worst": "Worst",
+    "space": "Space",
+    "stable": "Stable",
+    "unstable": "Unstable",
+    "in_place": "In-place",
+    "extra_space": "Extra space"
+  },
+  "controls": {
+    "play": "Play",
+    "pause": "Pause",
+    "step_back": "Step back",
+    "step_forward": "Step forward",
+    "reset": "Reset",
+    "speed": "Speed",
+    "steps": "Steps",
+    "randomize": "Randomize",
+    "apply": "Apply"
+  },
+  "visualizer": {
+    "sort_legend": {
+      "unsorted": "Unsorted",
+      "comparing": "Comparing",
+      "swapping": "Swapping",
+      "pivot": "Pivot",
+      "sorted": "Sorted"
+    },
+    "search_legend": {
+      "unsearched": "Unsearched",
+      "current": "Current",
+      "midpoint": "Midpoint",
+      "bounds": "Bounds",
+      "eliminated": "Eliminated",
+      "found": "Found",
+      "target": "Target",
+      "found_at_index": "Found at index"
+    },
+    "string": {
+      "text_label": "Text",
+      "pattern_label": "Pattern (offset:",
+      "found_at": "Found at positions:"
+    },
+    "math": {
+      "steps_label": "Steps",
+      "sequence_label": "Sequence",
+      "binary_steps_label": "Binary Exponentiation Steps",
+      "result_label": "Result:"
+    },
+    "grid": {
+      "result_label": "Result:"
+    },
+    "coming_soon": "Visualizer coming soon"
+  },
+  "algorithms": {
+    "bubble-sort": {
+      "name": "Bubble Sort",
+      "description": "Repeatedly steps through the list, compares adjacent elements, and swaps them if they are in the wrong order. The pass through the list is repeated until no swaps are needed."
+    },
+    "selection-sort": {
+      "name": "Selection Sort",
+      "description": "Divides the list into a sorted and unsorted portion. On each pass, finds the minimum element from the unsorted portion and places it at the end of the sorted portion."
+    },
+    "insertion-sort": {
+      "name": "Insertion Sort",
+      "description": "Builds the sorted array one element at a time by picking each element and inserting it into its correct position in the already-sorted portion."
+    },
+    "shell-sort": {
+      "name": "Shell Sort",
+      "description": "An extension of insertion sort that allows the exchange of far-apart elements. Uses a decreasing sequence of gaps to progressively reduce the disorder before a final insertion sort pass."
+    },
+    "cocktail-shaker-sort": {
+      "name": "Cocktail Shaker Sort",
+      "description": "A bidirectional variant of bubble sort that traverses the list in both directions alternately. This helps move small elements at the end of the list to the front more quickly."
+    },
+    "merge-sort": {
+      "name": "Merge Sort",
+      "description": "A divide-and-conquer algorithm that divides the array into halves, recursively sorts each half, and then merges the sorted halves. Guarantees O(n log n) in all cases."
+    },
+    "quick-sort": {
+      "name": "Quick Sort",
+      "description": "A divide-and-conquer algorithm that selects a pivot element and partitions the array around it, recursively sorting the sub-arrays. Very efficient in practice with O(n log n) average case."
+    },
+    "heap-sort": {
+      "name": "Heap Sort",
+      "description": "Builds a max-heap from the array, then repeatedly extracts the maximum element and places it at the end of the sorted portion. Achieves O(n log n) in all cases with O(1) space."
+    },
+    "counting-sort": {
+      "name": "Counting Sort",
+      "description": "A non-comparison integer sorting algorithm that counts the occurrences of each value and uses those counts to place elements directly in their final positions. Efficient for small integer ranges."
+    },
+    "radix-sort": {
+      "name": "Radix Sort",
+      "description": "A non-comparison integer sorting algorithm that sorts elements digit by digit from the least significant digit (LSD) to the most significant digit (MSD) using counting sort as a stable subroutine."
+    },
+    "linear-search": {
+      "name": "Linear Search",
+      "description": "Sequentially checks each element of the list until a match is found or the whole list has been searched. Works on both sorted and unsorted arrays."
+    },
+    "binary-search": {
+      "name": "Binary Search",
+      "description": "Efficiently searches a sorted array by repeatedly dividing the search interval in half. If the target is less than the midpoint, search the left half; otherwise search the right half."
+    },
+    "jump-search": {
+      "name": "Jump Search",
+      "description": "Works on sorted arrays by jumping ahead by fixed steps of √n, then performing a linear search backwards in the identified block. Faster than linear search for large sorted arrays."
+    },
+    "interpolation-search": {
+      "name": "Interpolation Search",
+      "description": "An improved variant of binary search for uniformly distributed sorted arrays. Uses interpolation to estimate the position of the target, potentially finding it faster than binary search."
+    },
+    "exponential-search": {
+      "name": "Exponential Search",
+      "description": "Finds the range where the target may exist by exponentially doubling the bound, then performs binary search within that range. Useful for unbounded or infinite sorted arrays."
+    },
+    "ternary-search": {
+      "name": "Ternary Search",
+      "description": "Divides the sorted array into three parts by computing two midpoints, then eliminates two-thirds of the search space each iteration. Similar to binary search but with three partitions."
+    },
+    "bfs": {
+      "name": "Breadth-First Search",
+      "description": "Explores a graph level by level from the start node, visiting all neighbors before moving deeper. Finds shortest path in unweighted graphs."
+    },
+    "dfs": {
+      "name": "Depth-First Search",
+      "description": "Explores as far as possible along each branch before backtracking. Useful for topological sorting, cycle detection, and finding connected components."
+    },
+    "dijkstra": {
+      "name": "Dijkstra's Algorithm",
+      "description": "Finds the shortest path from a source node to all other nodes in a weighted graph with non-negative edge weights. Uses a greedy approach with a priority queue."
+    },
+    "bellman-ford": {
+      "name": "Bellman-Ford",
+      "description": "Finds shortest paths from a source to all vertices, handling negative edge weights. Detects negative cycles. Slower than Dijkstra but more versatile."
+    },
+    "floyd-warshall": {
+      "name": "Floyd-Warshall",
+      "description": "Computes shortest paths between all pairs of vertices. Works with negative edge weights (but not negative cycles). Time complexity O(V³)."
+    },
+    "kruskal": {
+      "name": "Kruskal's Algorithm",
+      "description": "Builds a Minimum Spanning Tree by sorting all edges and greedily adding the smallest edge that does not create a cycle, using Union-Find for cycle detection."
+    },
+    "prim": {
+      "name": "Prim's Algorithm",
+      "description": "Builds a Minimum Spanning Tree by starting from one node and greedily growing the MST one edge at a time, always picking the minimum-weight edge that connects a new vertex."
+    },
+    "topological-sort": {
+      "name": "Topological Sort",
+      "description": "Orders vertices in a Directed Acyclic Graph (DAG) such that for every directed edge u → v, u appears before v. Uses DFS with a post-order stack."
+    },
+    "inorder-traversal": {
+      "name": "In-order Traversal",
+      "description": "Visits nodes in Left → Root → Right order, producing sorted output for a BST."
+    },
+    "preorder-traversal": {
+      "name": "Pre-order Traversal",
+      "description": "Visits nodes in Root → Left → Right order. Useful for creating a copy of the tree or prefix expression evaluation."
+    },
+    "postorder-traversal": {
+      "name": "Post-order Traversal",
+      "description": "Visits nodes in Left → Right → Root order. Useful for deleting a tree or evaluating postfix expressions."
+    },
+    "level-order-traversal": {
+      "name": "Level-order Traversal",
+      "description": "Visits nodes level by level using a queue (BFS). Explores all nodes at depth d before nodes at depth d+1."
+    },
+    "bst-insert": {
+      "name": "BST Insert",
+      "description": "Inserts a new value into a Binary Search Tree by comparing at each node to find the correct position."
+    },
+    "bst-search": {
+      "name": "BST Search",
+      "description": "Searches for a value in a Binary Search Tree by comparing at each node and moving left or right accordingly."
+    },
+    "bst-delete": {
+      "name": "BST Delete",
+      "description": "Deletes a value from a Binary Search Tree, handling three cases: leaf node, one child, and two children (in-order successor)."
+    },
+    "fibonacci": {
+      "name": "Fibonacci",
+      "description": "Computes the nth Fibonacci number using bottom-up dynamic programming, storing all values in a 1D table to avoid redundant computation."
+    },
+    "lcs": {
+      "name": "Longest Common Subsequence",
+      "description": "Finds the longest subsequence common to two strings. Uses a 2D DP table where dp[i][j] is the LCS length of the first i characters of s1 and first j characters of s2."
+    },
+    "knapsack": {
+      "name": "0/1 Knapsack",
+      "description": "Given items with weights and values, find the maximum total value that fits in a knapsack of capacity W. Each item can be taken at most once."
+    },
+    "coin-change": {
+      "name": "Coin Change",
+      "description": "Finds the minimum number of coins needed to make up a given amount. Uses a 1D DP array where dp[i] is the minimum coins required for amount i."
+    },
+    "lis": {
+      "name": "Longest Increasing Subsequence",
+      "description": "Finds the length of the longest strictly increasing subsequence in an array. Uses O(n²) DP where dp[i] is the LIS length ending at index i."
+    },
+    "edit-distance": {
+      "name": "Edit Distance",
+      "description": "Computes the minimum number of single-character edits (insertions, deletions, substitutions) required to transform one string into another."
+    },
+    "naive-search": {
+      "name": "Naive String Search",
+      "description": "The simplest string matching algorithm that checks for the pattern at each position in the text by comparing characters one by one. Simple but inefficient for large inputs."
+    },
+    "kmp-search": {
+      "name": "KMP Search",
+      "description": "Knuth-Morris-Pratt algorithm preprocesses the pattern to build a failure function that allows skipping redundant comparisons. Achieves linear time complexity by never re-examining characters."
+    },
+    "rabin-karp-search": {
+      "name": "Rabin-Karp Search",
+      "description": "Uses rolling hash to efficiently scan the text. Computes a hash for each window of the text and compares it against the pattern hash. Only performs character-by-character verification on hash matches."
+    },
+    "boyer-moore-search": {
+      "name": "Boyer-Moore Search",
+      "description": "Compares the pattern right-to-left and uses the bad character heuristic to skip large portions of the text. Often the fastest practical string matching algorithm for large alphabets."
+    },
+    "n-queens": {
+      "name": "N-Queens",
+      "description": "Place N queens on an N×N chessboard so that no two queens attack each other (no shared row, column, or diagonal). Uses backtracking to find the first valid arrangement."
+    },
+    "sudoku-solver": {
+      "name": "Sudoku Solver",
+      "description": "Solve a 4×4 Sudoku puzzle using backtracking. Each row, column, and 2×2 box must contain each digit from 1 to 4 exactly once."
+    },
+    "permutations": {
+      "name": "Permutations",
+      "description": "Generate all permutations of [1, 2, 3] using backtracking with in-place swapping. Each row in the grid shows one permutation."
+    },
+    "subsets": {
+      "name": "Subsets",
+      "description": "Generate all subsets (power set) of [1, 2, 3] using backtracking. Each row shows one subset, with included elements filled in."
+    },
+    "sieve-of-eratosthenes": {
+      "name": "Sieve of Eratosthenes",
+      "description": "Efficiently finds all prime numbers up to N by iteratively marking multiples of each prime as composite."
+    },
+    "euclidean-gcd": {
+      "name": "Euclidean GCD",
+      "description": "Computes the Greatest Common Divisor of two numbers using repeated division. Each step reduces the problem until the remainder is zero."
+    },
+    "fast-power": {
+      "name": "Fast Power (Binary Exponentiation)",
+      "description": "Computes base^exp in O(log exp) time by squaring the base at each step and multiplying into the result only when the corresponding bit of the exponent is set."
+    },
+    "prime-factorization": {
+      "name": "Prime Factorization",
+      "description": "Decomposes a number into its prime factors by trial division up to the square root of n."
+    },
+    "fibonacci-variants": {
+      "name": "Fibonacci Variants",
+      "description": "Demonstrates iterative Fibonacci computation with memoization. Each value is computed from the two preceding values, building the sequence step by step."
+    },
+    "comb-sort": {
+      "name": "Comb Sort",
+      "description": "An improvement over bubble sort that eliminates turtles (small values near the end of the list) by using a gap larger than 1. The gap shrinks by a factor of 1.3 each pass until it reaches 1."
+    },
+    "tim-sort": {
+      "name": "Tim Sort",
+      "description": "A hybrid stable sorting algorithm derived from merge sort and insertion sort. Used as the default sort in Python and Java. Divides data into small runs sorted by insertion sort, then merges them."
+    },
+    "pancake-sort": {
+      "name": "Pancake Sort",
+      "description": "Sorts by performing a series of 'pancake flips': reversing a prefix of the array. The only operation allowed is flipping the first k elements. Named after the pancake sorting problem."
+    },
+    "fibonacci-search": {
+      "name": "Fibonacci Search",
+      "description": "Searches a sorted array using Fibonacci numbers to divide the search space. Creates an offset using Fibonacci sequence values, eliminating roughly 1/3 of the remaining elements each step."
+    },
+    "tarjan-scc": {
+      "name": "Tarjan's SCC",
+      "description": "Finds all Strongly Connected Components in a directed graph using a single DFS pass. Uses a stack and low-link values to identify SCCs. Named after Robert Tarjan."
+    },
+    "a-star": {
+      "name": "A* Search",
+      "description": "Heuristic-guided shortest path algorithm that combines Dijkstra's guaranteed shortest path with a heuristic estimate of the remaining distance. Uses f(n) = g(n) + h(n) to prioritize exploration."
+    },
+    "avl-insert": {
+      "name": "AVL Tree Insert",
+      "description": "Inserts a value into an AVL tree (self-balancing BST). After insertion, checks balance factors and performs LL, RR, LR, or RL rotations to maintain the height-balance property."
+    },
+    "kadane": {
+      "name": "Kadane's Algorithm",
+      "description": "Finds the maximum sum contiguous subarray in O(n) time. Tracks the maximum sum ending at the current position and the global maximum seen so far."
+    },
+    "matrix-chain": {
+      "name": "Matrix Chain Multiplication",
+      "description": "Finds the optimal parenthesization to minimize the number of scalar multiplications when multiplying a chain of matrices. Uses a 2D DP table where dp[i][j] is the minimum cost for matrices i through j."
+    },
+    "z-algorithm": {
+      "name": "Z-Algorithm",
+      "description": "Computes the Z-array where Z[i] is the length of the longest substring starting at position i that is also a prefix of the string. Used for linear-time pattern matching by searching in the concatenated string P+$+T."
+    },
+    "knights-tour": {
+      "name": "Knight's Tour",
+      "description": "Finds a sequence of moves where a chess knight visits every square on the board exactly once. Uses backtracking with Warnsdorff's heuristic: always move to the square with the fewest onward moves."
+    },
+    "extended-gcd": {
+      "name": "Extended Euclidean GCD",
+      "description": "Extends the Euclidean algorithm to find integers x and y such that ax + by = gcd(a, b). Essential in modular arithmetic, cryptography (RSA), and solving linear Diophantine equations."
+    },
+    "miller-rabin": {
+      "name": "Miller-Rabin Primality Test",
+      "description": "A probabilistic primality test that determines whether a number is composite or probably prime. Tests multiple witness values (2, 3, 5, 7) — if all pass, the number is almost certainly prime."
+    }
+  }
+}

--- a/algo-compendium/app/_i18n/id.json
+++ b/algo-compendium/app/_i18n/id.json
@@ -1,0 +1,376 @@
+{
+  "site": {
+    "title": "Kumpulan Algoritma",
+    "subtitle": "Visualisasi interaktif dan penjelasan untuk algoritma klasik"
+  },
+  "nav": {
+    "collapse": "Ciutkan",
+    "expand": "Perluas bilah sisi",
+    "home_tooltip": "Ke beranda"
+  },
+  "language": {
+    "label": "Bahasa",
+    "en": "Inggris",
+    "id": "Indonesia"
+  },
+  "home": {
+    "algorithms": "algoritma"
+  },
+  "categories": {
+    "sorting": {
+      "name": "Pengurutan",
+      "description": "Algoritma yang mengurutkan elemen menggunakan perbandingan atau metode penghitungan."
+    },
+    "searching": {
+      "name": "Pencarian",
+      "description": "Algoritma yang menemukan elemen di dalam struktur data."
+    },
+    "graph": {
+      "name": "Graf",
+      "description": "Algoritma yang menelusuri dan menemukan jalur dalam jaringan."
+    },
+    "tree": {
+      "name": "Pohon",
+      "description": "Algoritma yang menelusuri dan memanipulasi struktur pohon."
+    },
+    "dynamic-programming": {
+      "name": "Pemrograman Dinamis",
+      "description": "Algoritma yang memecahkan submasalah yang tumpang tindih secara optimal."
+    },
+    "string-matching": {
+      "name": "Pencocokan String",
+      "description": "Algoritma yang menemukan pola dalam teks secara efisien."
+    },
+    "backtracking": {
+      "name": "Runut Balik",
+      "description": "Algoritma yang mengeksplorasi ruang solusi secara sistematis."
+    },
+    "math": {
+      "name": "Matematika",
+      "description": "Algoritma matematika klasik dan teori bilangan."
+    }
+  },
+  "category_list": {
+    "coming_soon": "Segera hadir",
+    "coming_soon_desc": "Algoritma untuk kategori ini sedang ditambahkan.",
+    "avg_label": "Rata-rata"
+  },
+  "detail": {
+    "overview": "Ikhtisar",
+    "complexity": "Kompleksitas",
+    "pseudocode": "Kode Semu",
+    "visualizer": "Visualisasi",
+    "not_found": "Algoritma tidak ditemukan",
+    "not_found_desc": "Algoritma ini tidak ada atau belum ditambahkan.",
+    "back_home": "← Kembali ke beranda"
+  },
+  "complexity": {
+    "best": "Terbaik",
+    "average": "Rata-rata",
+    "worst": "Terburuk",
+    "space": "Ruang",
+    "stable": "Stabil",
+    "unstable": "Tidak Stabil",
+    "in_place": "Di Tempat",
+    "extra_space": "Ruang Tambahan"
+  },
+  "controls": {
+    "play": "Putar",
+    "pause": "Jeda",
+    "step_back": "Langkah mundur",
+    "step_forward": "Langkah maju",
+    "reset": "Ulang",
+    "speed": "Kecepatan",
+    "steps": "Langkah",
+    "randomize": "Acak",
+    "apply": "Terapkan"
+  },
+  "visualizer": {
+    "sort_legend": {
+      "unsorted": "Belum Terurut",
+      "comparing": "Membandingkan",
+      "swapping": "Menukar",
+      "pivot": "Pivot",
+      "sorted": "Terurut"
+    },
+    "search_legend": {
+      "unsearched": "Belum Dicari",
+      "current": "Saat Ini",
+      "midpoint": "Titik Tengah",
+      "bounds": "Batas",
+      "eliminated": "Dieliminasi",
+      "found": "Ditemukan",
+      "target": "Target",
+      "found_at_index": "Ditemukan di indeks"
+    },
+    "string": {
+      "text_label": "Teks",
+      "pattern_label": "Pola (offset:",
+      "found_at": "Ditemukan di posisi:"
+    },
+    "math": {
+      "steps_label": "Langkah",
+      "sequence_label": "Urutan",
+      "binary_steps_label": "Langkah Eksponensiasi Biner",
+      "result_label": "Hasil:"
+    },
+    "grid": {
+      "result_label": "Hasil:"
+    },
+    "coming_soon": "Visualisasi segera hadir"
+  },
+  "algorithms": {
+    "bubble-sort": {
+      "name": "Pengurutan Gelembung",
+      "description": "Berulang kali melewati daftar, membandingkan elemen berdekatan, dan menukarnya jika urutannya salah. Proses diulang hingga tidak ada pertukaran yang diperlukan."
+    },
+    "selection-sort": {
+      "name": "Pengurutan Seleksi",
+      "description": "Membagi daftar menjadi bagian terurut dan belum terurut. Pada setiap langkah, mencari elemen minimum dari bagian belum terurut dan menempatkannya di akhir bagian terurut."
+    },
+    "insertion-sort": {
+      "name": "Pengurutan Penyisipan",
+      "description": "Membangun larik terurut satu elemen sekaligus dengan mengambil setiap elemen dan menyisipkannya ke posisi yang benar dalam bagian yang sudah terurut."
+    },
+    "shell-sort": {
+      "name": "Pengurutan Shell",
+      "description": "Perluasan dari pengurutan penyisipan yang memungkinkan pertukaran elemen yang berjauhan. Menggunakan urutan celah yang semakin berkurang sebelum pass penyisipan terakhir."
+    },
+    "cocktail-shaker-sort": {
+      "name": "Pengurutan Koktail",
+      "description": "Varian dua arah dari pengurutan gelembung yang menelusuri daftar secara bergantian dari dua arah. Membantu memindahkan elemen kecil di akhir daftar ke depan lebih cepat."
+    },
+    "merge-sort": {
+      "name": "Pengurutan Gabung",
+      "description": "Algoritma bagi-dan-taklukkan yang membagi larik menjadi dua, mengurutkan setiap setengah secara rekursif, lalu menggabungkan hasilnya. Menjamin O(n log n) di semua kasus."
+    },
+    "quick-sort": {
+      "name": "Pengurutan Cepat",
+      "description": "Algoritma bagi-dan-taklukkan yang memilih elemen pivot dan mempartisi larik di sekitarnya, lalu mengurutkan sub-larik secara rekursif. Sangat efisien dengan rata-rata O(n log n)."
+    },
+    "heap-sort": {
+      "name": "Pengurutan Heap",
+      "description": "Membangun max-heap dari larik, lalu berulang kali mengekstrak elemen maksimum dan menempatkannya di akhir bagian terurut. Mencapai O(n log n) di semua kasus dengan O(1) ruang."
+    },
+    "counting-sort": {
+      "name": "Pengurutan Cacahan",
+      "description": "Algoritma pengurutan bilangan bulat tanpa perbandingan yang menghitung kemunculan setiap nilai dan menggunakannya untuk menempatkan elemen langsung ke posisi akhirnya."
+    },
+    "radix-sort": {
+      "name": "Pengurutan Radix",
+      "description": "Algoritma pengurutan bilangan bulat tanpa perbandingan yang mengurutkan elemen digit per digit dari digit paling tidak signifikan menggunakan counting sort sebagai subrutin stabil."
+    },
+    "linear-search": {
+      "name": "Pencarian Linear",
+      "description": "Memeriksa setiap elemen daftar secara berurutan hingga kecocokan ditemukan atau seluruh daftar telah diperiksa. Bekerja pada larik terurut maupun tidak terurut."
+    },
+    "binary-search": {
+      "name": "Pencarian Biner",
+      "description": "Mencari larik terurut secara efisien dengan membagi interval pencarian menjadi dua secara berulang. Jika target kurang dari titik tengah, cari di setengah kiri; jika tidak, cari di setengah kanan."
+    },
+    "jump-search": {
+      "name": "Pencarian Lompat",
+      "description": "Bekerja pada larik terurut dengan melompat maju sebesar langkah tetap √n, lalu melakukan pencarian linear mundur dalam blok yang teridentifikasi."
+    },
+    "interpolation-search": {
+      "name": "Pencarian Interpolasi",
+      "description": "Varian pencarian biner yang lebih baik untuk larik terurut yang terdistribusi merata. Menggunakan interpolasi untuk memperkirakan posisi target."
+    },
+    "exponential-search": {
+      "name": "Pencarian Eksponensial",
+      "description": "Menemukan rentang di mana target mungkin berada dengan menggandakan batas secara eksponensial, lalu melakukan pencarian biner dalam rentang tersebut."
+    },
+    "ternary-search": {
+      "name": "Pencarian Terner",
+      "description": "Membagi larik terurut menjadi tiga bagian dengan menghitung dua titik tengah, lalu mengeliminasi dua per tiga ruang pencarian setiap iterasi."
+    },
+    "bfs": {
+      "name": "Penelusuran Lebar Pertama",
+      "description": "Mengeksplorasi graf level demi level dari simpul awal, mengunjungi semua tetangga sebelum bergerak lebih dalam. Menemukan jalur terpendek dalam graf tak berbobot."
+    },
+    "dfs": {
+      "name": "Penelusuran Kedalaman Pertama",
+      "description": "Mengeksplorasi sejauh mungkin di setiap cabang sebelum mundur. Berguna untuk pengurutan topologi, deteksi siklus, dan menemukan komponen terhubung."
+    },
+    "dijkstra": {
+      "name": "Algoritma Dijkstra",
+      "description": "Menemukan jalur terpendek dari simpul sumber ke semua simpul lain dalam graf berbobot dengan bobot sisi non-negatif menggunakan pendekatan serakah dengan antrian prioritas."
+    },
+    "bellman-ford": {
+      "name": "Bellman-Ford",
+      "description": "Menemukan jalur terpendek dari sumber ke semua simpul, menangani bobot sisi negatif. Mendeteksi siklus negatif. Lebih lambat dari Dijkstra namun lebih serbaguna."
+    },
+    "floyd-warshall": {
+      "name": "Floyd-Warshall",
+      "description": "Menghitung jalur terpendek antara semua pasang simpul. Bekerja dengan bobot sisi negatif (tetapi bukan siklus negatif). Kompleksitas waktu O(V³)."
+    },
+    "kruskal": {
+      "name": "Algoritma Kruskal",
+      "description": "Membangun Pohon Rentang Minimum dengan mengurutkan semua sisi dan menambahkan sisi terkecil yang tidak membentuk siklus menggunakan Union-Find untuk deteksi siklus."
+    },
+    "prim": {
+      "name": "Algoritma Prim",
+      "description": "Membangun Pohon Rentang Minimum mulai dari satu simpul dan secara serakah menambahkan satu sisi sekaligus, selalu memilih sisi berbobot minimum yang menghubungkan simpul baru."
+    },
+    "topological-sort": {
+      "name": "Pengurutan Topologi",
+      "description": "Mengurutkan simpul dalam Graf Asiklik Berarah (DAG) sehingga untuk setiap sisi berarah u → v, u muncul sebelum v. Menggunakan DFS dengan tumpukan post-order."
+    },
+    "inorder-traversal": {
+      "name": "Penelusuran In-order",
+      "description": "Mengunjungi simpul dalam urutan Kiri → Akar → Kanan, menghasilkan keluaran terurut untuk BST."
+    },
+    "preorder-traversal": {
+      "name": "Penelusuran Pre-order",
+      "description": "Mengunjungi simpul dalam urutan Akar → Kiri → Kanan. Berguna untuk membuat salinan pohon atau evaluasi ekspresi prefiks."
+    },
+    "postorder-traversal": {
+      "name": "Penelusuran Post-order",
+      "description": "Mengunjungi simpul dalam urutan Kiri → Kanan → Akar. Berguna untuk menghapus pohon atau mengevaluasi ekspresi postfiks."
+    },
+    "level-order-traversal": {
+      "name": "Penelusuran Level-order",
+      "description": "Mengunjungi simpul level demi level menggunakan antrian (BFS). Mengeksplorasi semua simpul pada kedalaman d sebelum simpul pada kedalaman d+1."
+    },
+    "bst-insert": {
+      "name": "Penyisipan BST",
+      "description": "Menyisipkan nilai baru ke dalam Pohon Pencarian Biner dengan membandingkan di setiap simpul untuk menemukan posisi yang tepat."
+    },
+    "bst-search": {
+      "name": "Pencarian BST",
+      "description": "Mencari nilai dalam Pohon Pencarian Biner dengan membandingkan di setiap simpul dan bergerak ke kiri atau kanan sesuai kebutuhan."
+    },
+    "bst-delete": {
+      "name": "Penghapusan BST",
+      "description": "Menghapus nilai dari Pohon Pencarian Biner, menangani tiga kasus: simpul daun, satu anak, dan dua anak (penerus in-order)."
+    },
+    "fibonacci": {
+      "name": "Fibonacci",
+      "description": "Menghitung bilangan Fibonacci ke-n menggunakan pemrograman dinamis bottom-up, menyimpan semua nilai dalam tabel 1D untuk menghindari komputasi berulang."
+    },
+    "lcs": {
+      "name": "Subsequens Terpanjang Bersama",
+      "description": "Menemukan subsequens terpanjang yang sama untuk dua string. Menggunakan tabel DP 2D di mana dp[i][j] adalah panjang LCS dari i karakter pertama s1 dan j karakter pertama s2."
+    },
+    "knapsack": {
+      "name": "Ransel 0/1",
+      "description": "Diberikan item dengan bobot dan nilai, temukan total nilai maksimum yang muat dalam ransel berkapasitas W. Setiap item hanya dapat diambil paling banyak satu kali."
+    },
+    "coin-change": {
+      "name": "Penukaran Koin",
+      "description": "Menemukan jumlah minimum koin yang diperlukan untuk membuat jumlah tertentu. Menggunakan larik DP 1D di mana dp[i] adalah jumlah koin minimum yang diperlukan untuk jumlah i."
+    },
+    "lis": {
+      "name": "Subsequens Meningkat Terpanjang",
+      "description": "Menemukan panjang subsequens meningkat ketat terpanjang dalam larik. Menggunakan DP O(n²) di mana dp[i] adalah panjang LIS yang berakhir di indeks i."
+    },
+    "edit-distance": {
+      "name": "Jarak Edit",
+      "description": "Menghitung jumlah minimum pengeditan karakter tunggal (penyisipan, penghapusan, substitusi) yang diperlukan untuk mengubah satu string menjadi string lain."
+    },
+    "naive-search": {
+      "name": "Pencarian String Naif",
+      "description": "Algoritma pencocokan string paling sederhana yang memeriksa pola di setiap posisi dalam teks dengan membandingkan karakter satu per satu. Sederhana namun tidak efisien untuk masukan besar."
+    },
+    "kmp-search": {
+      "name": "Pencarian KMP",
+      "description": "Algoritma Knuth-Morris-Pratt memproses pola terlebih dahulu untuk membangun fungsi kegagalan yang memungkinkan melewati perbandingan berulang. Mencapai kompleksitas waktu linear."
+    },
+    "rabin-karp-search": {
+      "name": "Pencarian Rabin-Karp",
+      "description": "Menggunakan hash bergulir untuk memindai teks secara efisien. Menghitung hash untuk setiap jendela teks dan membandingkannya dengan hash pola."
+    },
+    "boyer-moore-search": {
+      "name": "Pencarian Boyer-Moore",
+      "description": "Membandingkan pola dari kanan ke kiri dan menggunakan heuristik karakter buruk untuk melewatkan bagian besar teks. Sering menjadi algoritma pencocokan string praktis tercepat."
+    },
+    "n-queens": {
+      "name": "N-Ratu",
+      "description": "Tempatkan N ratu di papan catur N×N sehingga tidak ada dua ratu yang saling menyerang (tidak berbagi baris, kolom, atau diagonal). Menggunakan runut balik untuk menemukan susunan yang valid."
+    },
+    "sudoku-solver": {
+      "name": "Pemecah Sudoku",
+      "description": "Memecahkan teka-teki Sudoku 4×4 menggunakan runut balik. Setiap baris, kolom, dan kotak 2×2 harus berisi setiap digit dari 1 hingga 4 tepat satu kali."
+    },
+    "permutations": {
+      "name": "Permutasi",
+      "description": "Menghasilkan semua permutasi dari [1, 2, 3] menggunakan runut balik dengan penukaran di tempat. Setiap baris dalam grid menunjukkan satu permutasi."
+    },
+    "subsets": {
+      "name": "Himpunan Bagian",
+      "description": "Menghasilkan semua himpunan bagian (himpunan kuasa) dari [1, 2, 3] menggunakan runut balik. Setiap baris menunjukkan satu himpunan bagian."
+    },
+    "sieve-of-eratosthenes": {
+      "name": "Saringan Eratosthenes",
+      "description": "Menemukan semua bilangan prima hingga N secara efisien dengan secara iteratif menandai kelipatan setiap prima sebagai komposit."
+    },
+    "euclidean-gcd": {
+      "name": "FPB Euclidean",
+      "description": "Menghitung Faktor Persekutuan Terbesar dari dua bilangan menggunakan pembagian berulang. Setiap langkah mereduksi masalah hingga sisa bagi menjadi nol."
+    },
+    "fast-power": {
+      "name": "Eksponen Cepat (Eksponensiasi Biner)",
+      "description": "Menghitung base^exp dalam O(log exp) dengan mengkuadratkan basis di setiap langkah dan mengalikan ke hasil hanya ketika bit eksponen yang sesuai aktif."
+    },
+    "prime-factorization": {
+      "name": "Faktorisasi Prima",
+      "description": "Menguraikan bilangan menjadi faktor-faktor primanya menggunakan pembagian percobaan hingga akar kuadrat dari n."
+    },
+    "fibonacci-variants": {
+      "name": "Varian Fibonacci",
+      "description": "Mendemonstrasikan komputasi Fibonacci iteratif dengan memoization. Setiap nilai dihitung dari dua nilai sebelumnya, membangun urutan langkah demi langkah."
+    },
+    "comb-sort": {
+      "name": "Pengurutan Sisir",
+      "description": "Perbaikan dari pengurutan gelembung yang mengeliminasi 'kura-kura' (nilai kecil di dekat akhir daftar) menggunakan celah lebih besar dari 1. Celah menyusut dengan faktor 1.3 setiap pass."
+    },
+    "tim-sort": {
+      "name": "Tim Sort",
+      "description": "Algoritma pengurutan stabil hibrida turunan dari merge sort dan insertion sort. Digunakan sebagai pengurutan default di Python dan Java. Membagi data menjadi run kecil lalu menggabungkannya."
+    },
+    "pancake-sort": {
+      "name": "Pengurutan Pancake",
+      "description": "Mengurutkan dengan melakukan serangkaian 'pembalikan pancake': membalik prefiks larik. Satu-satunya operasi yang diizinkan adalah membalik k elemen pertama."
+    },
+    "fibonacci-search": {
+      "name": "Pencarian Fibonacci",
+      "description": "Mencari larik terurut menggunakan bilangan Fibonacci untuk membagi ruang pencarian. Menggunakan offset berdasarkan urutan Fibonacci, mengeliminasi sekitar 1/3 elemen yang tersisa setiap langkah."
+    },
+    "tarjan-scc": {
+      "name": "SCC Tarjan",
+      "description": "Menemukan semua Komponen Sangat Terhubung dalam graf berarah menggunakan satu pass DFS. Menggunakan tumpukan dan nilai low-link untuk mengidentifikasi SCC."
+    },
+    "a-star": {
+      "name": "Pencarian A*",
+      "description": "Algoritma jalur terpendek berbasis heuristik yang menggabungkan Dijkstra dengan estimasi jarak tersisa. Menggunakan f(n) = g(n) + h(n) untuk memprioritaskan eksplorasi."
+    },
+    "avl-insert": {
+      "name": "Penyisipan Pohon AVL",
+      "description": "Menyisipkan nilai ke pohon AVL (BST yang menyeimbangkan diri). Setelah penyisipan, memeriksa faktor keseimbangan dan melakukan rotasi LL, RR, LR, atau RL untuk mempertahankan sifat keseimbangan tinggi."
+    },
+    "kadane": {
+      "name": "Algoritma Kadane",
+      "description": "Menemukan sub-larik kontinu dengan jumlah maksimum dalam O(n). Melacak jumlah maksimum yang berakhir di posisi saat ini dan maksimum global yang terlihat sejauh ini."
+    },
+    "matrix-chain": {
+      "name": "Perkalian Rantai Matriks",
+      "description": "Menemukan parentisasi optimal untuk meminimalkan jumlah perkalian skalar saat mengalikan rantai matriks. Menggunakan tabel DP 2D di mana dp[i][j] adalah biaya minimum untuk matriks i hingga j."
+    },
+    "z-algorithm": {
+      "name": "Algoritma Z",
+      "description": "Menghitung larik Z di mana Z[i] adalah panjang substring terpanjang yang dimulai di posisi i yang juga merupakan prefiks string. Digunakan untuk pencocokan pola waktu linear."
+    },
+    "knights-tour": {
+      "name": "Tur Kuda",
+      "description": "Menemukan urutan langkah di mana kuda catur mengunjungi setiap kotak papan tepat satu kali. Menggunakan runut balik dengan heuristik Warnsdorff: selalu bergerak ke kotak dengan paling sedikit langkah ke depan."
+    },
+    "extended-gcd": {
+      "name": "FPB Euclidean Diperluas",
+      "description": "Memperluas algoritma Euclidean untuk menemukan bilangan bulat x dan y sehingga ax + by = gcd(a, b). Penting dalam aritmatika modular, kriptografi (RSA), dan penyelesaian persamaan Diophantine linear."
+    },
+    "miller-rabin": {
+      "name": "Uji Primalitas Miller-Rabin",
+      "description": "Uji primalitas probabilistik yang menentukan apakah suatu bilangan adalah komposit atau kemungkinan prima. Menguji beberapa nilai saksi (2, 3, 5, 7) — jika semua lulus, bilangan tersebut hampir pasti prima."
+    }
+  }
+}

--- a/algo-compendium/app/_i18n/index.tsx
+++ b/algo-compendium/app/_i18n/index.tsx
@@ -1,0 +1,155 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  type ReactNode,
+} from 'react';
+import en from './en.json';
+import id from './id.json';
+
+// ─── Language ────────────────────────────────────────────────────────────────
+
+export type Language = 'en' | 'id';
+
+const TRANSLATIONS = { en, id } as const;
+const LANG_KEY = 'algo-i18n-lang';
+
+type I18nCtx = {
+  language: Language;
+  setLanguage: (l: Language) => void;
+  t: (key: string) => string;
+};
+
+const I18nContext = createContext<I18nCtx>({
+  language: 'en',
+  setLanguage: () => {},
+  t: (k) => k,
+});
+
+function getNestedValue(obj: unknown, parts: string[]): string | undefined {
+  let cur: unknown = obj;
+  for (const part of parts) {
+    if (cur == null || typeof cur !== 'object') return undefined;
+    cur = (cur as Record<string, unknown>)[part];
+  }
+  return typeof cur === 'string' ? cur : undefined;
+}
+
+// ─── Theme ───────────────────────────────────────────────────────────────────
+
+export type Theme = 'light' | 'dark';
+
+const THEME_KEY = 'algo-theme';
+
+type ThemeCtx = {
+  theme: Theme;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeCtx>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+// ─── Providers ───────────────────────────────────────────────────────────────
+
+function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    try {
+      const stored = localStorage.getItem(THEME_KEY);
+      if (stored === 'dark' || stored === 'light') return stored;
+      if (window.matchMedia('(prefers-color-scheme: dark)').matches)
+        return 'dark';
+    } catch {
+      // ignore
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    try {
+      localStorage.setItem(THEME_KEY, theme);
+    } catch {
+      // ignore
+    }
+  }, [theme]);
+
+  const toggleTheme = useCallback(
+    () => setTheme((t) => (t === 'dark' ? 'light' : 'dark')),
+    []
+  );
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [language, setLang] = useState<Language>(() => {
+    try {
+      const stored = localStorage.getItem(LANG_KEY);
+      if (stored === 'en' || stored === 'id') return stored;
+    } catch {
+      // ignore
+    }
+    return 'en';
+  });
+
+  const setLanguage = useCallback((l: Language) => {
+    setLang(l);
+    try {
+      localStorage.setItem(LANG_KEY, l);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const t = useCallback(
+    (key: string): string => {
+      const parts = key.split('.');
+      return (
+        getNestedValue(TRANSLATIONS[language], parts) ??
+        getNestedValue(TRANSLATIONS['en'], parts) ??
+        key
+      );
+    },
+    [language]
+  );
+
+  return (
+    <ThemeProvider>
+      <I18nContext.Provider value={{ language, setLanguage, t }}>
+        {children}
+      </I18nContext.Provider>
+    </ThemeProvider>
+  );
+}
+
+export function useI18n() {
+  return useContext(I18nContext);
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+// Returns t(key) when a translation exists, fallback otherwise.
+// Avoids calling t() twice in the common "translate or use registered value" pattern.
+export function tOr(
+  translate: (k: string) => string,
+  key: string,
+  fallback: string
+): string {
+  const val = translate(key);
+  return val === key ? fallback : val;
+}

--- a/algo-compendium/app/globals.css
+++ b/algo-compendium/app/globals.css
@@ -1,0 +1,210 @@
+@import 'tailwindcss';
+
+@theme {
+  --color-turquoise: #2ec4b6;
+  --color-turquoise-dark: #1a9e91;
+  --color-turquoise-light: #7ee4dc;
+}
+
+@layer components {
+  /* ── Page layout ─────────────────────────────────────────────── */
+
+  .page-container {
+    @apply p-8 max-w-5xl mx-auto space-y-6;
+  }
+
+  .page-container-narrow {
+    @apply p-8 max-w-4xl mx-auto;
+  }
+
+  /* ── Card surfaces ───────────────────────────────────────────── */
+
+  /* Base surface — no padding, no interaction */
+  .card {
+    @apply bg-white dark:bg-gray-800 rounded-xl shadow-sm
+           border border-gray-100 dark:border-gray-700;
+  }
+
+  /* Clickable card that lifts on hover */
+  .card-link {
+    @apply bg-white dark:bg-gray-800 rounded-xl shadow-sm
+           border border-gray-100 dark:border-gray-700
+           p-5 flex flex-col gap-3
+           hover:shadow-md transition-shadow;
+  }
+
+  /* Card that hosts a header + body (collapsible or static) */
+  .card-section {
+    @apply bg-white dark:bg-gray-800 rounded-xl shadow-sm
+           border border-gray-100 dark:border-gray-700
+           overflow-hidden;
+  }
+
+  /* ── Section sub-components ──────────────────────────────────── */
+
+  /* Clickable toggle button spanning the full card width */
+  .section-toggle {
+    @apply w-full flex items-center justify-between
+           px-5 py-4 text-left
+           hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors;
+  }
+
+  /* Title row inside a toggle or static header */
+  .section-title {
+    @apply flex items-center gap-2 font-semibold
+           text-gray-700 dark:text-gray-200;
+  }
+
+  /* Chevron icon in a toggle */
+  .section-chevron {
+    @apply w-4 h-4 text-gray-400 transition-transform duration-200;
+  }
+
+  /* Static (non-clickable) header row, e.g. Visualizer header */
+  .section-header-row {
+    @apply flex items-center gap-2 px-5 py-4
+           border-b border-gray-100 dark:border-gray-700;
+  }
+
+  /* Title text inside a static section header */
+  .section-header-title {
+    @apply font-semibold text-gray-700 dark:text-gray-200;
+  }
+
+  /* Padded body beneath a section header */
+  .section-body {
+    @apply px-5 pb-5 pt-4
+           border-t border-gray-100 dark:border-gray-700;
+  }
+
+  /* Simple inner padding (Visualizer content area) */
+  .section-content {
+    @apply p-5;
+  }
+
+  /* ── Labels ──────────────────────────────────────────────────── */
+
+  /* ALL-CAPS field label with bottom margin (Complexity, Pseudocode …) */
+  .label-caps {
+    @apply text-xs font-semibold uppercase tracking-wide mb-3
+           text-gray-400 dark:text-gray-500;
+  }
+
+  /* ALL-CAPS field label inline (no bottom margin, for flex rows) */
+  .label-caps-inline {
+    @apply text-xs font-semibold uppercase tracking-wide
+           text-gray-400 dark:text-gray-500;
+  }
+
+  /* Turquoise accent icon */
+  .icon-accent {
+    @apply w-4 h-4 text-[var(--color-turquoise)];
+  }
+
+  /* ── Buttons ─────────────────────────────────────────────────── */
+
+  /* Filled turquoise — primary actions (Play, Apply) */
+  .btn-primary {
+    @apply bg-[var(--color-turquoise)] text-white
+           rounded px-3 py-1 text-sm font-medium
+           hover:opacity-90 transition-opacity
+           disabled:opacity-40 disabled:cursor-not-allowed;
+  }
+
+  /* Outlined — secondary actions (◀ ▶ Reset Randomize) */
+  .btn-secondary {
+    @apply rounded px-2 py-1 text-sm
+           border border-gray-300 dark:border-gray-600
+           text-gray-600 dark:text-gray-300
+           hover:bg-gray-50 dark:hover:bg-gray-700
+           disabled:opacity-40 disabled:cursor-not-allowed
+           transition-colors;
+  }
+
+  /* Full-width icon+text button in sidebar footer */
+  .btn-sidebar-action {
+    @apply w-full flex items-center justify-center gap-2
+           px-3 py-2 rounded-lg
+           text-gray-500 dark:text-gray-400
+           hover:bg-gray-100 dark:hover:bg-gray-700
+           hover:text-gray-700 dark:hover:text-gray-100
+           transition-colors;
+  }
+
+  /* ── Sidebar navigation links ────────────────────────────────── */
+
+  .nav-link {
+    @apply flex items-center gap-3 px-3 py-2.5 mx-1
+           rounded-lg text-sm transition-colors;
+  }
+
+  .nav-link-inactive {
+    @apply flex items-center gap-3 px-3 py-2.5 mx-1
+           rounded-lg text-sm transition-colors
+           text-gray-600 dark:text-gray-300
+           hover:bg-gray-100 dark:hover:bg-gray-700
+           hover:text-gray-900;
+  }
+
+  .nav-link-active {
+    @apply flex items-center gap-3 px-3 py-2.5 mx-1
+           rounded-lg text-sm transition-colors
+           bg-[var(--color-turquoise)] text-white;
+  }
+
+  /* ── Complexity / property badges ───────────────────────────── */
+
+  .badge-stable {
+    @apply px-2 py-0.5 rounded text-xs
+           bg-green-100 dark:bg-green-900
+           text-green-700 dark:text-green-300;
+  }
+
+  .badge-unstable {
+    @apply px-2 py-0.5 rounded text-xs
+           bg-gray-100 dark:bg-gray-700
+           text-gray-600 dark:text-gray-300;
+  }
+
+  .badge-in-place {
+    @apply px-2 py-0.5 rounded text-xs
+           bg-blue-100 dark:bg-blue-900
+           text-blue-700 dark:text-blue-300;
+  }
+
+  .badge-extra-space {
+    @apply px-2 py-0.5 rounded text-xs
+           bg-gray-100 dark:bg-gray-700
+           text-gray-600 dark:text-gray-300;
+  }
+
+  /* ── Visualizer surfaces ─────────────────────────────────────── */
+
+  /* Background behind chart / grid / string visualizers */
+  .viz-surface {
+    @apply bg-gray-50 dark:bg-gray-900 rounded-lg;
+  }
+
+  /* Legend row beneath a bar chart */
+  .viz-legend {
+    @apply flex items-center gap-4 flex-wrap text-xs
+           text-gray-500 dark:text-gray-400;
+  }
+
+  /* ── Controls widget ─────────────────────────────────────────── */
+
+  .controls-wrapper {
+    @apply flex flex-col gap-2 p-3 rounded-lg shadow-sm
+           bg-white dark:bg-gray-800
+           border border-gray-200 dark:border-gray-700;
+  }
+
+  .controls-row {
+    @apply flex items-center gap-2 flex-wrap;
+  }
+
+  .controls-description {
+    @apply text-xs italic leading-snug
+           text-gray-400 dark:text-gray-500;
+  }
+}

--- a/algo-compendium/bun.lock
+++ b/algo-compendium/bun.lock
@@ -1,0 +1,213 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "algo-compendium",
+      "devDependencies": {
+        "vitest": "^3.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.4", "", { "os": "android", "cpu": "arm" }, "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.4", "", { "os": "android", "cpu": "arm64" }, "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.4", "", { "os": "linux", "cpu": "arm" }, "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.4", "", { "os": "linux", "cpu": "arm" }, "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.4", "", { "os": "linux", "cpu": "none" }, "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.4", "", { "os": "none", "cpu": "arm64" }, "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.4", "", { "os": "win32", "cpu": "x64" }, "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "rollup": ["rollup@4.60.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.4", "@rollup/rollup-android-arm64": "4.60.4", "@rollup/rollup-darwin-arm64": "4.60.4", "@rollup/rollup-darwin-x64": "4.60.4", "@rollup/rollup-freebsd-arm64": "4.60.4", "@rollup/rollup-freebsd-x64": "4.60.4", "@rollup/rollup-linux-arm-gnueabihf": "4.60.4", "@rollup/rollup-linux-arm-musleabihf": "4.60.4", "@rollup/rollup-linux-arm64-gnu": "4.60.4", "@rollup/rollup-linux-arm64-musl": "4.60.4", "@rollup/rollup-linux-loong64-gnu": "4.60.4", "@rollup/rollup-linux-loong64-musl": "4.60.4", "@rollup/rollup-linux-ppc64-gnu": "4.60.4", "@rollup/rollup-linux-ppc64-musl": "4.60.4", "@rollup/rollup-linux-riscv64-gnu": "4.60.4", "@rollup/rollup-linux-riscv64-musl": "4.60.4", "@rollup/rollup-linux-s390x-gnu": "4.60.4", "@rollup/rollup-linux-x64-gnu": "4.60.4", "@rollup/rollup-linux-x64-musl": "4.60.4", "@rollup/rollup-openbsd-x64": "4.60.4", "@rollup/rollup-openharmony-arm64": "4.60.4", "@rollup/rollup-win32-arm64-msvc": "4.60.4", "@rollup/rollup-win32-ia32-msvc": "4.60.4", "@rollup/rollup-win32-x64-gnu": "4.60.4", "@rollup/rollup-win32-x64-msvc": "4.60.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+
+    "vite": ["vite@7.3.3", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA=="],
+
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+  }
+}

--- a/algo-compendium/index.html
+++ b/algo-compendium/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Algorithm Compendium</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/algo-compendium/package.json
+++ b/algo-compendium/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "algo-compendium",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite --port 3003 --strictPort",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --port 3003 --strictPort",
+    "prod": "bun run build && bun run preview",
+    "test": "cd .. && bun playwright test tests/algo-compendium",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^3.0.0"
+  }
+}

--- a/algo-compendium/public/favicon.svg
+++ b/algo-compendium/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#2ec4b6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>
+</svg>

--- a/algo-compendium/src/main.tsx
+++ b/algo-compendium/src/main.tsx
@@ -1,0 +1,70 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Layout } from '../app/Layout';
+import { Home } from '../app/Home';
+import { CategoryList } from '../app/CategoryList';
+import { AlgorithmDetail } from '../app/AlgorithmDetail';
+import { NotFound } from '../app/NotFound';
+import { LanguageProvider } from '../app/_i18n';
+import '../app/globals.css';
+import '../_algorithms/sorting';
+import '../_algorithms/searching';
+import '../_algorithms/tree';
+import '../_algorithms/graph';
+import '../_algorithms/dynamic-programming';
+import '../_algorithms/backtracking';
+import '../_algorithms/string-matching';
+import '../_algorithms/math';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <LanguageProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route element={<Layout />}>
+            <Route path="/" element={<Home />} />
+            <Route
+              path="/sorting"
+              element={<CategoryList category="sorting" />}
+            />
+            <Route path="/sorting/:slug" element={<AlgorithmDetail />} />
+            <Route
+              path="/searching"
+              element={<CategoryList category="searching" />}
+            />
+            <Route path="/searching/:slug" element={<AlgorithmDetail />} />
+            <Route path="/graph" element={<CategoryList category="graph" />} />
+            <Route path="/graph/:slug" element={<AlgorithmDetail />} />
+            <Route path="/tree" element={<CategoryList category="tree" />} />
+            <Route path="/tree/:slug" element={<AlgorithmDetail />} />
+            <Route
+              path="/dynamic-programming"
+              element={<CategoryList category="dynamic-programming" />}
+            />
+            <Route
+              path="/dynamic-programming/:slug"
+              element={<AlgorithmDetail />}
+            />
+            <Route
+              path="/string-matching"
+              element={<CategoryList category="string-matching" />}
+            />
+            <Route
+              path="/string-matching/:slug"
+              element={<AlgorithmDetail />}
+            />
+            <Route
+              path="/backtracking"
+              element={<CategoryList category="backtracking" />}
+            />
+            <Route path="/backtracking/:slug" element={<AlgorithmDetail />} />
+            <Route path="/math" element={<CategoryList category="math" />} />
+            <Route path="/math/:slug" element={<AlgorithmDetail />} />
+            <Route path="*" element={<NotFound />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </LanguageProvider>
+  </StrictMode>
+);

--- a/algo-compendium/tsconfig.json
+++ b/algo-compendium/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["src", "app", "_algorithms", "_components", "_visualizers"]
+}

--- a/algo-compendium/vite.config.ts
+++ b/algo-compendium/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: { host: '127.0.0.1', port: 3003, strictPort: true },
+  preview: { host: '127.0.0.1', port: 3003, strictPort: true },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+});

--- a/algo-compendium/vitest.config.ts
+++ b/algo-compendium/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts'],
+    pool: 'vmThreads',
+    poolOptions: {
+      vmThreads: {
+        singleThread: true,
+      },
+    },
+  },
+});

--- a/bilbatez.dev/content/en/projects.md
+++ b/bilbatez.dev/content/en/projects.md
@@ -1,6 +1,9 @@
 ---
 intro: "Here are the tech projects that I've worked on!"
 projects:
+  - title: Algorithm Compendium
+    link: https://github.com/bilbatez/monorepo.bilbatez.dev/tree/main/algo-compendium
+    description: 'Interactive step-by-step visualizer for 63 classic algorithms with complexity analysis, pseudocode, dark mode, and bilingual (EN/ID) support.'
   - title: KPR for Dummies
     link: https://github.com/bilbatez/monorepo.bilbatez.dev/tree/main/kprfordummies
     description: Home mortgage calculator based on Indonesia.

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,13 @@
         "vite": "^6.4.2",
       },
     },
+    "algo-compendium": {
+      "name": "algo-compendium",
+      "version": "1.0.0",
+      "devDependencies": {
+        "vitest": "^3.0.0",
+      },
+    },
     "bilbatez.dev": {
       "name": "bilbatez.dev",
       "version": "1.0.0",
@@ -392,6 +399,10 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
@@ -426,6 +437,20 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
     "@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
 
     "abs-svg-path": ["abs-svg-path@0.1.1", "", {}, "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA=="],
@@ -435,6 +460,8 @@
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "algo-compendium": ["algo-compendium@workspace:algo-compendium"],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
@@ -459,6 +486,8 @@
     "array.prototype.tosorted": ["array.prototype.tosorted@1.1.4", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3", "es-errors": "^1.3.0", "es-shim-unscopables": "^1.0.2" } }, "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA=="],
 
     "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
@@ -486,6 +515,8 @@
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
     "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -496,7 +527,11 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001793", "", {}, "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA=="],
 
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
@@ -548,6 +583,8 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
@@ -585,6 +622,8 @@
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
     "es-iterator-helpers": ["es-iterator-helpers@1.3.2", "", { "dependencies": { "call-bind": "^1.0.9", "call-bound": "^1.0.4", "define-properties": "^1.2.1", "es-abstract": "^1.24.2", "es-errors": "^1.3.0", "es-set-tostringtag": "^2.1.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.3.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "iterator.prototype": "^1.1.5", "math-intrinsics": "^1.1.0" } }, "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
@@ -626,6 +665,8 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
@@ -633,6 +674,8 @@
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
     "execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -876,6 +919,8 @@
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -961,6 +1006,10 @@
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -1058,6 +1107,8 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
@@ -1065,6 +1116,10 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "speech-rule-engine": ["speech-rule-engine@4.1.4", "", { "dependencies": { "@xmldom/xmldom": "0.9.10", "commander": "13.1.0", "wicked-good-xpath": "1.3.0" }, "bin": { "sre": "bin/sre" } }, "sha512-i/VCLG1fvRc95pMHRqG4aQNscv+9aIsqA2oI7ZQS51sTdUcDHYX6cpT8/tqZ+enjs1tKVwbRBWgxut9SWn+f9g=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
@@ -1092,6 +1147,8 @@
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
@@ -1106,9 +1163,17 @@
 
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
     "tinyexec": ["tinyexec@1.2.2", "", {}, "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g=="],
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -1150,6 +1215,10 @@
 
     "vite-compatible-readable-stream": ["vite-compatible-readable-stream@3.6.1", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ=="],
 
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-boxed-primitive": ["which-boxed-primitive@1.1.1", "", { "dependencies": { "is-bigint": "^1.1.0", "is-boolean-object": "^1.2.1", "is-number-object": "^1.1.1", "is-string": "^1.1.1", "is-symbol": "^1.1.1" } }, "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA=="],
@@ -1159,6 +1228,8 @@
     "which-collection": ["which-collection@1.0.2", "", { "dependencies": { "is-map": "^2.0.3", "is-set": "^2.0.3", "is-weakmap": "^2.0.2", "is-weakset": "^2.0.3" } }, "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw=="],
 
     "which-typed-array": ["which-typed-array@1.1.21", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.9", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "wicked-good-xpath": ["wicked-good-xpath@1.3.0", "", {}, "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="],
 
@@ -1236,9 +1307,13 @@
 
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
+    "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
     "unicode-properties/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "unicode-trie/pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
+
+    "vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "workspaces": [
     "./bilbatez.dev",
-    "./kprfordummies"
+    "./kprfordummies",
+    "./algo-compendium"
   ],
   "scripts": {
     "postinstall": "[ \"$PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD\" = \"1\" ] || bun playwright install",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -62,5 +62,13 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
     },
+    {
+      command: process.env.CI
+        ? 'bun run --filter "algo-compendium" preview'
+        : 'bun run --filter "algo-compendium" dev',
+      url: 'http://127.0.0.1:3003',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
   ],
 });

--- a/tests/algo-compendium/pom/algorithm-detail-page.ts
+++ b/tests/algo-compendium/pom/algorithm-detail-page.ts
@@ -1,0 +1,113 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { Nav } from './components/nav';
+
+export class AlgorithmDetailPage {
+  constructor(
+    public readonly page: Page,
+    public readonly nav: Nav
+  ) {}
+
+  /** Open the Overview collapsible if it is currently collapsed. */
+  async openOverview() {
+    const complexityLabel = this.page.getByText('Complexity', { exact: true });
+    const isOpen = await complexityLabel.isVisible().catch(() => false);
+    if (!isOpen) {
+      await this.page.getByRole('button', { name: /overview/i }).click();
+      await expect(complexityLabel).toBeVisible();
+    }
+  }
+
+  async hasAlgorithmName() {
+    await expect(this.page.getByRole('heading', { level: 1 })).toBeVisible();
+  }
+
+  async hasComplexityInfo() {
+    await this.openOverview();
+    await expect(this.page.getByText(/best/i).first()).toBeVisible();
+    await expect(this.page.getByText(/worst/i).first()).toBeVisible();
+  }
+
+  async hasPseudocode() {
+    await this.openOverview();
+    await expect(
+      this.page.getByText('Pseudocode', { exact: true })
+    ).toBeVisible();
+    await expect(this.page.locator('pre').first()).toBeVisible();
+  }
+
+  async overviewToggles() {
+    const btn = this.page.getByRole('button', { name: /overview/i });
+    await expect(btn).toBeVisible();
+
+    // Ensure closed first
+    const complexityLabel = this.page.getByText('Complexity', { exact: true });
+    if (await complexityLabel.isVisible().catch(() => false)) {
+      await btn.click();
+      await expect(complexityLabel).not.toBeVisible();
+    }
+
+    // Open
+    await btn.click();
+    await expect(complexityLabel).toBeVisible();
+
+    // Close again
+    await btn.click();
+    await expect(complexityLabel).not.toBeVisible();
+  }
+
+  async hasVisualizerSection() {
+    await expect(
+      this.page.getByText('Visualizer', { exact: true })
+    ).toBeVisible();
+  }
+
+  async hasVisualizerArea() {
+    const visualizer = this.page
+      .locator('.flex.items-end')
+      .or(this.page.locator('svg').first())
+      .or(this.page.locator('table').first());
+    await expect(visualizer.first()).toBeVisible({ timeout: 5000 });
+  }
+
+  async hasPlayControls() {
+    await expect(
+      this.page.getByRole('button', { name: /play|pause/i }).first()
+    ).toBeVisible();
+  }
+
+  async canPlay() {
+    const playBtn = this.page.getByRole('button', { name: 'Play' }).first();
+    await expect(playBtn).toBeVisible();
+    await playBtn.click();
+    await expect(
+      this.page.getByRole('button', { name: 'Pause' }).first()
+    ).toBeVisible();
+    // Reset to paused state
+    await this.page.getByRole('button', { name: 'Pause' }).first().click();
+  }
+
+  async canStepForward() {
+    const stepBtn = this.page.getByRole('button', { name: 'Step forward' });
+    await expect(stepBtn).toBeEnabled();
+    await stepBtn.click();
+  }
+
+  async canReset() {
+    await this.page.getByRole('button', { name: 'Reset' }).click();
+  }
+
+  async categoryBadgeIsVisible() {
+    const badge = this.page
+      .locator('a[href^="/"]')
+      .filter({
+        hasText: /sorting|searching|graph|tree|dynamic|string|backtrack|math/i,
+      })
+      .first();
+    await expect(badge).toBeVisible();
+  }
+
+  static factory(page: Page): AlgorithmDetailPage {
+    return new AlgorithmDetailPage(page, new Nav(page));
+  }
+}

--- a/tests/algo-compendium/pom/category-list-page.ts
+++ b/tests/algo-compendium/pom/category-list-page.ts
@@ -1,0 +1,49 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { Nav } from './components/nav';
+
+export class CategoryListPage {
+  constructor(
+    public readonly page: Page,
+    public readonly nav: Nav
+  ) {}
+
+  /** Links that navigate to algorithm detail pages within the current category. */
+  private algorithmCardLinks() {
+    // Cards are <Link to="/:category/:slug"> rendered as <a> inside the grid
+    return this.page.locator('main a[href*="/"]').filter({
+      has: this.page.locator('h2'),
+    });
+  }
+
+  async hasAlgorithmCards() {
+    await expect(this.algorithmCardLinks().first()).toBeVisible();
+  }
+
+  async hasAlgorithmCount(expected: number) {
+    await expect(this.algorithmCardLinks()).toHaveCount(expected, {
+      timeout: 5000,
+    });
+  }
+
+  async algorithmCardCount() {
+    return this.algorithmCardLinks().count();
+  }
+
+  async hasCategoryHeading(name: string) {
+    await expect(
+      this.page.getByRole('heading', { name: new RegExp(name, 'i'), level: 1 })
+    ).toBeVisible();
+  }
+
+  async navigatesToAlgorithm(slug: string) {
+    await this.page
+      .getByRole('link', { name: new RegExp(slug.replace(/-/g, ' '), 'i') })
+      .first()
+      .click();
+  }
+
+  static factory(page: Page): CategoryListPage {
+    return new CategoryListPage(page, new Nav(page));
+  }
+}

--- a/tests/algo-compendium/pom/components/nav.ts
+++ b/tests/algo-compendium/pom/components/nav.ts
@@ -1,0 +1,55 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+export class Nav {
+  constructor(public readonly page: Page) {}
+
+  async gotoWebsite() {
+    await this.page.goto('http://localhost:3003');
+  }
+
+  async gotoCategory(category: string) {
+    await this.page.goto(`http://localhost:3003/${category}`);
+  }
+
+  async gotoAlgorithm(category: string, slug: string) {
+    await this.page.goto(`http://localhost:3003/${category}/${slug}`);
+  }
+
+  async sidebarIsVisible() {
+    await expect(this.page.locator('aside')).toBeVisible();
+  }
+
+  async hasAlgorithmCompendiumTitle() {
+    await expect(
+      this.page.getByText('Algorithm Compendium').first()
+    ).toBeVisible();
+  }
+
+  async sidebarTitleNavigatesHome() {
+    // Sidebar title is a <Link to="/"> — click it, verify URL lands on home
+    const sidebarTitle = this.page.locator('aside a[href="/"]').first();
+    await expect(sidebarTitle).toBeVisible();
+    await sidebarTitle.click();
+    await this.page.waitForURL('http://localhost:3003/');
+    await expect(
+      this.page.getByRole('heading', { name: /algorithm compendium/i })
+    ).toBeVisible();
+  }
+
+  async canCollapseAndExpandSidebar() {
+    const collapseBtn = this.page.getByRole('button', { name: /collapse/i });
+    await expect(collapseBtn).toBeVisible();
+    await collapseBtn.click();
+    // Sidebar narrows — text labels hidden
+    await expect(this.page.locator('aside')).toHaveClass(/w-14/, {
+      timeout: 3000,
+    });
+    // Expand again
+    const expandBtn = this.page.getByRole('button', { name: /expand/i });
+    await expandBtn.click();
+    await expect(this.page.locator('aside')).toHaveClass(/w-64/, {
+      timeout: 3000,
+    });
+  }
+}

--- a/tests/algo-compendium/pom/components/visualizer.ts
+++ b/tests/algo-compendium/pom/components/visualizer.ts
@@ -1,0 +1,32 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+export class Visualizer {
+  constructor(public readonly page: Page) {}
+
+  async isVisible() {
+    const visualizerArea = this.page
+      .locator('[data-testid="visualizer"]')
+      .or(this.page.locator('svg, .visualizer, [class*="Visualizer"]'));
+    await expect(visualizerArea.first())
+      .toBeVisible({ timeout: 5000 })
+      .catch(async () => {
+        await expect(
+          this.page.getByRole('button', { name: /play|pause/i }).first()
+        ).toBeVisible();
+      });
+  }
+
+  async hasControls() {
+    await expect(
+      this.page
+        .getByRole('button')
+        .filter({ hasText: /play|pause|▶|⏸/i })
+        .first()
+    ).toBeVisible();
+  }
+
+  playButtonLocator() {
+    return this.page.getByRole('button').filter({ hasText: /play/i }).first();
+  }
+}

--- a/tests/algo-compendium/pom/home-page.ts
+++ b/tests/algo-compendium/pom/home-page.ts
@@ -1,0 +1,51 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { Nav } from './components/nav';
+
+export class HomePage {
+  constructor(
+    public readonly page: Page,
+    public readonly nav: Nav
+  ) {}
+
+  async hasTitle() {
+    await expect(
+      this.page.getByRole('heading', {
+        name: /algorithm compendium/i,
+        level: 1,
+      })
+    ).toBeVisible();
+  }
+
+  async hasCategoryCards() {
+    const cards = this.page
+      .locator('main a[href]')
+      .filter({ has: this.page.locator('h2') });
+    await expect(cards.first()).toBeVisible();
+  }
+
+  async hasEightCategoryCards() {
+    const cards = this.page
+      .locator('main a[href]')
+      .filter({ has: this.page.locator('h2') });
+    await expect(cards).toHaveCount(8, { timeout: 5000 });
+  }
+
+  async hasCategoryCard(name: string) {
+    await expect(
+      this.page.getByRole('link', { name: new RegExp(name, 'i') }).first()
+    ).toBeVisible();
+  }
+
+  async navigatesToCategory(category: string) {
+    await this.page
+      .getByRole('link', { name: new RegExp(category, 'i') })
+      .first()
+      .click();
+    await this.page.waitForURL(`**/${category}`);
+  }
+
+  static factory(page: Page): HomePage {
+    return new HomePage(page, new Nav(page));
+  }
+}

--- a/tests/algo-compendium/spec/backtracking.spec.ts
+++ b/tests/algo-compendium/spec/backtracking.spec.ts
@@ -1,0 +1,69 @@
+import { AlgorithmDetailPage } from '@/algo-compendium/pom/algorithm-detail-page';
+import { CategoryListPage } from '@/algo-compendium/pom/category-list-page';
+import { test as base } from '@playwright/test';
+
+const test = base.extend<{
+  categoryPage: CategoryListPage;
+  detailPage: AlgorithmDetailPage;
+}>({
+  categoryPage: async ({ page }, use) => {
+    const p = CategoryListPage.factory(page);
+    await p.nav.gotoCategory('backtracking');
+    await use(p);
+  },
+  detailPage: async ({ page }, use) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('backtracking', 'n-queens');
+    await use(p);
+  },
+});
+
+test.describe('Backtracking — category list', () => {
+  test('shows "Backtracking" heading', async ({ categoryPage }) => {
+    await categoryPage.hasCategoryHeading('Backtracking');
+  });
+
+  test('shows 5 algorithm cards', async ({ categoryPage }) => {
+    await categoryPage.hasAlgorithmCount(5);
+  });
+});
+
+test.describe('Backtracking — N-Queens detail', () => {
+  test('has algorithm name', async ({ detailPage }) => {
+    await detailPage.hasAlgorithmName();
+  });
+
+  test('has visualizer section', async ({ detailPage }) => {
+    await detailPage.hasVisualizerSection();
+  });
+
+  test('has play controls', async ({ detailPage }) => {
+    await detailPage.hasPlayControls();
+  });
+
+  test('can play and pause', async ({ detailPage }) => {
+    await detailPage.canPlay();
+  });
+
+  test('overview shows complexity info', async ({ detailPage }) => {
+    await detailPage.hasComplexityInfo();
+  });
+});
+
+test.describe('Backtracking — Permutations detail', () => {
+  test('has algorithm name and visualizer', async ({ page }) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('backtracking', 'permutations');
+    await p.hasAlgorithmName();
+    await p.hasVisualizerSection();
+  });
+});
+
+test.describe('Backtracking — Sudoku Solver detail', () => {
+  test('has algorithm name and controls', async ({ page }) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('backtracking', 'sudoku-solver');
+    await p.hasAlgorithmName();
+    await p.hasPlayControls();
+  });
+});

--- a/tests/algo-compendium/spec/dynamic-programming.spec.ts
+++ b/tests/algo-compendium/spec/dynamic-programming.spec.ts
@@ -1,0 +1,69 @@
+import { AlgorithmDetailPage } from '@/algo-compendium/pom/algorithm-detail-page';
+import { CategoryListPage } from '@/algo-compendium/pom/category-list-page';
+import { test as base } from '@playwright/test';
+
+const test = base.extend<{
+  categoryPage: CategoryListPage;
+  detailPage: AlgorithmDetailPage;
+}>({
+  categoryPage: async ({ page }, use) => {
+    const p = CategoryListPage.factory(page);
+    await p.nav.gotoCategory('dynamic-programming');
+    await use(p);
+  },
+  detailPage: async ({ page }, use) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('dynamic-programming', 'fibonacci');
+    await use(p);
+  },
+});
+
+test.describe('Dynamic Programming — category list', () => {
+  test('shows "Dynamic Programming" heading', async ({ categoryPage }) => {
+    await categoryPage.hasCategoryHeading('Dynamic Programming');
+  });
+
+  test('shows 8 algorithm cards', async ({ categoryPage }) => {
+    await categoryPage.hasAlgorithmCount(8);
+  });
+});
+
+test.describe('Dynamic Programming — Fibonacci detail', () => {
+  test('has algorithm name', async ({ detailPage }) => {
+    await detailPage.hasAlgorithmName();
+  });
+
+  test('has visualizer section', async ({ detailPage }) => {
+    await detailPage.hasVisualizerSection();
+  });
+
+  test('has play controls', async ({ detailPage }) => {
+    await detailPage.hasPlayControls();
+  });
+
+  test('can play and pause', async ({ detailPage }) => {
+    await detailPage.canPlay();
+  });
+
+  test('overview shows complexity info', async ({ detailPage }) => {
+    await detailPage.hasComplexityInfo();
+  });
+});
+
+test.describe('Dynamic Programming — LCS detail', () => {
+  test('has algorithm name and visualizer', async ({ page }) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('dynamic-programming', 'lcs');
+    await p.hasAlgorithmName();
+    await p.hasVisualizerSection();
+  });
+});
+
+test.describe('Dynamic Programming — Knapsack detail', () => {
+  test('has algorithm name and controls', async ({ page }) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('dynamic-programming', 'knapsack');
+    await p.hasAlgorithmName();
+    await p.hasPlayControls();
+  });
+});

--- a/tests/algo-compendium/spec/graph.spec.ts
+++ b/tests/algo-compendium/spec/graph.spec.ts
@@ -1,0 +1,69 @@
+import { AlgorithmDetailPage } from '@/algo-compendium/pom/algorithm-detail-page';
+import { CategoryListPage } from '@/algo-compendium/pom/category-list-page';
+import { test as base } from '@playwright/test';
+
+const test = base.extend<{
+  categoryPage: CategoryListPage;
+  detailPage: AlgorithmDetailPage;
+}>({
+  categoryPage: async ({ page }, use) => {
+    const p = CategoryListPage.factory(page);
+    await p.nav.gotoCategory('graph');
+    await use(p);
+  },
+  detailPage: async ({ page }, use) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('graph', 'bfs');
+    await use(p);
+  },
+});
+
+test.describe('Graph — category list', () => {
+  test('shows "Graph" heading', async ({ categoryPage }) => {
+    await categoryPage.hasCategoryHeading('Graph');
+  });
+
+  test('shows 10 algorithm cards', async ({ categoryPage }) => {
+    await categoryPage.hasAlgorithmCount(10);
+  });
+});
+
+test.describe('Graph — BFS detail', () => {
+  test('has algorithm name', async ({ detailPage }) => {
+    await detailPage.hasAlgorithmName();
+  });
+
+  test('has visualizer section', async ({ detailPage }) => {
+    await detailPage.hasVisualizerSection();
+  });
+
+  test('has play controls', async ({ detailPage }) => {
+    await detailPage.hasPlayControls();
+  });
+
+  test('can play and pause', async ({ detailPage }) => {
+    await detailPage.canPlay();
+  });
+
+  test('overview shows complexity info', async ({ detailPage }) => {
+    await detailPage.hasComplexityInfo();
+  });
+});
+
+test.describe('Graph — DFS detail', () => {
+  test('has algorithm name and visualizer', async ({ page }) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('graph', 'dfs');
+    await p.hasAlgorithmName();
+    await p.hasVisualizerSection();
+  });
+});
+
+test.describe('Graph — Dijkstra detail', () => {
+  test('has algorithm name and controls', async ({ page }) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('graph', 'dijkstra');
+    await p.hasAlgorithmName();
+    await p.hasPlayControls();
+  });
+});

--- a/tests/algo-compendium/spec/home.spec.ts
+++ b/tests/algo-compendium/spec/home.spec.ts
@@ -1,0 +1,66 @@
+import { HomePage } from '@/algo-compendium/pom/home-page';
+import { test as base, expect } from '@playwright/test';
+
+const test = base.extend<{ homePage: HomePage }>({
+  homePage: async ({ page }, use) => {
+    const homePage = HomePage.factory(page);
+    await homePage.nav.gotoWebsite();
+    await use(homePage);
+  },
+});
+
+test.describe('Algorithm Compendium — Home', () => {
+  test('has "Algorithm Compendium" heading', async ({ homePage }) => {
+    await homePage.hasTitle();
+  });
+
+  test('shows exactly 8 category cards', async ({ homePage }) => {
+    await homePage.hasEightCategoryCards();
+  });
+
+  test('shows all 8 categories', async ({ homePage }) => {
+    for (const name of [
+      'Sorting',
+      'Searching',
+      'Graph',
+      'Tree',
+      'Dynamic Programming',
+      'String Matching',
+      'Backtracking',
+      'Mathematics',
+    ]) {
+      await homePage.hasCategoryCard(name);
+    }
+  });
+
+  test('sidebar is visible', async ({ homePage }) => {
+    await homePage.nav.sidebarIsVisible();
+  });
+
+  test('sidebar title links to home', async ({ page }) => {
+    const homePage = HomePage.factory(page);
+    await homePage.nav.gotoCategory('sorting');
+    await homePage.nav.sidebarTitleNavigatesHome();
+  });
+
+  test('navigates to sorting category on card click', async ({ homePage }) => {
+    await homePage.navigatesToCategory('sorting');
+  });
+
+  test('navigates to graph category on card click', async ({ homePage }) => {
+    await homePage.navigatesToCategory('graph');
+  });
+});
+
+test.describe('Algorithm Compendium — Sidebar', () => {
+  test('sidebar collapse/expand works', async ({ page }) => {
+    const homePage = HomePage.factory(page);
+    await homePage.nav.gotoWebsite();
+    await homePage.nav.canCollapseAndExpandSidebar();
+  });
+
+  test('sidebar has algorithm compendium title', async ({ page }) => {
+    await page.goto('http://localhost:3003');
+    await expect(page.getByText('Algorithm Compendium').first()).toBeVisible();
+  });
+});

--- a/tests/algo-compendium/spec/math.spec.ts
+++ b/tests/algo-compendium/spec/math.spec.ts
@@ -1,0 +1,69 @@
+import { AlgorithmDetailPage } from '@/algo-compendium/pom/algorithm-detail-page';
+import { CategoryListPage } from '@/algo-compendium/pom/category-list-page';
+import { test as base } from '@playwright/test';
+
+const test = base.extend<{
+  categoryPage: CategoryListPage;
+  detailPage: AlgorithmDetailPage;
+}>({
+  categoryPage: async ({ page }, use) => {
+    const p = CategoryListPage.factory(page);
+    await p.nav.gotoCategory('math');
+    await use(p);
+  },
+  detailPage: async ({ page }, use) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('math', 'sieve-of-eratosthenes');
+    await use(p);
+  },
+});
+
+test.describe('Math — category list', () => {
+  test('shows "Mathematics" heading', async ({ categoryPage }) => {
+    await categoryPage.hasCategoryHeading('Mathematics');
+  });
+
+  test('shows 7 algorithm cards', async ({ categoryPage }) => {
+    await categoryPage.hasAlgorithmCount(7);
+  });
+});
+
+test.describe('Math — Sieve of Eratosthenes detail', () => {
+  test('has algorithm name', async ({ detailPage }) => {
+    await detailPage.hasAlgorithmName();
+  });
+
+  test('has visualizer section', async ({ detailPage }) => {
+    await detailPage.hasVisualizerSection();
+  });
+
+  test('has play controls', async ({ detailPage }) => {
+    await detailPage.hasPlayControls();
+  });
+
+  test('can play and pause', async ({ detailPage }) => {
+    await detailPage.canPlay();
+  });
+
+  test('overview shows complexity info', async ({ detailPage }) => {
+    await detailPage.hasComplexityInfo();
+  });
+});
+
+test.describe('Math — Euclidean GCD detail', () => {
+  test('has algorithm name and visualizer', async ({ page }) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('math', 'euclidean-gcd');
+    await p.hasAlgorithmName();
+    await p.hasVisualizerSection();
+  });
+});
+
+test.describe('Math — Fast Power detail', () => {
+  test('has algorithm name and controls', async ({ page }) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('math', 'fast-power');
+    await p.hasAlgorithmName();
+    await p.hasPlayControls();
+  });
+});

--- a/tests/algo-compendium/spec/searching.spec.ts
+++ b/tests/algo-compendium/spec/searching.spec.ts
@@ -1,0 +1,69 @@
+import { AlgorithmDetailPage } from '@/algo-compendium/pom/algorithm-detail-page';
+import { CategoryListPage } from '@/algo-compendium/pom/category-list-page';
+import { test as base } from '@playwright/test';
+
+const test = base.extend<{
+  categoryPage: CategoryListPage;
+  detailPage: AlgorithmDetailPage;
+}>({
+  categoryPage: async ({ page }, use) => {
+    const p = CategoryListPage.factory(page);
+    await p.nav.gotoCategory('searching');
+    await use(p);
+  },
+  detailPage: async ({ page }, use) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('searching', 'binary-search');
+    await use(p);
+  },
+});
+
+test.describe('Searching — category list', () => {
+  test('shows "Searching" heading', async ({ categoryPage }) => {
+    await categoryPage.hasCategoryHeading('Searching');
+  });
+
+  test('shows 7 algorithm cards', async ({ categoryPage }) => {
+    await categoryPage.hasAlgorithmCount(7);
+  });
+});
+
+test.describe('Searching — Binary Search detail', () => {
+  test('has algorithm name', async ({ detailPage }) => {
+    await detailPage.hasAlgorithmName();
+  });
+
+  test('has visualizer section', async ({ detailPage }) => {
+    await detailPage.hasVisualizerSection();
+  });
+
+  test('has play controls', async ({ detailPage }) => {
+    await detailPage.hasPlayControls();
+  });
+
+  test('can play and pause', async ({ detailPage }) => {
+    await detailPage.canPlay();
+  });
+
+  test('overview shows complexity info', async ({ detailPage }) => {
+    await detailPage.hasComplexityInfo();
+  });
+});
+
+test.describe('Searching — Linear Search detail', () => {
+  test('has algorithm name and visualizer', async ({ page }) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('searching', 'linear-search');
+    await p.hasAlgorithmName();
+    await p.hasVisualizerSection();
+  });
+});
+
+test.describe('Searching — Jump Search detail', () => {
+  test('has algorithm name and controls', async ({ page }) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('searching', 'jump-search');
+    await p.hasAlgorithmName();
+    await p.hasPlayControls();
+  });
+});

--- a/tests/algo-compendium/spec/sorting.spec.ts
+++ b/tests/algo-compendium/spec/sorting.spec.ts
@@ -1,0 +1,88 @@
+import { AlgorithmDetailPage } from '@/algo-compendium/pom/algorithm-detail-page';
+import { CategoryListPage } from '@/algo-compendium/pom/category-list-page';
+import { test as base } from '@playwright/test';
+
+const test = base.extend<{
+  categoryPage: CategoryListPage;
+  detailPage: AlgorithmDetailPage;
+}>({
+  categoryPage: async ({ page }, use) => {
+    const p = CategoryListPage.factory(page);
+    await p.nav.gotoCategory('sorting');
+    await use(p);
+  },
+  detailPage: async ({ page }, use) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('sorting', 'bubble-sort');
+    await use(p);
+  },
+});
+
+test.describe('Sorting — category list', () => {
+  test('shows "Sorting" heading', async ({ categoryPage }) => {
+    await categoryPage.hasCategoryHeading('Sorting');
+  });
+
+  test('shows 13 algorithm cards', async ({ categoryPage }) => {
+    await categoryPage.hasAlgorithmCount(13);
+  });
+
+  test('navigates to merge sort detail', async ({ categoryPage }) => {
+    await categoryPage.navigatesToAlgorithm('merge-sort');
+  });
+});
+
+test.describe('Sorting — Bubble Sort detail', () => {
+  test('has algorithm name heading', async ({ detailPage }) => {
+    await detailPage.hasAlgorithmName();
+  });
+
+  test('has category badge', async ({ detailPage }) => {
+    await detailPage.categoryBadgeIsVisible();
+  });
+
+  test('has visualizer section', async ({ detailPage }) => {
+    await detailPage.hasVisualizerSection();
+  });
+
+  test('has play controls', async ({ detailPage }) => {
+    await detailPage.hasPlayControls();
+  });
+
+  test('can play and pause visualizer', async ({ detailPage }) => {
+    await detailPage.canPlay();
+  });
+
+  test('can step forward', async ({ detailPage }) => {
+    await detailPage.canStepForward();
+  });
+
+  test('overview toggle shows complexity and pseudocode', async ({
+    detailPage,
+  }) => {
+    await detailPage.hasComplexityInfo();
+    await detailPage.hasPseudocode();
+  });
+
+  test('overview collapses and expands', async ({ detailPage }) => {
+    await detailPage.overviewToggles();
+  });
+});
+
+test.describe('Sorting — Quick Sort detail', () => {
+  test('has algorithm name', async ({ page }) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('sorting', 'quick-sort');
+    await p.hasAlgorithmName();
+    await p.hasVisualizerSection();
+  });
+});
+
+test.describe('Sorting — Merge Sort detail', () => {
+  test('has visualizer and controls', async ({ page }) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('sorting', 'merge-sort');
+    await p.hasAlgorithmName();
+    await p.hasPlayControls();
+  });
+});

--- a/tests/algo-compendium/spec/string-matching.spec.ts
+++ b/tests/algo-compendium/spec/string-matching.spec.ts
@@ -1,0 +1,69 @@
+import { AlgorithmDetailPage } from '@/algo-compendium/pom/algorithm-detail-page';
+import { CategoryListPage } from '@/algo-compendium/pom/category-list-page';
+import { test as base } from '@playwright/test';
+
+const test = base.extend<{
+  categoryPage: CategoryListPage;
+  detailPage: AlgorithmDetailPage;
+}>({
+  categoryPage: async ({ page }, use) => {
+    const p = CategoryListPage.factory(page);
+    await p.nav.gotoCategory('string-matching');
+    await use(p);
+  },
+  detailPage: async ({ page }, use) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('string-matching', 'naive-search');
+    await use(p);
+  },
+});
+
+test.describe('String Matching — category list', () => {
+  test('shows "String Matching" heading', async ({ categoryPage }) => {
+    await categoryPage.hasCategoryHeading('String Matching');
+  });
+
+  test('shows 5 algorithm cards', async ({ categoryPage }) => {
+    await categoryPage.hasAlgorithmCount(5);
+  });
+});
+
+test.describe('String Matching — Naive Search detail', () => {
+  test('has algorithm name', async ({ detailPage }) => {
+    await detailPage.hasAlgorithmName();
+  });
+
+  test('has visualizer section', async ({ detailPage }) => {
+    await detailPage.hasVisualizerSection();
+  });
+
+  test('has play controls', async ({ detailPage }) => {
+    await detailPage.hasPlayControls();
+  });
+
+  test('can play and pause', async ({ detailPage }) => {
+    await detailPage.canPlay();
+  });
+
+  test('overview shows complexity info', async ({ detailPage }) => {
+    await detailPage.hasComplexityInfo();
+  });
+});
+
+test.describe('String Matching — KMP Search detail', () => {
+  test('has algorithm name and visualizer', async ({ page }) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('string-matching', 'kmp-search');
+    await p.hasAlgorithmName();
+    await p.hasVisualizerSection();
+  });
+});
+
+test.describe('String Matching — Boyer-Moore Search detail', () => {
+  test('has algorithm name and controls', async ({ page }) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('string-matching', 'boyer-moore-search');
+    await p.hasAlgorithmName();
+    await p.hasPlayControls();
+  });
+});

--- a/tests/algo-compendium/spec/tree.spec.ts
+++ b/tests/algo-compendium/spec/tree.spec.ts
@@ -1,0 +1,69 @@
+import { AlgorithmDetailPage } from '@/algo-compendium/pom/algorithm-detail-page';
+import { CategoryListPage } from '@/algo-compendium/pom/category-list-page';
+import { test as base } from '@playwright/test';
+
+const test = base.extend<{
+  categoryPage: CategoryListPage;
+  detailPage: AlgorithmDetailPage;
+}>({
+  categoryPage: async ({ page }, use) => {
+    const p = CategoryListPage.factory(page);
+    await p.nav.gotoCategory('tree');
+    await use(p);
+  },
+  detailPage: async ({ page }, use) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('tree', 'inorder-traversal');
+    await use(p);
+  },
+});
+
+test.describe('Tree — category list', () => {
+  test('shows "Tree" heading', async ({ categoryPage }) => {
+    await categoryPage.hasCategoryHeading('Tree');
+  });
+
+  test('shows 8 algorithm cards', async ({ categoryPage }) => {
+    await categoryPage.hasAlgorithmCount(8);
+  });
+});
+
+test.describe('Tree — Inorder Traversal detail', () => {
+  test('has algorithm name', async ({ detailPage }) => {
+    await detailPage.hasAlgorithmName();
+  });
+
+  test('has visualizer section', async ({ detailPage }) => {
+    await detailPage.hasVisualizerSection();
+  });
+
+  test('has play controls', async ({ detailPage }) => {
+    await detailPage.hasPlayControls();
+  });
+
+  test('can play and pause', async ({ detailPage }) => {
+    await detailPage.canPlay();
+  });
+
+  test('overview shows complexity info', async ({ detailPage }) => {
+    await detailPage.hasComplexityInfo();
+  });
+});
+
+test.describe('Tree — BST Insert detail', () => {
+  test('has algorithm name and visualizer', async ({ page }) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('tree', 'bst-insert');
+    await p.hasAlgorithmName();
+    await p.hasVisualizerSection();
+  });
+});
+
+test.describe('Tree — Level Order Traversal detail', () => {
+  test('has algorithm name and controls', async ({ page }) => {
+    const p = AlgorithmDetailPage.factory(page);
+    await p.nav.gotoAlgorithm('tree', 'level-order-traversal');
+    await p.hasAlgorithmName();
+    await p.hasPlayControls();
+  });
+});

--- a/tests/bilbatez.dev/pom/projects-page.ts
+++ b/tests/bilbatez.dev/pom/projects-page.ts
@@ -15,7 +15,7 @@ export class ProjectsPage {
   async hasProjectsContent() {
     const projects = this.page.getByRole('article');
     await expect(projects).toBeVisible();
-    await expect(projects.getByRole('listitem')).toHaveCount(3);
+    await expect(projects.getByRole('listitem')).toHaveCount(4);
   }
 
   static factory(page: Page): ProjectsPage {


### PR DESCRIPTION
## Summary

- New `algo-compendium` SPA module (port 3003) — complete algorithm reference and interactive step-by-step visualizer
- 63 algorithms across 8 categories: Sorting, Searching, Graph, Tree, Dynamic Programming, String Matching, Backtracking, Math
- Command Pattern architecture: each algorithm is a pure function `(input) → Command[]`; visualizer is a pure reducer — clean separation, fully unit-testable
- Turquoise theme, collapsible left sidebar with category/algorithm navigation, per-algorithm metadata panel (complexity, stable, in-place), pseudocode viewer, and 6 visualizer types (array bars, SVG graph, SVG tree, grid table, string rows, math display)
- 385 Vitest unit tests (all pass); Playwright e2e tests for all 8 categories

## Visualizers

| Type | Used by |
|---|---|
| Array bar chart | Sorting, Searching |
| SVG tree diagram | Tree |
| SVG node/edge graph | Graph |
| HTML grid table | DP, Backtracking |
| Character row alignment | String Matching |
| Adaptive number display | Math |

## Test Plan

- [ ] `bun run --filter "algo-compendium" dev` → app loads at http://localhost:3003
- [ ] Home page shows 8 category cards with icons
- [ ] Sidebar expands/collapses, persists state in localStorage
- [ ] `/sorting/bubble-sort` → metadata panel, bar chart, play/pause/step/speed controls work
- [ ] `/graph/dijkstra` → SVG graph animates shortest path
- [ ] `/tree/inorder-traversal` → SVG tree highlights nodes in order
- [ ] `cd algo-compendium && bun vitest run` → 385/385 tests pass
- [ ] `bun test tests/algo-compendium` → all Playwright e2e pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
