### PR TITLE
feat(again): add platformer game workspace

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,6 +29,7 @@ jobs:
           bun run --filter "bilbatez.dev" build
           bun run --filter "kprfordummies" build
           bun run --filter "algo-compendium" build
+          bun run --filter "again" build
       - name: Run Playwright tests
         run: bun run test
       - uses: actions/upload-artifact@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,16 @@ monorepo.bilbatez.dev/
 │   │   └── globals.css    # Tailwind v4 entry + custom CSS
 │   ├── public/
 │   └── vite.config.ts
+├── algo-compendium/       # Algorithm visualizer SPA, port 3003
+│   ├── _algorithms/       # Pure TS: 63 algorithms across 8 categories
+│   ├── _visualizers/      # React visualizer components (per visualizer type)
+│   └── _components/       # Shared UI: controls, metadata, pseudocode
+├── again/                 # Platformer game, port 3004
+│   ├── _game/             # Phaser 3 scene/factory/sprites/config
+│   ├── _engine/           # Pure TS: constants, types, proximity triggers
+│   ├── _levels/           # Tiled JSON parse/validate/manifest
+│   ├── _progress/         # Cookie-based level progress
+│   └── public/levels/     # Tiled JSON map files (level-01…level-10.json)
 ├── tests/
 │   ├── bilbatez.dev/      # Playwright e2e for portfolio
 │   └── kprfordummies/     # Playwright e2e for KPR app
@@ -50,16 +60,22 @@ monorepo.bilbatez.dev/
 # Dev servers (run from workspace or root)
 bun run --filter "bilbatez.dev" dev      # http://localhost:3001
 bun run --filter "kprfordummies" dev     # http://localhost:3002
+bun run --filter "algo-compendium" dev   # http://localhost:3003
+bun run --filter "again" dev             # http://localhost:3004
 
 # Build (per workspace)
 bun run --filter "bilbatez.dev" build
 bun run --filter "kprfordummies" build
+bun run --filter "algo-compendium" build
+bun run --filter "again" build
 
 # Tests (from root — Playwright auto-starts dev servers)
 bun test                   # all e2e tests
 bun test:ui                # Playwright UI mode
 bun run --filter "bilbatez.dev" test     # portfolio tests only
 bun run --filter "kprfordummies" test    # KPR tests only
+bun run --filter "again" test            # again e2e tests only
+bun run --filter "again" test:unit       # again vitest (pure engine modules)
 
 # Maintenance
 bun clean                  # remove node_modules + dist
@@ -71,9 +87,9 @@ bun format                 # Prettier across all workspaces
 
 - **Commits MUST follow Conventional Commits** (enforced by commitlint). Allowed types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `style`, `perf`, `build`, `ci`, `revert`. Optional scope in parens. Subject ≤ 50 chars, imperative mood, no trailing period. Example: `feat(kpr): add annuity interest calculator`. Body wraps at 72 chars when needed.
 - `_` prefix = private/internal (e.g. `_utils/`, `_constants/`)
-- No unit tests — only Playwright e2e
+- `bilbatez.dev` and `kprfordummies`: Playwright e2e only (no unit tests). `algo-compendium` and `again`: Vitest unit tests for pure logic + Playwright e2e.
 - Playwright retries: 2 local, 3 CI; workers: unlimited local, 4 CI; browsers: all 5 local, Chrome-only CI
-- Both apps share root `node_modules` via Bun workspaces
+- All workspaces share root `node_modules` via Bun workspaces
 - React Router v7 in declarative SPA mode (no framework features, no SSR/SSG)
 - External link "shortcuts" (`/github`, `/linkedin`, `/bofa`, `/shopee`, `/blibli`, `/bilbatez.dev`) are handled by `<ExternalRedirect to=…>` route components that call `window.location.replace`.
 
@@ -85,3 +101,4 @@ bun format                 # Prettier across all workspaces
 - Tailwind v4 reads config from CSS via `@import 'tailwindcss'` + `@theme { … }` blocks. There is no `tailwind.config.ts`.
 - `bilbatez.dev/public/contents/` is untracked (gitignored / drafts).
 - `kprfordummies` uses plain CSS only — do not reintroduce SCSS unless you also switch to a PostCSS-based Tailwind pipeline (`@tailwindcss/vite` cannot reprocess post-sass output, leaving `@apply` literal in the bundle).
+- `again` uses **Phaser 3** (`phaser@^3.90.0`) in `again/package.json` only. Levels are **Tiled JSON** maps in `again/public/levels/` — object-layer-only, no tileset image. Moving bodies must use `setVelocity` (NOT tweens) for Arcade auto-carry to work. Sprite swap seam: `again/_game/sprites.ts:textureFor()`.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A collection of applications I feel like making.
 
 - Bilbatez.dev: My personal page.
 - KPR for Dummies: A KPR (mortgage) calculator. KPR is Indonesia's acronym for mortgage.
+- Algorithm Compendium: Interactive visualizer for 63 algorithms across 8 categories.
+- Again: A browser platformer game with Tiled-JSON level authoring and proximity triggers.
 
 ## Contributing
 
@@ -32,6 +34,15 @@ Change the `*` wildcard to package name to run certain application
 
 ```shell
 bun --filter "*" dev
+```
+
+Or run a specific app by name:
+
+```bash
+bun run --filter "bilbatez.dev" dev     # http://localhost:3001
+bun run --filter "kprfordummies" dev    # http://localhost:3002
+bun run --filter "algo-compendium" dev  # http://localhost:3003
+bun run --filter "again" dev            # http://localhost:3004
 ```
 
 ### Running Playwright Tests

--- a/again/CLAUDE.md
+++ b/again/CLAUDE.md
@@ -1,0 +1,112 @@
+# again
+
+Browser platformer game with Tiled-JSON level authoring — left/right/jump controls, proximity triggers, and 10 built-in levels.
+
+## Stack
+
+- **Runtime/package manager**: Bun (workspace member of monorepo root)
+- **Build tool**: Vite 6 (`@vitejs/plugin-react` + `@tailwindcss/vite`)
+- **Framework**: React 19 SPA via react-router-dom v7 (BrowserRouter, declarative)
+- **Language**: TypeScript 5, strict mode
+- **Game engine**: Phaser 3 (`phaser@^3.90.0`) — Arcade Physics, Scale Manager, Tweens, Camera FX
+- **Styling**: Tailwind CSS v4 — CSS-only config via `@theme {}` in `app/globals.css`
+- **Unit tests**: Vitest 3 (pure engine modules only; `_engine`, `_levels`, `_progress`)
+- **E2E tests**: Playwright (shared root config, POM pattern, tests live in `../tests/again/`)
+- **Dev port**: 3004
+
+## Directory Structure
+
+```
+again/
+├── src/main.tsx              # Entry: BrowserRouter + routes (/, /levels, /play/:id, *)
+├── app/
+│   ├── globals.css           # @import 'tailwindcss' + @theme dark game vars
+│   ├── Home.tsx              # Title screen: Play/Continue + Level Select (after level 1)
+│   ├── LevelSelect.tsx       # Grid of unlocked levels from cookie progress
+│   ├── Game.tsx              # Mounts Phaser.Game; listens for win/death events; overlays
+│   ├── NotFound.tsx
+│   └── _components/
+│       ├── WinPopup.tsx      # Congrats overlay — Next Level or Return Home
+│       ├── SmallScreenOverlay.tsx  # Shown when window < MIN_SCREEN_PX (1024px)
+│       └── Hud.tsx           # Level name + Back to Home button
+├── _game/                    # Phaser layer — no React (exercised via e2e + manual)
+│   ├── config.ts             # createGameConfig(): 1920×1080, Arcade, Scale.FIT
+│   ├── events.ts             # Typed event names: WIN | DEATH | READY
+│   ├── sprites.ts            # SWAP SEAM: textureFor() colored rects → real sprites later
+│   ├── factory.ts            # buildScene(): LevelEntity[] → Arcade bodies/groups
+│   └── PlatformerScene.ts    # init/preload/create/update: input, triggers, camera FX
+├── _engine/                  # Pure TS, no Phaser/React — unit-tested
+│   ├── constants.ts          # TILE, WIDTH, HEIGHT, GRAVITY, JUMP_VELOCITY, MOVE_SPEED, etc.
+│   ├── types.ts              # EntityType, LevelEntity, LevelManifestEntry, TiledObject
+│   └── triggers.ts           # Proximity math: getActivatedEntities(entities, px, py)
+├── _levels/
+│   ├── parse.ts              # parseTiledObjects(): Tiled JSON objects → LevelEntity[]
+│   ├── validate.ts           # validateEntities(): checks one start + one exit + bounds
+│   └── manifest.ts           # LEVELS[]: 10 ordered { id, key, name, url } entries
+├── _progress/
+│   └── cookie.ts             # getProgress() / setPassed(id) / unlockedLevels() via cookie
+└── public/
+    ├── favicon.svg
+    └── levels/               # Tiled JSON maps loaded at runtime by Phaser loader
+        └── level-01.json … level-10.json
+```
+
+## Level Format (Tiled JSON)
+
+Levels are **Tiled JSON maps** in `public/levels/`. Loaded via Phaser's `load.tilemapTiledJSON` → `make.tilemap` → `getObjectLayer('entities')`. No tileset image needed — all objects are rectangle objects on a single `entities` layer.
+
+**Map dimensions**: `width: 32, height: 18, tilewidth: 60, tileheight: 60` → 1920×1080 px canvas. Coordinates are pixels, origin top-left.
+
+### EntityType values (Tiled object `type` / class field)
+
+| type           | description                                     | custom properties                                       |
+| -------------- | ----------------------------------------------- | ------------------------------------------------------- |
+| `solid`        | Static block, no physics passthrough            | —                                                       |
+| `start`        | Player spawn point (one per level)              | —                                                       |
+| `exit`         | Level exit, green (one per level)               | —                                                       |
+| `disappearing` | Vanishes permanently when player enters radius  | `radius: int` (px)                                      |
+| `mover`        | Slides once to target when player enters radius | `toX: int`, `toY: int`, `radius: int`, `rideable: bool` |
+| `platform`     | Continuous patrol, always rideable              | `toX: int`, `toY: int`, `speed: int` (px/s)             |
+| `hazard`       | Kills on touch, static                          | `hazardKind: "spike" \| "lava"`                         |
+| `movingHazard` | Kills on touch, patrols                         | `toX: int`, `toY: int`, `speed: int`                    |
+| `decoration`   | Visual only, no collision                       | `color: string` (optional)                              |
+
+### How to add a level
+
+1. Author the map in [Tiled editor](https://www.mapeditor.org/) at 32×18 tiles, 60px each — OR hand-write the JSON.
+2. Place all objects on an object layer named **`entities`**.
+3. Export as JSON to `again/public/levels/level-NN.json`.
+4. Register in `again/_levels/manifest.ts` — append to the `LEVELS` array.
+5. Stay within physics reach limits (from `_engine/constants.ts`):
+   - `MAX_JUMP_HEIGHT` ≈ 225 px (~3.7 tiles vertical)
+   - `MAX_GAP` ≈ 300 px (~5 tiles horizontal at full speed)
+6. Ensure exactly one `start` and one `exit` entity (validated by `_levels/validate.ts`).
+
+## Sprite-swap seam
+
+**`again/_game/sprites.ts`** — `textureFor(scene, type, w, h)` is the single seam between colored shapes and real sprites.
+
+- **Now**: generates a solid-color `generateTexture` per `type` (e.g. solid=slate, exit=green, hazard=red).
+- **Later**: replace the body of `textureFor` with `scene.textures.get(key)` after adding `load.image/atlas` calls in `PlatformerScene.preload()` — keyed by the same `type` strings. No factory, scene-logic, or level data changes.
+
+## Commands
+
+```bash
+bun run dev          # dev server at http://localhost:3004
+bun run build        # tsc + vite build → dist/
+bun run preview      # serve dist/ at port 3004
+bun run prod         # build + preview
+bun run test         # Playwright e2e (from monorepo root)
+bun run test:unit    # Vitest unit tests (run once)
+bun run test:unit:watch  # Vitest watch mode
+```
+
+## Gotchas
+
+- **Moving bodies must use `setVelocity`, NOT tweens.** Phaser Arcade's auto-carry (player riding a platform) only works when the platform is `setImmovable(true)` and driven by `setVelocity`. Tweening breaks the carry.
+- **World bounds bottom is intentionally open.** `physics.world.setBoundsCollision(true, true, true, false)` — falling off the bottom kills the player; left/right/top are solid walls.
+- **Object layers need no tileset image.** Only tile layers require `addTilesetImage`. Calling it for object-only maps throws an error.
+- **`scene.restart` is used for respawn.** On death the scene restarts (re-runs `preload` → `create`), which resets all entity state. This guarantees levels are never unwinnable after dying.
+- **`clearTextureCache()`** should be called before re-creating the Phaser game instance to avoid stale texture keys across React remounts.
+- **Cookie not localStorage.** Progress is stored in `document.cookie` (user's choice). See `_progress/cookie.ts`.
+- **Phaser 3, not 4.** Phaser 4.1 exists (released Apr 2026) but 3.90 was chosen for stability and wider AI/documentation coverage. Upgrading is a one-line dep change — same API.

--- a/again/_engine/constants.ts
+++ b/again/_engine/constants.ts
@@ -1,0 +1,16 @@
+export const TILE = 60;
+export const WIDTH = 1920;
+export const HEIGHT = 1080;
+export const GRAVITY = 600;
+export const JUMP_VELOCITY = -520;
+export const MOVE_SPEED = 300;
+export const MIN_SCREEN_PX = 1024;
+export const COYOTE_TIME = 80;
+export const JUMP_BUFFER_TIME = 100;
+// derived reach limits — author all levels within these
+export const MAX_JUMP_HEIGHT = Math.round(
+  (JUMP_VELOCITY * JUMP_VELOCITY) / (2 * GRAVITY)
+); // px
+export const MAX_GAP = Math.round(
+  (MOVE_SPEED * 2 * Math.abs(JUMP_VELOCITY)) / GRAVITY
+); // px

--- a/again/_engine/triggers.test.ts
+++ b/again/_engine/triggers.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { getActivatedEntities, distancePx } from './triggers';
+import type { LevelEntity } from './types';
+
+describe('distancePx', () => {
+  it('returns 0 for same point', () => expect(distancePx(0, 0, 0, 0)).toBe(0));
+  it('returns 5 for 3-4-5 triangle', () =>
+    expect(distancePx(0, 0, 3, 4)).toBe(5));
+});
+
+describe('getActivatedEntities', () => {
+  const disappearing: LevelEntity = {
+    type: 'disappearing',
+    x: 100,
+    y: 100,
+    w: 60,
+    h: 60,
+    radius: 120,
+  };
+  const mover: LevelEntity = {
+    type: 'mover',
+    x: 400,
+    y: 100,
+    w: 60,
+    h: 60,
+    radius: 90,
+    toX: 600,
+    toY: 100,
+  };
+  const solid: LevelEntity = { type: 'solid', x: 0, y: 200, w: 1920, h: 60 };
+
+  it('activates disappearing block when player within radius', () => {
+    // entity center = (130,130), radius=120 → player at (130,130) is distance 0
+    const result = getActivatedEntities([disappearing], 130, 130);
+    expect(result).toContain(disappearing);
+  });
+
+  it('does not activate when player outside radius', () => {
+    // distance from (130,130) to (400,400) >> 120
+    const result = getActivatedEntities([disappearing], 400, 400);
+    expect(result).not.toContain(disappearing);
+  });
+
+  it('activates mover within its radius', () => {
+    // mover center = (430,130), radius=90 → player at (430,130) is distance 0
+    const result = getActivatedEntities([mover], 430, 130);
+    expect(result).toContain(mover);
+  });
+
+  it('ignores solid entities regardless of distance', () => {
+    const result = getActivatedEntities([solid], 30, 230);
+    expect(result).toHaveLength(0);
+  });
+
+  it('activates at exactly the radius boundary', () => {
+    // entity center = (130,130), radius=120 → player at (130+120,130) = distance 120
+    const result = getActivatedEntities([disappearing], 250, 130);
+    expect(result).toContain(disappearing);
+  });
+
+  it('does not activate just outside radius', () => {
+    // player at (130+121,130) = distance 121 > 120
+    const result = getActivatedEntities([disappearing], 251, 130);
+    expect(result).not.toContain(disappearing);
+  });
+});

--- a/again/_engine/triggers.ts
+++ b/again/_engine/triggers.ts
@@ -1,0 +1,28 @@
+import { LevelEntity } from './types';
+
+export function distancePx(
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number
+): number {
+  return Math.sqrt((ax - bx) ** 2 + (ay - by) ** 2);
+}
+
+/** Returns entities (disappearing/mover) whose trigger radius the player center is within. */
+export function getActivatedEntities(
+  entities: LevelEntity[],
+  playerCenterX: number,
+  playerCenterY: number
+): LevelEntity[] {
+  return entities.filter((e) => {
+    if (e.type !== 'disappearing' && e.type !== 'mover') return false;
+    if (e.radius == null) return false;
+    const entityCenterX = e.x + e.w / 2;
+    const entityCenterY = e.y + e.h / 2;
+    return (
+      distancePx(playerCenterX, playerCenterY, entityCenterX, entityCenterY) <=
+      e.radius
+    );
+  });
+}

--- a/again/_engine/types.ts
+++ b/again/_engine/types.ts
@@ -1,0 +1,49 @@
+export type EntityType =
+  | 'solid'
+  | 'disappearing'
+  | 'mover'
+  | 'platform'
+  | 'hazard'
+  | 'movingHazard'
+  | 'decoration'
+  | 'start'
+  | 'exit';
+
+export interface LevelEntity {
+  type: EntityType;
+  x: number; // px, top-left
+  y: number;
+  w: number;
+  h: number;
+  // optional per-type props
+  toX?: number;
+  toY?: number;
+  radius?: number;
+  speed?: number;
+  hazardKind?: 'spike' | 'lava';
+  rideable?: boolean;
+}
+
+export interface LevelManifestEntry {
+  id: number;
+  key: string; // e.g. 'level-01'
+  name: string;
+  url: string; // e.g. '/levels/level-01.json'
+}
+
+export interface TiledObject {
+  id: number;
+  name: string;
+  type: string; // Tiled "class" field
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  visible: boolean;
+  properties?: Array<{ name: string; type: string; value: unknown }>;
+}
+
+export interface TiledObjectLayer {
+  name: string;
+  objects: TiledObject[];
+}

--- a/again/_game/PlatformerScene.ts
+++ b/again/_game/PlatformerScene.ts
@@ -1,0 +1,297 @@
+import Phaser from 'phaser';
+import { GAME_EVENTS } from './events';
+import { buildScene, type SceneObjects } from './factory';
+import { getActivatedEntities } from '../_engine/triggers';
+import { parseTiledObjects } from '../_levels/parse';
+import type { LevelManifestEntry, LevelEntity } from '../_engine/types';
+import {
+  HEIGHT,
+  WIDTH,
+  JUMP_VELOCITY,
+  MOVE_SPEED,
+  COYOTE_TIME,
+  JUMP_BUFFER_TIME,
+} from '../_engine/constants';
+
+interface SceneInitData {
+  entry: LevelManifestEntry;
+}
+
+export class PlatformerScene extends Phaser.Scene {
+  private entry!: LevelManifestEntry;
+  private objects!: SceneObjects;
+  private allEntities: LevelEntity[] = [];
+
+  // input
+  private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
+  private wasd!: Record<string, Phaser.Input.Keyboard.Key>;
+
+  // coyote time + jump buffer
+  private coyoteTimer = 0;
+  private jumpBufferTimer = 0;
+
+  // one-shot tracking
+  private activatedIds = new Set<number>();
+  private dead = false;
+  private won = false;
+
+  constructor() {
+    super('PlatformerScene');
+  }
+
+  init(data: SceneInitData) {
+    this.entry = data.entry;
+    this.activatedIds.clear();
+    this.dead = false;
+    this.won = false;
+    this.coyoteTimer = 0;
+    this.jumpBufferTimer = 0;
+  }
+
+  preload() {
+    this.load.tilemapTiledJSON(this.entry.key, this.entry.url);
+  }
+
+  create() {
+    // parse map
+    const map = this.make.tilemap({ key: this.entry.key });
+    const layer = map.getObjectLayer('entities');
+    if (!layer)
+      throw new Error(`Map ${this.entry.key} missing 'entities' layer`);
+    this.allEntities = parseTiledObjects(
+      layer.objects as unknown as import('../_engine/types').TiledObject[]
+    );
+
+    // build scene
+    this.objects = buildScene(this, this.allEntities);
+    const { player, statics, movers, hazards, movingHazards, exitSprite } =
+      this.objects;
+
+    // world bounds — bottom open so falling kills
+    this.physics.world.setBounds(0, 0, WIDTH, HEIGHT);
+    this.physics.world.setBoundsCollision(true, true, true, false);
+
+    // colliders
+    this.physics.add.collider(player, statics);
+    this.physics.add.collider(player, this.objects.platformGroup);
+    this.physics.add.collider(player, movers);
+
+    // disappearing blocks collider (checked individually in update)
+    for (const d of this.objects.disappearingEntities) {
+      this.physics.add.collider(
+        player,
+        d.sprite as unknown as Phaser.Physics.Arcade.Image
+      );
+    }
+
+    // hazard overlaps → death
+    this.physics.add.overlap(player, hazards, () => this.triggerDeath());
+    this.physics.add.overlap(player, movingHazards, () => this.triggerDeath());
+
+    // exit overlap → win
+    this.physics.add.overlap(
+      player,
+      exitSprite as unknown as Phaser.Physics.Arcade.Image,
+      () => this.triggerWin()
+    );
+
+    // input
+    this.cursors = this.input.keyboard!.createCursorKeys();
+    this.wasd = this.input.keyboard!.addKeys('W,A,S,D,SPACE') as Record<
+      string,
+      Phaser.Input.Keyboard.Key
+    >;
+
+    // notify React the scene is ready
+    this.game.events.emit(GAME_EVENTS.READY);
+  }
+
+  update(_time: number, delta: number) {
+    if (this.dead || this.won) return;
+
+    const { player } = this.objects;
+    const body = player.body as Phaser.Physics.Arcade.Body;
+    const grounded = body.blocked.down;
+
+    // --- coyote time ---
+    if (grounded) {
+      this.coyoteTimer = COYOTE_TIME;
+    } else {
+      this.coyoteTimer = Math.max(0, this.coyoteTimer - delta);
+    }
+
+    // --- jump buffer ---
+    const jumpPressed =
+      Phaser.Input.Keyboard.JustDown(this.cursors.up) ||
+      Phaser.Input.Keyboard.JustDown(this.cursors.space) ||
+      Phaser.Input.Keyboard.JustDown(this.wasd['W']) ||
+      Phaser.Input.Keyboard.JustDown(this.wasd['SPACE']);
+
+    if (jumpPressed) this.jumpBufferTimer = JUMP_BUFFER_TIME;
+    else this.jumpBufferTimer = Math.max(0, this.jumpBufferTimer - delta);
+
+    // --- jump execution ---
+    if (this.jumpBufferTimer > 0 && (grounded || this.coyoteTimer > 0)) {
+      body.setVelocityY(JUMP_VELOCITY);
+      this.jumpBufferTimer = 0;
+      this.coyoteTimer = 0;
+    }
+
+    // --- horizontal movement ---
+    const left = this.cursors.left.isDown || this.wasd['A'].isDown;
+    const right = this.cursors.right.isDown || this.wasd['D'].isDown;
+    if (left) body.setVelocityX(-MOVE_SPEED);
+    else if (right) body.setVelocityX(MOVE_SPEED);
+    else body.setVelocityX(0);
+
+    // --- platform patrol (static bodies moved manually + carry player) ---
+    const playerBody = player.body as Phaser.Physics.Arcade.Body;
+    for (const p of this.objects.platformEntries) {
+      const e = p.entity;
+      const speed = (e.speed ?? 150) * (delta / 1000);
+      const startCX = e.x + e.w / 2;
+      const endCX = (e.toX ?? e.x) + e.w / 2;
+      const prevX = p.currentX;
+
+      p.currentX += p.dir * speed;
+      if (p.dir === 1 && p.currentX >= endCX) {
+        p.currentX = endCX;
+        p.dir = -1;
+      }
+      if (p.dir === -1 && p.currentX <= startCX) {
+        p.currentX = startCX;
+        p.dir = 1;
+      }
+
+      p.sprite.setPosition(p.currentX, p.currentY);
+      (p.sprite.body as Phaser.Physics.Arcade.StaticBody).reset(
+        p.currentX,
+        p.currentY
+      );
+
+      // carry player when standing on this platform
+      const dx = p.currentX - prevX;
+      if (dx !== 0 && playerBody.blocked.down) {
+        const platTop = p.currentY - e.h / 2;
+        const platLeft = p.currentX - e.w / 2;
+        const platRight = p.currentX + e.w / 2;
+        const playerBottom = player.y + playerBody.halfHeight;
+        if (
+          Math.abs(playerBottom - platTop) < 8 &&
+          player.x + playerBody.halfWidth > platLeft &&
+          player.x - playerBody.halfWidth < platRight
+        ) {
+          // Update both sprite AND body immediately so blocked.down stays
+          // true next frame (body position lags sprite by one step otherwise)
+          player.x += dx;
+          playerBody.position.x += dx;
+        }
+      }
+    }
+
+    // --- moving hazard patrol reversal ---
+    for (const mh of this.objects.movingHazards.getChildren() as Phaser.Physics.Arcade.Image[]) {
+      const e = mh.getData('entity') as LevelEntity;
+      if (!e.toX && !e.toY) continue;
+      const speed = e.speed ?? 150;
+      const dir = mh.getData('dir') as number;
+      const startX = e.x + e.w / 2;
+      const endX = e.toX !== undefined ? e.toX + e.w / 2 : startX;
+      if (dir === 1 && mh.x >= endX) {
+        mh.setData('dir', -1);
+        mh.setVelocityX(-speed);
+      } else if (dir === -1 && mh.x <= startX) {
+        mh.setData('dir', 1);
+        mh.setVelocityX(speed);
+      }
+    }
+
+    // --- proximity triggers ---
+    const px = player.x;
+    const py = player.y;
+    const unactivated = this.allEntities.filter(
+      (_e, i) => !this.activatedIds.has(i)
+    );
+    const triggered = getActivatedEntities(unactivated, px, py);
+
+    for (const e of triggered) {
+      const idx = this.allEntities.indexOf(e);
+      if (this.activatedIds.has(idx)) continue;
+      this.activatedIds.add(idx);
+
+      if (e.type === 'disappearing') {
+        const d = this.objects.disappearingEntities.find((d) => d.entity === e);
+        if (d) {
+          this.tweens.add({
+            targets: d.sprite,
+            alpha: 0,
+            duration: 150,
+            onComplete: () => {
+              const physBody = d.sprite
+                .body as Phaser.Physics.Arcade.StaticBody | null;
+              if (physBody) {
+                this.physics.world.remove(physBody);
+              }
+              d.sprite.setActive(false).setVisible(false);
+            },
+          });
+        }
+      }
+
+      if (e.type === 'mover') {
+        const m = this.objects.movers
+          .getChildren()
+          .find(
+            (child) =>
+              (child as Phaser.Physics.Arcade.Image).getData('entity') === e
+          ) as Phaser.Physics.Arcade.Image | undefined;
+        if (m && e.toX !== undefined) {
+          const speed = e.speed ?? MOVE_SPEED / 2;
+          const dx = e.toX + e.w / 2 - m.x;
+          const dy = e.toY !== undefined ? e.toY + e.h / 2 - m.y : 0;
+          const dist = Math.sqrt(dx * dx + dy * dy);
+          if (dist > 1) {
+            m.setVelocityX((dx / dist) * speed);
+            m.setVelocityY((dy / dist) * speed);
+            // stop when arrived
+            const targetX = e.toX + e.w / 2;
+            const targetY = e.toY !== undefined ? e.toY + e.h / 2 : m.y;
+            this.time.addEvent({
+              delay: (dist / speed) * 1000,
+              callback: () => {
+                m.setVelocity(0, 0);
+                m.setPosition(targetX, targetY);
+                (m.body as Phaser.Physics.Arcade.Body).reset(targetX, targetY);
+              },
+            });
+          }
+        }
+      }
+    }
+
+    // --- fall death ---
+    if (player.y > HEIGHT + 60) {
+      this.triggerDeath();
+    }
+  }
+
+  private triggerDeath() {
+    if (this.dead || this.won) return;
+    this.dead = true;
+    this.cameras.main.shake(200, 0.01);
+    this.cameras.main.flash(150, 255, 50, 50);
+    this.time.delayedCall(350, () => {
+      this.game.events.emit(GAME_EVENTS.DEATH);
+      this.scene.restart({ entry: this.entry });
+    });
+  }
+
+  private triggerWin() {
+    if (this.dead || this.won) return;
+    this.won = true;
+    this.cameras.main.fade(400, 0, 0, 0);
+    this.time.delayedCall(400, () => {
+      this.game.events.emit(GAME_EVENTS.WIN);
+    });
+  }
+}

--- a/again/_game/config.ts
+++ b/again/_game/config.ts
@@ -1,0 +1,24 @@
+import Phaser from 'phaser';
+import { WIDTH, HEIGHT, GRAVITY } from '../_engine/constants';
+
+export function createGameConfig(
+  parent: string | HTMLElement
+): Phaser.Types.Core.GameConfig {
+  return {
+    type: Phaser.AUTO,
+    width: WIDTH,
+    height: HEIGHT,
+    backgroundColor: '#1a1a2e',
+    parent,
+    physics: {
+      default: 'arcade',
+      arcade: { gravity: { x: 0, y: GRAVITY }, debug: false },
+    },
+    scale: {
+      mode: Phaser.Scale.FIT,
+      autoCenter: Phaser.Scale.CENTER_BOTH,
+    },
+    scene: [],
+    audio: { noAudio: true },
+  };
+}

--- a/again/_game/events.ts
+++ b/again/_game/events.ts
@@ -1,0 +1,7 @@
+export const GAME_EVENTS = {
+  WIN: 'win',
+  DEATH: 'death',
+  READY: 'ready',
+} as const;
+
+export type GameEventName = (typeof GAME_EVENTS)[keyof typeof GAME_EVENTS];

--- a/again/_game/factory.ts
+++ b/again/_game/factory.ts
@@ -1,0 +1,152 @@
+import Phaser from 'phaser';
+import type { LevelEntity } from '../_engine/types';
+import { textureFor } from './sprites';
+
+export interface PlatformEntry {
+  sprite: Phaser.Physics.Arcade.Image;
+  entity: LevelEntity;
+  dir: number;
+  currentX: number;
+  currentY: number;
+}
+
+export interface SceneObjects {
+  player: Phaser.Physics.Arcade.Sprite;
+  statics: Phaser.Physics.Arcade.StaticGroup;
+  platformGroup: Phaser.Physics.Arcade.StaticGroup;
+  platformEntries: PlatformEntry[];
+  movers: Phaser.Physics.Arcade.Group;
+  hazards: Phaser.Physics.Arcade.StaticGroup;
+  movingHazards: Phaser.Physics.Arcade.Group;
+  disappearingEntities: Array<{
+    entity: LevelEntity;
+    sprite: Phaser.GameObjects.Image;
+  }>;
+  exitSprite: Phaser.GameObjects.Image;
+  startPos: { x: number; y: number };
+}
+
+export function buildScene(
+  scene: Phaser.Scene,
+  entities: LevelEntity[]
+): SceneObjects {
+  const statics = scene.physics.add.staticGroup();
+  const platformGroup = scene.physics.add.staticGroup();
+  const platformEntries: PlatformEntry[] = [];
+  const movers = scene.physics.add.group({ allowGravity: false });
+  const hazards = scene.physics.add.staticGroup();
+  const movingHazards = scene.physics.add.group({ allowGravity: false });
+  const disappearingEntities: SceneObjects['disappearingEntities'] = [];
+  let exitSprite!: Phaser.GameObjects.Image;
+  let startPos = { x: 120, y: 900 };
+
+  for (const e of entities) {
+    const cx = e.x + e.w / 2;
+    const cy = e.y + e.h / 2;
+
+    switch (e.type) {
+      case 'start':
+        startPos = { x: cx, y: cy };
+        break;
+
+      case 'exit': {
+        const tex = textureFor(scene, 'exit', e.w, e.h);
+        exitSprite = scene.add.image(cx, cy, tex);
+        scene.physics.add.existing(exitSprite, true);
+        break;
+      }
+
+      case 'solid': {
+        const tex = textureFor(scene, 'solid', e.w, e.h);
+        const s = statics.create(cx, cy, tex) as Phaser.Physics.Arcade.Image;
+        s.setImmovable(true);
+        s.refreshBody();
+        break;
+      }
+
+      case 'disappearing': {
+        const tex = textureFor(scene, 'disappearing', e.w, e.h);
+        const img = scene.add.image(cx, cy, tex);
+        scene.physics.add.existing(img, true);
+        disappearingEntities.push({ entity: e, sprite: img });
+        break;
+      }
+
+      case 'mover': {
+        const tex = textureFor(scene, 'mover', e.w, e.h);
+        const body = scene.physics.add.image(cx, cy, tex);
+        body.setImmovable(true);
+        (body.body as Phaser.Physics.Arcade.Body).allowGravity = false;
+        // store entity data on the image for update logic
+        body.setData('entity', e);
+        body.setData('activated', false);
+        movers.add(body);
+        break;
+      }
+
+      case 'platform': {
+        const tex = textureFor(scene, 'platform', e.w, e.h);
+        const sprite = platformGroup.create(
+          cx,
+          cy,
+          tex
+        ) as Phaser.Physics.Arcade.Image;
+        sprite.refreshBody();
+        platformEntries.push({
+          sprite,
+          entity: e,
+          dir: 1,
+          currentX: cx,
+          currentY: cy,
+        });
+        break;
+      }
+
+      case 'hazard': {
+        const tex = textureFor(scene, 'hazard', e.w, e.h);
+        const h = hazards.create(cx, cy, tex) as Phaser.Physics.Arcade.Image;
+        h.setImmovable(true);
+        h.refreshBody();
+        break;
+      }
+
+      case 'movingHazard': {
+        const tex = textureFor(scene, 'movingHazard', e.w, e.h);
+        const body = scene.physics.add.image(cx, cy, tex);
+        body.setImmovable(true);
+        (body.body as Phaser.Physics.Arcade.Body).allowGravity = false;
+        body.setData('entity', e);
+        body.setData('dir', 1);
+        const speed = e.speed ?? 150;
+        body.setVelocityX(speed);
+        movingHazards.add(body);
+        break;
+      }
+
+      case 'decoration': {
+        const tex = textureFor(scene, 'decoration', e.w, e.h);
+        scene.add.image(cx, cy, tex).setAlpha(0.5);
+        break;
+      }
+    }
+  }
+
+  // Player
+  const playerTex = textureFor(scene, 'player', 40, 48);
+  const player = scene.physics.add.sprite(startPos.x, startPos.y, playerTex);
+  player.setCollideWorldBounds(true);
+  (player.body as Phaser.Physics.Arcade.Body).setSize(36, 44);
+
+  return {
+    player,
+    statics,
+    platformGroup,
+    platformEntries,
+    movers,
+    hazards,
+    movingHazards,
+    disappearingEntities,
+    exitSprite,
+    startPos,
+  };
+}

--- a/again/_game/sprites.ts
+++ b/again/_game/sprites.ts
@@ -1,0 +1,40 @@
+import Phaser from 'phaser';
+import type { EntityType } from '../_engine/types';
+
+const COLOR_MAP: Record<EntityType | 'player', number> = {
+  solid: 0x64748b, // slate
+  disappearing: 0xf59e0b, // amber
+  mover: 0x3b82f6, // blue
+  platform: 0x60a5fa, // lighter blue
+  hazard: 0xef4444, // red
+  movingHazard: 0xdc2626, // darker red
+  decoration: 0x6b7280, // gray
+  start: 0x22c55e, // green (not drawn)
+  exit: 0x22c55e, // green
+  player: 0xf8fafc, // white
+};
+
+const textureCache = new Set<string>();
+
+export function textureFor(
+  scene: Phaser.Scene,
+  type: EntityType | 'player',
+  w: number,
+  h: number
+): string {
+  const key = `${type}_${w}_${h}`;
+  if (!textureCache.has(key)) {
+    const color = COLOR_MAP[type] ?? 0x888888;
+    const gfx = scene.add.graphics();
+    gfx.fillStyle(color, 1);
+    gfx.fillRect(0, 0, w, h);
+    gfx.generateTexture(key, w, h);
+    gfx.destroy();
+    textureCache.add(key);
+  }
+  return key;
+}
+
+export function clearTextureCache(): void {
+  textureCache.clear();
+}

--- a/again/_levels/manifest.ts
+++ b/again/_levels/manifest.ts
@@ -1,0 +1,41 @@
+import type { LevelManifestEntry } from '../_engine/types';
+
+export const LEVELS: LevelManifestEntry[] = [
+  { id: 1, key: 'level-01', name: 'First Steps', url: '/levels/level-01.json' },
+  { id: 2, key: 'level-02', name: 'Moving On', url: '/levels/level-02.json' },
+  {
+    id: 3,
+    key: 'level-03',
+    name: 'Now You See Me',
+    url: '/levels/level-03.json',
+  },
+  {
+    id: 4,
+    key: 'level-04',
+    name: 'Bridge Builder',
+    url: '/levels/level-04.json',
+  },
+  { id: 5, key: 'level-05', name: 'Spike Zone', url: '/levels/level-05.json' },
+  { id: 6, key: 'level-06', name: 'Lava Flow', url: '/levels/level-06.json' },
+  {
+    id: 7,
+    key: 'level-07',
+    name: 'Danger Patrol',
+    url: '/levels/level-07.json',
+  },
+  {
+    id: 8,
+    key: 'level-08',
+    name: 'Fade and Shift',
+    url: '/levels/level-08.json',
+  },
+  { id: 9, key: 'level-09', name: 'Gauntlet', url: '/levels/level-09.json' },
+  {
+    id: 10,
+    key: 'level-10',
+    name: 'The Final Run',
+    url: '/levels/level-10.json',
+  },
+];
+
+export const TOTAL_LEVELS = LEVELS.length;

--- a/again/_levels/parse.test.ts
+++ b/again/_levels/parse.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { parseTiledObject, parseTiledObjects } from './parse';
+import type { TiledObject } from '../_engine/types';
+
+const solidObj: TiledObject = {
+  id: 1,
+  name: '',
+  type: 'solid',
+  x: 0,
+  y: 960,
+  width: 1920,
+  height: 60,
+  visible: true,
+};
+const disappearingObj: TiledObject = {
+  id: 2,
+  name: '',
+  type: 'disappearing',
+  x: 300,
+  y: 600,
+  width: 60,
+  height: 60,
+  visible: true,
+  properties: [{ name: 'radius', type: 'int', value: 150 }],
+};
+const moverObj: TiledObject = {
+  id: 3,
+  name: '',
+  type: 'mover',
+  x: 600,
+  y: 600,
+  width: 60,
+  height: 60,
+  visible: true,
+  properties: [
+    { name: 'toX', type: 'int', value: 900 },
+    { name: 'toY', type: 'int', value: 600 },
+    { name: 'radius', type: 'int', value: 120 },
+    { name: 'rideable', type: 'bool', value: true },
+  ],
+};
+
+describe('parseTiledObject', () => {
+  it('parses solid with no properties', () => {
+    const e = parseTiledObject(solidObj);
+    expect(e.type).toBe('solid');
+    expect(e.x).toBe(0);
+    expect(e.w).toBe(1920);
+    expect(e.radius).toBeUndefined();
+  });
+
+  it('parses disappearing radius', () => {
+    const e = parseTiledObject(disappearingObj);
+    expect(e.type).toBe('disappearing');
+    expect(e.radius).toBe(150);
+  });
+
+  it('parses mover with all props', () => {
+    const e = parseTiledObject(moverObj);
+    expect(e.type).toBe('mover');
+    expect(e.toX).toBe(900);
+    expect(e.toY).toBe(600);
+    expect(e.rideable).toBe(true);
+  });
+});
+
+describe('parseTiledObjects', () => {
+  it('maps array correctly', () => {
+    const result = parseTiledObjects([solidObj, disappearingObj]);
+    expect(result).toHaveLength(2);
+    expect(result[0].type).toBe('solid');
+    expect(result[1].type).toBe('disappearing');
+  });
+});

--- a/again/_levels/parse.ts
+++ b/again/_levels/parse.ts
@@ -1,0 +1,42 @@
+import type { LevelEntity, EntityType, TiledObject } from '../_engine/types';
+
+function getProp<T>(
+  properties: TiledObject['properties'],
+  name: string
+): T | undefined {
+  return properties?.find((p) => p.name === name)?.value as T | undefined;
+}
+
+export function parseTiledObject(obj: TiledObject): LevelEntity {
+  const props = obj.properties ?? [];
+  const type = obj.type as EntityType;
+  return {
+    type,
+    x: obj.x,
+    y: obj.y,
+    w: obj.width,
+    h: obj.height,
+    ...(getProp<number>(props, 'toX') !== undefined && {
+      toX: getProp<number>(props, 'toX'),
+    }),
+    ...(getProp<number>(props, 'toY') !== undefined && {
+      toY: getProp<number>(props, 'toY'),
+    }),
+    ...(getProp<number>(props, 'radius') !== undefined && {
+      radius: getProp<number>(props, 'radius'),
+    }),
+    ...(getProp<number>(props, 'speed') !== undefined && {
+      speed: getProp<number>(props, 'speed'),
+    }),
+    ...(getProp<string>(props, 'hazardKind') !== undefined && {
+      hazardKind: getProp<string>(props, 'hazardKind') as 'spike' | 'lava',
+    }),
+    ...(getProp<boolean>(props, 'rideable') !== undefined && {
+      rideable: getProp<boolean>(props, 'rideable'),
+    }),
+  };
+}
+
+export function parseTiledObjects(objects: TiledObject[]): LevelEntity[] {
+  return objects.map(parseTiledObject);
+}

--- a/again/_levels/validate.test.ts
+++ b/again/_levels/validate.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { validateEntities } from './validate';
+import type { LevelEntity } from '../_engine/types';
+
+const floor: LevelEntity = { type: 'solid', x: 0, y: 1020, w: 1920, h: 60 };
+const start: LevelEntity = { type: 'start', x: 60, y: 960, w: 60, h: 60 };
+const exit: LevelEntity = { type: 'exit', x: 1800, y: 960, w: 60, h: 60 };
+
+describe('validateEntities', () => {
+  it('passes a valid level', () => {
+    const r = validateEntities([floor, start, exit]);
+    expect(r.valid).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('fails with no start', () => {
+    const r = validateEntities([floor, exit]);
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes('start'))).toBe(true);
+  });
+
+  it('fails with no exit', () => {
+    const r = validateEntities([floor, start]);
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes('exit'))).toBe(true);
+  });
+
+  it('fails with out-of-bounds entity', () => {
+    const oob: LevelEntity = { type: 'solid', x: 1900, y: 0, w: 120, h: 60 }; // x+w=2020 > 1920
+    const r = validateEntities([oob, start, exit]);
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes('out of bounds'))).toBe(true);
+  });
+
+  it('fails with two starts', () => {
+    const r = validateEntities([floor, start, start, exit]);
+    expect(r.valid).toBe(false);
+  });
+});

--- a/again/_levels/validate.ts
+++ b/again/_levels/validate.ts
@@ -1,0 +1,24 @@
+import type { LevelEntity } from '../_engine/types';
+import { WIDTH, HEIGHT } from '../_engine/constants';
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export function validateEntities(entities: LevelEntity[]): ValidationResult {
+  const errors: string[] = [];
+  const starts = entities.filter((e) => e.type === 'start');
+  const exits = entities.filter((e) => e.type === 'exit');
+  if (starts.length !== 1)
+    errors.push(`Expected 1 start, got ${starts.length}`);
+  if (exits.length !== 1) errors.push(`Expected 1 exit, got ${exits.length}`);
+  for (const e of entities) {
+    if (e.x < 0 || e.y < 0 || e.x + e.w > WIDTH || e.y + e.h > HEIGHT) {
+      errors.push(
+        `Entity type=${e.type} at (${e.x},${e.y}) w=${e.w} h=${e.h} out of bounds`
+      );
+    }
+  }
+  return { valid: errors.length === 0, errors };
+}

--- a/again/_progress/cookie.test.ts
+++ b/again/_progress/cookie.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock document.cookie with a simple in-memory store
+let cookieStore = '';
+vi.stubGlobal('document', {
+  get cookie() {
+    return cookieStore;
+  },
+  set cookie(val: string) {
+    // parse and store (simplified)
+    const [pair] = val.split(';');
+    const [key, value] = pair.split('=');
+    const existing = cookieStore
+      .split(';')
+      .filter((s) => !s.trim().startsWith(`${key.trim()}=`));
+    cookieStore = [
+      ...existing.filter(Boolean),
+      `${key.trim()}=${value?.trim() ?? ''}`,
+    ].join('; ');
+  },
+});
+
+import { getProgress, setPassed, unlockedLevels } from './cookie';
+
+beforeEach(() => {
+  cookieStore = '';
+});
+
+describe('getProgress', () => {
+  it('returns 0 when no cookie', () => {
+    expect(getProgress().maxLevelPassed).toBe(0);
+  });
+});
+
+describe('setPassed', () => {
+  it('updates maxLevelPassed', () => {
+    setPassed(3);
+    expect(getProgress().maxLevelPassed).toBe(3);
+  });
+
+  it('does not lower maxLevelPassed', () => {
+    setPassed(5);
+    setPassed(2);
+    expect(getProgress().maxLevelPassed).toBe(5);
+  });
+});
+
+describe('unlockedLevels', () => {
+  it('returns [1] when nothing passed', () => {
+    expect(unlockedLevels(10)).toEqual([1]);
+  });
+
+  it('returns 1..passed+1 when levels passed', () => {
+    setPassed(3);
+    expect(unlockedLevels(10)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('caps at totalLevels', () => {
+    setPassed(10);
+    expect(unlockedLevels(10)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+});

--- a/again/_progress/cookie.ts
+++ b/again/_progress/cookie.ts
@@ -1,0 +1,42 @@
+const COOKIE_KEY = 'again_progress';
+const EXPIRY_DAYS = 365;
+
+function setCookie(value: string): void {
+  const expires = new Date(Date.now() + EXPIRY_DAYS * 864e5).toUTCString();
+  document.cookie = `${COOKIE_KEY}=${encodeURIComponent(value)}; expires=${expires}; path=/; SameSite=Lax`;
+}
+
+function getCookie(): string | null {
+  const match = document.cookie
+    .split(';')
+    .map((s) => s.trim())
+    .find((s) => s.startsWith(`${COOKIE_KEY}=`));
+  return match ? decodeURIComponent(match.slice(COOKIE_KEY.length + 1)) : null;
+}
+
+export interface Progress {
+  maxLevelPassed: number;
+}
+
+export function getProgress(): Progress {
+  try {
+    const raw = getCookie();
+    if (!raw) return { maxLevelPassed: 0 };
+    return JSON.parse(raw) as Progress;
+  } catch {
+    return { maxLevelPassed: 0 };
+  }
+}
+
+export function setPassed(levelId: number): void {
+  const current = getProgress();
+  if (levelId > current.maxLevelPassed) {
+    setCookie(JSON.stringify({ maxLevelPassed: levelId }));
+  }
+}
+
+export function unlockedLevels(totalLevels: number): number[] {
+  const { maxLevelPassed } = getProgress();
+  const max = Math.min(maxLevelPassed + 1, totalLevels);
+  return Array.from({ length: max }, (_, i) => i + 1);
+}

--- a/again/app/Game.tsx
+++ b/again/app/Game.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import Phaser from 'phaser';
+import { createGameConfig } from '../_game/config';
+import { GAME_EVENTS } from '../_game/events';
+import { PlatformerScene } from '../_game/PlatformerScene';
+import { clearTextureCache } from '../_game/sprites';
+import { LEVELS, TOTAL_LEVELS } from '../_levels/manifest';
+import { setPassed } from '../_progress/cookie';
+import { MIN_SCREEN_PX } from '../_engine/constants';
+import WinPopup from './_components/WinPopup';
+import SmallScreenOverlay from './_components/SmallScreenOverlay';
+import Hud from './_components/Hud';
+
+export default function Game() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const gameRef = useRef<Phaser.Game | null>(null);
+  const [showWin, setShowWin] = useState(false);
+  const [smallScreen, setSmallScreen] = useState(
+    window.innerWidth < MIN_SCREEN_PX
+  );
+
+  const levelId = parseInt(id ?? '1', 10);
+  const entry = LEVELS.find((l) => l.id === levelId) ?? LEVELS[0];
+
+  const destroyGame = useCallback(() => {
+    if (gameRef.current) {
+      gameRef.current.destroy(true);
+      gameRef.current = null;
+    }
+  }, []);
+
+  const handleHome = useCallback(() => {
+    destroyGame();
+    navigate('/');
+  }, [destroyGame, navigate]);
+
+  const handleNext = useCallback(() => {
+    setPassed(levelId);
+    destroyGame();
+    if (levelId >= TOTAL_LEVELS) {
+      navigate('/');
+    } else {
+      navigate(`/play/${levelId + 1}`);
+    }
+  }, [levelId, destroyGame, navigate]);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    setShowWin(false);
+
+    clearTextureCache();
+    const game = new Phaser.Game(createGameConfig(containerRef.current));
+    gameRef.current = game;
+
+    game.events.on(GAME_EVENTS.WIN, () => {
+      setPassed(levelId);
+      setShowWin(true);
+    });
+
+    // Add and start the scene with entry data — must happen after boot so the
+    // scene manager exists. scene[] is empty in config to prevent auto-start
+    // with no init data (which would crash in preload with undefined key).
+    game.events.once('ready', () => {
+      game.scene.add('PlatformerScene', PlatformerScene, false);
+      game.scene.start('PlatformerScene', { entry });
+    });
+
+    const handleResize = () =>
+      setSmallScreen(window.innerWidth < MIN_SCREEN_PX);
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      if (gameRef.current) {
+        gameRef.current.destroy(true);
+        gameRef.current = null;
+      }
+    };
+  }, [entry.key]); // restart when level key changes
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        width: '100vw',
+        height: '100vh',
+        background: '#0f0f1a',
+        overflow: 'hidden',
+      }}
+    >
+      <div ref={containerRef} style={{ width: '100%', height: '100%' }} />
+      <Hud levelName={entry.name} onBack={handleHome} />
+      <SmallScreenOverlay show={smallScreen} />
+      {showWin && (
+        <WinPopup
+          levelId={levelId}
+          totalLevels={TOTAL_LEVELS}
+          onNext={handleNext}
+          onHome={handleHome}
+        />
+      )}
+    </div>
+  );
+}

--- a/again/app/Home.tsx
+++ b/again/app/Home.tsx
@@ -1,0 +1,82 @@
+import { useNavigate } from 'react-router-dom';
+import { getProgress, unlockedLevels } from '../_progress/cookie';
+import { TOTAL_LEVELS } from '../_levels/manifest';
+
+export default function Home() {
+  const navigate = useNavigate();
+  const { maxLevelPassed } = getProgress();
+  const unlocked = unlockedLevels(TOTAL_LEVELS);
+  const nextLevel = unlocked[unlocked.length - 1] ?? 1;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh',
+        background: '#0f0f1a',
+        color: '#f8fafc',
+        gap: '2rem',
+      }}
+    >
+      <h1
+        style={{
+          fontSize: '5rem',
+          fontWeight: 'bold',
+          letterSpacing: '0.1em',
+          margin: 0,
+          color: '#22c55e',
+        }}
+      >
+        again
+      </h1>
+      <p style={{ color: '#94a3b8', margin: 0 }}>a platformer</p>
+
+      <button
+        onClick={() => navigate(`/play/${nextLevel}`)}
+        style={{
+          padding: '0.75rem 3rem',
+          background: '#22c55e',
+          color: '#0f0f1a',
+          border: 'none',
+          borderRadius: '6px',
+          fontSize: '1.25rem',
+          fontWeight: 'bold',
+          cursor: 'pointer',
+        }}
+      >
+        {maxLevelPassed === 0 ? 'Play' : 'Continue'}
+      </button>
+
+      {maxLevelPassed >= 1 && (
+        <button
+          onClick={() => navigate('/levels')}
+          style={{
+            padding: '0.5rem 2rem',
+            background: 'transparent',
+            color: '#94a3b8',
+            border: '1px solid #94a3b8',
+            borderRadius: '6px',
+            fontSize: '1rem',
+            cursor: 'pointer',
+          }}
+        >
+          Level Select
+        </button>
+      )}
+
+      <div
+        style={{
+          position: 'absolute',
+          bottom: '1rem',
+          color: '#374151',
+          fontSize: '0.75rem',
+        }}
+      >
+        Arrow keys / WASD to move · Space / W / ↑ to jump
+      </div>
+    </div>
+  );
+}

--- a/again/app/LevelSelect.tsx
+++ b/again/app/LevelSelect.tsx
@@ -1,0 +1,82 @@
+import { useNavigate } from 'react-router-dom';
+import { unlockedLevels } from '../_progress/cookie';
+import { LEVELS, TOTAL_LEVELS } from '../_levels/manifest';
+
+export default function LevelSelect() {
+  const navigate = useNavigate();
+  const unlocked = new Set(unlockedLevels(TOTAL_LEVELS));
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        background: '#0f0f1a',
+        color: '#f8fafc',
+        gap: '2rem',
+        padding: '2rem',
+      }}
+    >
+      <h2 style={{ margin: 0, fontSize: '2rem', color: '#22c55e' }}>
+        Level Select
+      </h2>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(5, 1fr)',
+          gap: '1rem',
+          maxWidth: '600px',
+        }}
+      >
+        {LEVELS.map((level) => {
+          const isUnlocked = unlocked.has(level.id);
+          return (
+            <button
+              key={level.id}
+              disabled={!isUnlocked}
+              onClick={() => isUnlocked && navigate(`/play/${level.id}`)}
+              style={{
+                padding: '1rem 0.5rem',
+                background: isUnlocked ? '#1a1a2e' : '#111',
+                color: isUnlocked ? '#f8fafc' : '#374151',
+                border: `1px solid ${isUnlocked ? '#22c55e' : '#1f2937'}`,
+                borderRadius: '6px',
+                cursor: isUnlocked ? 'pointer' : 'default',
+                fontSize: '0.875rem',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: '0.25rem',
+              }}
+            >
+              <span style={{ fontWeight: 'bold' }}>{level.id}</span>
+              <span
+                style={{
+                  fontSize: '0.7rem',
+                  color: isUnlocked ? '#94a3b8' : '#1f2937',
+                }}
+              >
+                {level.name}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+      <button
+        onClick={() => navigate('/')}
+        style={{
+          background: 'transparent',
+          color: '#94a3b8',
+          border: 'none',
+          cursor: 'pointer',
+          textDecoration: 'underline',
+        }}
+      >
+        ← Back
+      </button>
+    </div>
+  );
+}

--- a/again/app/NotFound.tsx
+++ b/again/app/NotFound.tsx
@@ -1,0 +1,36 @@
+import { useNavigate } from 'react-router-dom';
+
+export default function NotFound() {
+  const navigate = useNavigate();
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh',
+        background: '#0f0f1a',
+        color: '#f8fafc',
+        gap: '1rem',
+      }}
+    >
+      <h1 style={{ fontSize: '3rem', margin: 0 }}>404</h1>
+      <p style={{ color: '#94a3b8' }}>Page not found</p>
+      <button
+        onClick={() => navigate('/')}
+        style={{
+          padding: '0.5rem 1.5rem',
+          background: '#22c55e',
+          color: '#0f0f1a',
+          border: 'none',
+          borderRadius: '4px',
+          cursor: 'pointer',
+          fontWeight: 'bold',
+        }}
+      >
+        Home
+      </button>
+    </div>
+  );
+}

--- a/again/app/_components/Hud.tsx
+++ b/again/app/_components/Hud.tsx
@@ -1,0 +1,43 @@
+interface HudProps {
+  levelName: string;
+  onBack: () => void;
+}
+
+export default function Hud({ levelName, onBack }: HudProps) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 50,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '0.5rem 1rem',
+        background: 'rgba(0,0,0,0.4)',
+        color: '#f8fafc',
+        fontSize: '0.875rem',
+        pointerEvents: 'none',
+      }}
+    >
+      <span style={{ color: '#94a3b8' }}>{levelName}</span>
+      <button
+        onClick={onBack}
+        style={{
+          pointerEvents: 'auto',
+          background: 'transparent',
+          color: '#94a3b8',
+          border: '1px solid #374151',
+          borderRadius: '4px',
+          padding: '0.25rem 0.75rem',
+          cursor: 'pointer',
+          fontSize: '0.75rem',
+        }}
+      >
+        ← Home
+      </button>
+    </div>
+  );
+}

--- a/again/app/_components/SmallScreenOverlay.tsx
+++ b/again/app/_components/SmallScreenOverlay.tsx
@@ -1,0 +1,32 @@
+interface SmallScreenOverlayProps {
+  show: boolean;
+}
+
+export default function SmallScreenOverlay({ show }: SmallScreenOverlayProps) {
+  if (!show) return null;
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: '#0f0f1a',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: '#f8fafc',
+        zIndex: 200,
+        gap: '1rem',
+        padding: '2rem',
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ fontSize: '3rem' }}>📺</div>
+      <h2 style={{ margin: 0, color: '#22c55e' }}>Screen Too Small</h2>
+      <p style={{ color: '#94a3b8', maxWidth: '360px' }}>
+        Please play on a wider screen — at least 1024px wide is recommended for
+        the best experience.
+      </p>
+    </div>
+  );
+}

--- a/again/app/_components/WinPopup.tsx
+++ b/again/app/_components/WinPopup.tsx
@@ -1,0 +1,80 @@
+interface WinPopupProps {
+  levelId: number;
+  totalLevels: number;
+  onNext: () => void;
+  onHome: () => void;
+}
+
+export default function WinPopup({
+  levelId,
+  totalLevels,
+  onNext,
+  onHome,
+}: WinPopupProps) {
+  const isLast = levelId >= totalLevels;
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        background: 'rgba(0,0,0,0.75)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 100,
+      }}
+    >
+      <div
+        style={{
+          background: '#1a1a2e',
+          border: '1px solid #22c55e',
+          borderRadius: '12px',
+          padding: '2.5rem 3rem',
+          textAlign: 'center',
+          color: '#f8fafc',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '1.5rem',
+        }}
+      >
+        <div style={{ fontSize: '3rem' }}>{isLast ? '🏆' : '🎉'}</div>
+        <h2 style={{ margin: 0, fontSize: '1.75rem', color: '#22c55e' }}>
+          {isLast ? 'You Beat the Game!' : 'Level Complete!'}
+        </h2>
+        {!isLast && (
+          <p style={{ margin: 0, color: '#94a3b8' }}>Level {levelId} cleared</p>
+        )}
+        <button
+          onClick={isLast ? onHome : onNext}
+          style={{
+            padding: '0.75rem 2rem',
+            background: '#22c55e',
+            color: '#0f0f1a',
+            border: 'none',
+            borderRadius: '6px',
+            fontSize: '1.1rem',
+            fontWeight: 'bold',
+            cursor: 'pointer',
+          }}
+        >
+          {isLast ? 'Return Home' : 'Next Level →'}
+        </button>
+        {!isLast && (
+          <button
+            onClick={onHome}
+            style={{
+              background: 'transparent',
+              color: '#94a3b8',
+              border: 'none',
+              cursor: 'pointer',
+              fontSize: '0.875rem',
+              textDecoration: 'underline',
+            }}
+          >
+            Home
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/again/app/globals.css
+++ b/again/app/globals.css
@@ -1,0 +1,23 @@
+@import 'tailwindcss';
+
+@theme {
+  --color-game-bg: #0f0f1a;
+  --color-game-surface: #1a1a2e;
+  --color-game-accent: #22c55e;
+  --color-game-text: #f8fafc;
+  --color-game-muted: #94a3b8;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #0f0f1a;
+  color: #f8fafc;
+  font-family: system-ui, sans-serif;
+  overflow: hidden;
+}

--- a/again/index.html
+++ b/again/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>again</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/again/package.json
+++ b/again/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "again",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite --port 3004 --strictPort",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --port 3004 --strictPort",
+    "prod": "bun run build && bun run preview",
+    "test": "cd .. && bun playwright test tests/again",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest"
+  },
+  "dependencies": {
+    "phaser": "^3.90.0"
+  },
+  "devDependencies": {
+    "vitest": "^3.0.0"
+  }
+}

--- a/again/public/favicon.svg
+++ b/again/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#0f0f1a"/>
+  <rect x="8" y="8" width="16" height="16" fill="#22c55e"/>
+</svg>

--- a/again/public/levels/level-01.json
+++ b/again/public/levels/level-01.json
@@ -1,0 +1,110 @@
+{
+  "width": 32,
+  "height": 18,
+  "tilewidth": 60,
+  "tileheight": 60,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "version": "1.10",
+  "type": "map",
+  "layers": [
+    {
+      "type": "objectgroup",
+      "name": "entities",
+      "objects": [
+        {
+          "id": 1,
+          "name": "",
+          "type": "solid",
+          "x": 0,
+          "y": 1020,
+          "width": 600,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 2,
+          "name": "",
+          "type": "solid",
+          "x": 720,
+          "y": 1020,
+          "width": 1200,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 3,
+          "name": "",
+          "type": "solid",
+          "x": 1860,
+          "y": 1020,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 4,
+          "name": "",
+          "type": "solid",
+          "x": 360,
+          "y": 840,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 5,
+          "name": "",
+          "type": "solid",
+          "x": 900,
+          "y": 900,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 6,
+          "name": "",
+          "type": "solid",
+          "x": 1380,
+          "y": 840,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 7,
+          "name": "",
+          "type": "start",
+          "x": 60,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 8,
+          "name": "",
+          "type": "exit",
+          "x": 1800,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        }
+      ]
+    }
+  ],
+  "tilesets": [],
+  "nextlayerid": 2,
+  "nextobjectid": 9,
+  "infinite": false
+}

--- a/again/public/levels/level-02.json
+++ b/again/public/levels/level-02.json
@@ -1,0 +1,94 @@
+{
+  "width": 32,
+  "height": 18,
+  "tilewidth": 60,
+  "tileheight": 60,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "version": "1.10",
+  "type": "map",
+  "layers": [
+    {
+      "type": "objectgroup",
+      "name": "entities",
+      "objects": [
+        {
+          "id": 1,
+          "name": "",
+          "type": "solid",
+          "x": 0,
+          "y": 1020,
+          "width": 780,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 2,
+          "name": "",
+          "type": "solid",
+          "x": 1080,
+          "y": 1020,
+          "width": 840,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 3,
+          "name": "",
+          "type": "start",
+          "x": 60,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 4,
+          "name": "",
+          "type": "exit",
+          "x": 1800,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 5,
+          "name": "",
+          "type": "platform",
+          "x": 840,
+          "y": 960,
+          "width": 120,
+          "height": 30,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 1020
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 960
+            },
+            {
+              "name": "speed",
+              "type": "int",
+              "value": 150
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "tilesets": [],
+  "nextlayerid": 2,
+  "nextobjectid": 6,
+  "infinite": false
+}

--- a/again/public/levels/level-03.json
+++ b/again/public/levels/level-03.json
@@ -1,0 +1,117 @@
+{
+  "width": 32,
+  "height": 18,
+  "tilewidth": 60,
+  "tileheight": 60,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "version": "1.10",
+  "type": "map",
+  "layers": [
+    {
+      "type": "objectgroup",
+      "name": "entities",
+      "objects": [
+        {
+          "id": 1,
+          "name": "",
+          "type": "solid",
+          "x": 0,
+          "y": 1020,
+          "width": 1920,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 2,
+          "name": "",
+          "type": "solid",
+          "x": 600,
+          "y": 840,
+          "width": 300,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 3,
+          "name": "",
+          "type": "solid",
+          "x": 1020,
+          "y": 660,
+          "width": 300,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 4,
+          "name": "",
+          "type": "solid",
+          "x": 1440,
+          "y": 840,
+          "width": 300,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 5,
+          "name": "",
+          "type": "solid",
+          "x": 1680,
+          "y": 660,
+          "width": 240,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 6,
+          "name": "",
+          "type": "disappearing",
+          "x": 900,
+          "y": 660,
+          "width": 120,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "radius",
+              "type": "int",
+              "value": 180
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "name": "",
+          "type": "start",
+          "x": 60,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 8,
+          "name": "",
+          "type": "exit",
+          "x": 1740,
+          "y": 600,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        }
+      ]
+    }
+  ],
+  "tilesets": [],
+  "nextlayerid": 2,
+  "nextobjectid": 9,
+  "infinite": false
+}

--- a/again/public/levels/level-04.json
+++ b/again/public/levels/level-04.json
@@ -1,0 +1,99 @@
+{
+  "width": 32,
+  "height": 18,
+  "tilewidth": 60,
+  "tileheight": 60,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "version": "1.10",
+  "type": "map",
+  "layers": [
+    {
+      "type": "objectgroup",
+      "name": "entities",
+      "objects": [
+        {
+          "id": 1,
+          "name": "",
+          "type": "solid",
+          "x": 0,
+          "y": 1020,
+          "width": 600,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 2,
+          "name": "",
+          "type": "solid",
+          "x": 960,
+          "y": 1020,
+          "width": 960,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 3,
+          "name": "",
+          "type": "mover",
+          "x": 360,
+          "y": 960,
+          "width": 240,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 600
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 960
+            },
+            {
+              "name": "radius",
+              "type": "int",
+              "value": 200
+            },
+            {
+              "name": "rideable",
+              "type": "bool",
+              "value": true
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "name": "",
+          "type": "start",
+          "x": 60,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 5,
+          "name": "",
+          "type": "exit",
+          "x": 1800,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        }
+      ]
+    }
+  ],
+  "tilesets": [],
+  "nextlayerid": 2,
+  "nextobjectid": 6,
+  "infinite": false
+}

--- a/again/public/levels/level-05.json
+++ b/again/public/levels/level-05.json
@@ -1,0 +1,139 @@
+{
+  "width": 32,
+  "height": 18,
+  "tilewidth": 60,
+  "tileheight": 60,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "version": "1.10",
+  "type": "map",
+  "layers": [
+    {
+      "type": "objectgroup",
+      "name": "entities",
+      "objects": [
+        {
+          "id": 1,
+          "name": "",
+          "type": "solid",
+          "x": 0,
+          "y": 1020,
+          "width": 360,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 2,
+          "name": "",
+          "type": "solid",
+          "x": 1560,
+          "y": 1020,
+          "width": 360,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 3,
+          "name": "",
+          "type": "hazard",
+          "x": 360,
+          "y": 1020,
+          "width": 1200,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "hazardKind",
+              "type": "string",
+              "value": "spike"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "name": "",
+          "type": "solid",
+          "x": 420,
+          "y": 840,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 5,
+          "name": "",
+          "type": "solid",
+          "x": 720,
+          "y": 720,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 6,
+          "name": "",
+          "type": "solid",
+          "x": 1020,
+          "y": 840,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 7,
+          "name": "",
+          "type": "solid",
+          "x": 1320,
+          "y": 720,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 8,
+          "name": "",
+          "type": "solid",
+          "x": 1560,
+          "y": 840,
+          "width": 240,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 9,
+          "name": "",
+          "type": "start",
+          "x": 60,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 10,
+          "name": "",
+          "type": "exit",
+          "x": 1680,
+          "y": 780,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        }
+      ]
+    }
+  ],
+  "tilesets": [],
+  "nextlayerid": 2,
+  "nextobjectid": 11,
+  "infinite": false
+}

--- a/again/public/levels/level-06.json
+++ b/again/public/levels/level-06.json
@@ -1,0 +1,196 @@
+{
+  "width": 32,
+  "height": 18,
+  "tilewidth": 60,
+  "tileheight": 60,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "version": "1.10",
+  "type": "map",
+  "layers": [
+    {
+      "type": "objectgroup",
+      "name": "entities",
+      "objects": [
+        {
+          "id": 1,
+          "name": "",
+          "type": "solid",
+          "x": 0,
+          "y": 1020,
+          "width": 300,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 2,
+          "name": "",
+          "type": "solid",
+          "x": 1620,
+          "y": 1020,
+          "width": 300,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 3,
+          "name": "",
+          "type": "hazard",
+          "x": 300,
+          "y": 1020,
+          "width": 1320,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "hazardKind",
+              "type": "string",
+              "value": "lava"
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "name": "",
+          "type": "platform",
+          "x": 420,
+          "y": 900,
+          "width": 120,
+          "height": 30,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 600
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 900
+            },
+            {
+              "name": "speed",
+              "type": "int",
+              "value": 120
+            }
+          ]
+        },
+        {
+          "id": 5,
+          "name": "",
+          "type": "platform",
+          "x": 780,
+          "y": 840,
+          "width": 120,
+          "height": 30,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 960
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 840
+            },
+            {
+              "name": "speed",
+              "type": "int",
+              "value": 160
+            }
+          ]
+        },
+        {
+          "id": 6,
+          "name": "",
+          "type": "platform",
+          "x": 1140,
+          "y": 900,
+          "width": 120,
+          "height": 30,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 1320
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 900
+            },
+            {
+              "name": "speed",
+              "type": "int",
+              "value": 140
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "name": "",
+          "type": "platform",
+          "x": 1440,
+          "y": 840,
+          "width": 120,
+          "height": 30,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 1560
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 840
+            },
+            {
+              "name": "speed",
+              "type": "int",
+              "value": 120
+            }
+          ]
+        },
+        {
+          "id": 8,
+          "name": "",
+          "type": "start",
+          "x": 60,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 9,
+          "name": "",
+          "type": "exit",
+          "x": 1800,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        }
+      ]
+    }
+  ],
+  "tilesets": [],
+  "nextlayerid": 2,
+  "nextobjectid": 10,
+  "infinite": false
+}

--- a/again/public/levels/level-07.json
+++ b/again/public/levels/level-07.json
@@ -1,0 +1,144 @@
+{
+  "width": 32,
+  "height": 18,
+  "tilewidth": 60,
+  "tileheight": 60,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "version": "1.10",
+  "type": "map",
+  "layers": [
+    {
+      "type": "objectgroup",
+      "name": "entities",
+      "objects": [
+        {
+          "id": 1,
+          "name": "",
+          "type": "solid",
+          "x": 0,
+          "y": 1020,
+          "width": 1920,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 2,
+          "name": "",
+          "type": "solid",
+          "x": 0,
+          "y": 480,
+          "width": 1920,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 3,
+          "name": "",
+          "type": "solid",
+          "x": 0,
+          "y": 540,
+          "width": 60,
+          "height": 480,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 4,
+          "name": "",
+          "type": "solid",
+          "x": 1860,
+          "y": 540,
+          "width": 60,
+          "height": 480,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 5,
+          "name": "",
+          "type": "movingHazard",
+          "x": 300,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 1560
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 960
+            },
+            {
+              "name": "speed",
+              "type": "int",
+              "value": 200
+            }
+          ]
+        },
+        {
+          "id": 6,
+          "name": "",
+          "type": "movingHazard",
+          "x": 900,
+          "y": 600,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 1200
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 600
+            },
+            {
+              "name": "speed",
+              "type": "int",
+              "value": 180
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "name": "",
+          "type": "start",
+          "x": 60,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 8,
+          "name": "",
+          "type": "exit",
+          "x": 1800,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        }
+      ]
+    }
+  ],
+  "tilesets": [],
+  "nextlayerid": 2,
+  "nextobjectid": 9,
+  "infinite": false
+}

--- a/again/public/levels/level-08.json
+++ b/again/public/levels/level-08.json
@@ -1,0 +1,150 @@
+{
+  "width": 32,
+  "height": 18,
+  "tilewidth": 60,
+  "tileheight": 60,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "version": "1.10",
+  "type": "map",
+  "layers": [
+    {
+      "type": "objectgroup",
+      "name": "entities",
+      "objects": [
+        {
+          "id": 1,
+          "name": "",
+          "type": "solid",
+          "x": 0,
+          "y": 1020,
+          "width": 420,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 2,
+          "name": "",
+          "type": "solid",
+          "x": 660,
+          "y": 1020,
+          "width": 300,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 3,
+          "name": "",
+          "type": "solid",
+          "x": 1200,
+          "y": 1020,
+          "width": 720,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 4,
+          "name": "",
+          "type": "solid",
+          "x": 1200,
+          "y": 840,
+          "width": 240,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 5,
+          "name": "",
+          "type": "solid",
+          "x": 1560,
+          "y": 840,
+          "width": 360,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 6,
+          "name": "",
+          "type": "disappearing",
+          "x": 420,
+          "y": 1020,
+          "width": 240,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "radius",
+              "type": "int",
+              "value": 150
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "name": "",
+          "type": "mover",
+          "x": 1200,
+          "y": 960,
+          "width": 240,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 960
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 960
+            },
+            {
+              "name": "radius",
+              "type": "int",
+              "value": 200
+            },
+            {
+              "name": "rideable",
+              "type": "bool",
+              "value": true
+            }
+          ]
+        },
+        {
+          "id": 8,
+          "name": "",
+          "type": "start",
+          "x": 60,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 9,
+          "name": "",
+          "type": "exit",
+          "x": 1800,
+          "y": 780,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        }
+      ]
+    }
+  ],
+  "tilesets": [],
+  "nextlayerid": 2,
+  "nextobjectid": 10,
+  "infinite": false
+}

--- a/again/public/levels/level-09.json
+++ b/again/public/levels/level-09.json
@@ -1,0 +1,275 @@
+{
+  "width": 32,
+  "height": 18,
+  "tilewidth": 60,
+  "tileheight": 60,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "version": "1.10",
+  "type": "map",
+  "layers": [
+    {
+      "type": "objectgroup",
+      "name": "entities",
+      "objects": [
+        {
+          "id": 1,
+          "name": "",
+          "type": "solid",
+          "x": 0,
+          "y": 1020,
+          "width": 360,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 2,
+          "name": "",
+          "type": "hazard",
+          "x": 360,
+          "y": 1020,
+          "width": 480,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "hazardKind",
+              "type": "string",
+              "value": "spike"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "name": "",
+          "type": "solid",
+          "x": 840,
+          "y": 1020,
+          "width": 120,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 4,
+          "name": "",
+          "type": "hazard",
+          "x": 960,
+          "y": 1020,
+          "width": 480,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "hazardKind",
+              "type": "string",
+              "value": "lava"
+            }
+          ]
+        },
+        {
+          "id": 5,
+          "name": "",
+          "type": "solid",
+          "x": 1440,
+          "y": 1020,
+          "width": 480,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 6,
+          "name": "",
+          "type": "solid",
+          "x": 420,
+          "y": 840,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 7,
+          "name": "",
+          "type": "solid",
+          "x": 720,
+          "y": 720,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 8,
+          "name": "",
+          "type": "solid",
+          "x": 1200,
+          "y": 840,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 9,
+          "name": "",
+          "type": "solid",
+          "x": 1560,
+          "y": 720,
+          "width": 240,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 10,
+          "name": "",
+          "type": "solid",
+          "x": 1680,
+          "y": 540,
+          "width": 240,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 11,
+          "name": "",
+          "type": "platform",
+          "x": 1020,
+          "y": 900,
+          "width": 120,
+          "height": 30,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 1200
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 900
+            },
+            {
+              "name": "speed",
+              "type": "int",
+              "value": 150
+            }
+          ]
+        },
+        {
+          "id": 12,
+          "name": "",
+          "type": "disappearing",
+          "x": 600,
+          "y": 720,
+          "width": 120,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "radius",
+              "type": "int",
+              "value": 160
+            }
+          ]
+        },
+        {
+          "id": 13,
+          "name": "",
+          "type": "mover",
+          "x": 1440,
+          "y": 780,
+          "width": 120,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 1560
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 660
+            },
+            {
+              "name": "radius",
+              "type": "int",
+              "value": 180
+            },
+            {
+              "name": "rideable",
+              "type": "bool",
+              "value": true
+            }
+          ]
+        },
+        {
+          "id": 14,
+          "name": "",
+          "type": "movingHazard",
+          "x": 840,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 960
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 960
+            },
+            {
+              "name": "speed",
+              "type": "int",
+              "value": 180
+            }
+          ]
+        },
+        {
+          "id": 15,
+          "name": "",
+          "type": "start",
+          "x": 60,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 16,
+          "name": "",
+          "type": "exit",
+          "x": 1800,
+          "y": 480,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        }
+      ]
+    }
+  ],
+  "tilesets": [],
+  "nextlayerid": 2,
+  "nextobjectid": 17,
+  "infinite": false
+}

--- a/again/public/levels/level-10.json
+++ b/again/public/levels/level-10.json
@@ -1,0 +1,396 @@
+{
+  "width": 32,
+  "height": 18,
+  "tilewidth": 60,
+  "tileheight": 60,
+  "orientation": "orthogonal",
+  "renderorder": "right-down",
+  "version": "1.10",
+  "type": "map",
+  "layers": [
+    {
+      "type": "objectgroup",
+      "name": "entities",
+      "objects": [
+        {
+          "id": 1,
+          "name": "",
+          "type": "solid",
+          "x": 0,
+          "y": 1020,
+          "width": 300,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 2,
+          "name": "",
+          "type": "hazard",
+          "x": 300,
+          "y": 1020,
+          "width": 360,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "hazardKind",
+              "type": "string",
+              "value": "spike"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "name": "",
+          "type": "solid",
+          "x": 660,
+          "y": 1020,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 4,
+          "name": "",
+          "type": "hazard",
+          "x": 840,
+          "y": 1020,
+          "width": 600,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "hazardKind",
+              "type": "string",
+              "value": "lava"
+            }
+          ]
+        },
+        {
+          "id": 5,
+          "name": "",
+          "type": "solid",
+          "x": 1440,
+          "y": 1020,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 6,
+          "name": "",
+          "type": "hazard",
+          "x": 1620,
+          "y": 1020,
+          "width": 300,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "hazardKind",
+              "type": "string",
+              "value": "lava"
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "name": "",
+          "type": "solid",
+          "x": 360,
+          "y": 840,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 8,
+          "name": "",
+          "type": "solid",
+          "x": 660,
+          "y": 720,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 9,
+          "name": "",
+          "type": "solid",
+          "x": 1020,
+          "y": 840,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 10,
+          "name": "",
+          "type": "solid",
+          "x": 1320,
+          "y": 720,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 11,
+          "name": "",
+          "type": "solid",
+          "x": 1620,
+          "y": 600,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 12,
+          "name": "",
+          "type": "solid",
+          "x": 1740,
+          "y": 420,
+          "width": 180,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 13,
+          "name": "",
+          "type": "disappearing",
+          "x": 540,
+          "y": 840,
+          "width": 120,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "radius",
+              "type": "int",
+              "value": 150
+            }
+          ]
+        },
+        {
+          "id": 14,
+          "name": "",
+          "type": "disappearing",
+          "x": 900,
+          "y": 720,
+          "width": 120,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "radius",
+              "type": "int",
+              "value": 160
+            }
+          ]
+        },
+        {
+          "id": 15,
+          "name": "",
+          "type": "mover",
+          "x": 1200,
+          "y": 780,
+          "width": 120,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 1320
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 660
+            },
+            {
+              "name": "radius",
+              "type": "int",
+              "value": 200
+            },
+            {
+              "name": "rideable",
+              "type": "bool",
+              "value": true
+            }
+          ]
+        },
+        {
+          "id": 16,
+          "name": "",
+          "type": "platform",
+          "x": 900,
+          "y": 900,
+          "width": 120,
+          "height": 30,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 1080
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 900
+            },
+            {
+              "name": "speed",
+              "type": "int",
+              "value": 140
+            }
+          ]
+        },
+        {
+          "id": 17,
+          "name": "",
+          "type": "platform",
+          "x": 1500,
+          "y": 720,
+          "width": 120,
+          "height": 30,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 1620
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 720
+            },
+            {
+              "name": "speed",
+              "type": "int",
+              "value": 160
+            }
+          ]
+        },
+        {
+          "id": 18,
+          "name": "",
+          "type": "movingHazard",
+          "x": 660,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 840
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 960
+            },
+            {
+              "name": "speed",
+              "type": "int",
+              "value": 200
+            }
+          ]
+        },
+        {
+          "id": 19,
+          "name": "",
+          "type": "movingHazard",
+          "x": 1440,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "toX",
+              "type": "int",
+              "value": 1620
+            },
+            {
+              "name": "toY",
+              "type": "int",
+              "value": 960
+            },
+            {
+              "name": "speed",
+              "type": "int",
+              "value": 220
+            }
+          ]
+        },
+        {
+          "id": 20,
+          "name": "",
+          "type": "decoration",
+          "x": 0,
+          "y": 0,
+          "width": 1920,
+          "height": 60,
+          "visible": true,
+          "rotation": 0,
+          "properties": [
+            {
+              "name": "color",
+              "type": "string",
+              "value": "#1a1a2e"
+            }
+          ]
+        },
+        {
+          "id": 21,
+          "name": "",
+          "type": "start",
+          "x": 60,
+          "y": 960,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        },
+        {
+          "id": 22,
+          "name": "",
+          "type": "exit",
+          "x": 1800,
+          "y": 360,
+          "width": 60,
+          "height": 60,
+          "visible": true,
+          "rotation": 0
+        }
+      ]
+    }
+  ],
+  "tilesets": [],
+  "nextlayerid": 2,
+  "nextobjectid": 23,
+  "infinite": false
+}

--- a/again/src/main.tsx
+++ b/again/src/main.tsx
@@ -1,0 +1,21 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Home from '../app/Home';
+import LevelSelect from '../app/LevelSelect';
+import Game from '../app/Game';
+import NotFound from '../app/NotFound';
+import '../app/globals.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/levels" element={<LevelSelect />} />
+        <Route path="/play/:id" element={<Game />} />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </BrowserRouter>
+  </StrictMode>
+);

--- a/again/src/vite-env.d.ts
+++ b/again/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/again/tsconfig.json
+++ b/again/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "paths": { "@/*": ["./*"] }
+  },
+  "include": ["src", "app", "_game", "_engine", "_levels", "_progress"]
+}

--- a/again/vite.config.ts
+++ b/again/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: { host: '127.0.0.1', port: 3004, strictPort: true },
+  preview: { host: '127.0.0.1', port: 3004, strictPort: true },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+});

--- a/again/vitest.config.ts
+++ b/again/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts'],
+    pool: 'vmThreads',
+    poolOptions: {
+      vmThreads: {
+        singleThread: true,
+      },
+    },
+  },
+});

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,16 @@
         "vite": "^6.4.2",
       },
     },
+    "again": {
+      "name": "again",
+      "version": "1.0.0",
+      "dependencies": {
+        "phaser": "^3.90.0",
+      },
+      "devDependencies": {
+        "vitest": "^3.0.0",
+      },
+    },
     "algo-compendium": {
       "name": "algo-compendium",
       "version": "1.0.0",
@@ -458,6 +468,8 @@
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "again": ["again@workspace:again"],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
@@ -1010,6 +1022,8 @@
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "phaser": ["phaser@3.90.0", "", { "dependencies": { "eventemitter3": "^5.0.1" } }, "sha512-/cziz/5ZIn02uDkC9RzN8VF9x3Gs3XdFFf9nkiMEQT3p7hQlWuyjy4QWosU802qqno2YSLn2BfqwOKLv/sSVfQ=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "workspaces": [
     "./bilbatez.dev",
     "./kprfordummies",
-    "./algo-compendium"
+    "./algo-compendium",
+    "./again"
   ],
   "scripts": {
     "postinstall": "[ \"$PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD\" = \"1\" ] || bun playwright install",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -70,5 +70,13 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
       timeout: 120_000,
     },
+    {
+      command: process.env.CI
+        ? 'bun run --filter "again" preview'
+        : 'bun run --filter "again" dev',
+      url: 'http://127.0.0.1:3004',
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
   ],
 });

--- a/tests/again/pom/game-page.ts
+++ b/tests/again/pom/game-page.ts
@@ -1,0 +1,25 @@
+import type { Page } from '@playwright/test';
+
+export class GamePage {
+  constructor(private page: Page) {}
+
+  async goto(levelId = 1) {
+    await this.page.goto(`http://127.0.0.1:3004/play/${levelId}`);
+  }
+
+  get canvas() {
+    return this.page.locator('canvas');
+  }
+
+  get hudHomeButton() {
+    return this.page.getByRole('button', { name: /home/i });
+  }
+
+  get smallScreenOverlay() {
+    return this.page.getByText(/screen too small/i);
+  }
+
+  get winPopup() {
+    return this.page.getByText(/level complete|you beat the game/i);
+  }
+}

--- a/tests/again/pom/home-page.ts
+++ b/tests/again/pom/home-page.ts
@@ -1,0 +1,21 @@
+import type { Page } from '@playwright/test';
+
+export class HomePage {
+  constructor(private page: Page) {}
+
+  async goto() {
+    await this.page.goto('http://127.0.0.1:3004/');
+  }
+
+  get playButton() {
+    return this.page.getByRole('button', { name: /play|continue/i });
+  }
+
+  get levelSelectButton() {
+    return this.page.getByRole('button', { name: /level select/i });
+  }
+
+  get title() {
+    return this.page.getByRole('heading', { name: 'again' });
+  }
+}

--- a/tests/again/spec/game.spec.ts
+++ b/tests/again/spec/game.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+import { GamePage } from '../pom/game-page';
+
+test.describe('Game screen', () => {
+  test('shows canvas on /play/1', async ({ page }) => {
+    const game = new GamePage(page);
+    await game.goto(1);
+    await expect(game.canvas).toBeVisible();
+  });
+
+  test('shows HUD home button', async ({ page }) => {
+    const game = new GamePage(page);
+    await game.goto(1);
+    await expect(game.hudHomeButton).toBeVisible();
+  });
+
+  test('Home button navigates back to /', async ({ page }) => {
+    const game = new GamePage(page);
+    await game.goto(1);
+    await game.hudHomeButton.click();
+    await expect(page).toHaveURL('http://127.0.0.1:3004/');
+  });
+
+  test('shows small screen overlay on narrow viewport', async ({ browser }) => {
+    // MIN_SCREEN_PX = 1024; use 800px to trigger the overlay
+    const context = await browser.newContext({
+      viewport: { width: 800, height: 600 },
+    });
+    const page = await context.newPage();
+    const game = new GamePage(page);
+    await game.goto(1);
+    await expect(game.smallScreenOverlay).toBeVisible();
+    await context.close();
+  });
+
+  test('does not show small screen overlay on wide viewport', async ({
+    browser,
+  }) => {
+    // MIN_SCREEN_PX = 1024; use 1280px to stay above threshold
+    const context = await browser.newContext({
+      viewport: { width: 1280, height: 720 },
+    });
+    const page = await context.newPage();
+    const game = new GamePage(page);
+    await game.goto(1);
+    await expect(game.smallScreenOverlay).not.toBeVisible();
+    await context.close();
+  });
+});

--- a/tests/again/spec/home.spec.ts
+++ b/tests/again/spec/home.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+import { HomePage } from '../pom/home-page';
+
+test.describe('Home screen', () => {
+  test('shows title and Play button', async ({ page }) => {
+    const home = new HomePage(page);
+    await home.goto();
+    await expect(home.title).toBeVisible();
+    await expect(home.playButton).toBeVisible();
+  });
+
+  test('hides Level Select when no progress', async ({ page }) => {
+    // Clear any cookies from prior tests
+    await page.context().clearCookies();
+    const home = new HomePage(page);
+    await home.goto();
+    await expect(home.levelSelectButton).not.toBeVisible();
+  });
+
+  test('shows Level Select when level 1 passed', async ({ page }) => {
+    await page.context().clearCookies();
+    // Set the progress cookie — value must be URL-encoded to match cookie.ts setCookie()
+    await page.context().addCookies([
+      {
+        name: 'again_progress',
+        value: encodeURIComponent(JSON.stringify({ maxLevelPassed: 1 })),
+        url: 'http://127.0.0.1:3004',
+      },
+    ]);
+    const home = new HomePage(page);
+    await home.goto();
+    await expect(home.levelSelectButton).toBeVisible();
+  });
+
+  test('Play button navigates to /play/1 when no progress', async ({
+    page,
+  }) => {
+    await page.context().clearCookies();
+    const home = new HomePage(page);
+    await home.goto();
+    await home.playButton.click();
+    await expect(page).toHaveURL(/\/play\/1/);
+  });
+});

--- a/tests/again/spec/progress.spec.ts
+++ b/tests/again/spec/progress.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Level select progress', () => {
+  test('shows levels 1 and 2 when level 1 passed', async ({ page }) => {
+    await page.context().clearCookies();
+    await page.context().addCookies([
+      {
+        name: 'again_progress',
+        value: encodeURIComponent(JSON.stringify({ maxLevelPassed: 1 })),
+        url: 'http://127.0.0.1:3004',
+      },
+    ]);
+    await page.goto('http://127.0.0.1:3004/levels');
+    // Level 1 and 2 should be enabled buttons (unlocked = [1, 2] when maxLevelPassed = 1).
+    // Match by level name — number prefixes collide (/^1/ also matches level 10).
+    const level1 = page.getByRole('button', { name: 'First Steps' });
+    const level2 = page.getByRole('button', { name: 'Moving On' });
+    await expect(level1).toBeEnabled();
+    await expect(level2).toBeEnabled();
+  });
+
+  test('level 4 is locked when only levels 1-2 passed', async ({ page }) => {
+    await page.context().clearCookies();
+    await page.context().addCookies([
+      {
+        name: 'again_progress',
+        value: encodeURIComponent(JSON.stringify({ maxLevelPassed: 2 })),
+        url: 'http://127.0.0.1:3004',
+      },
+    ]);
+    await page.goto('http://127.0.0.1:3004/levels');
+    // unlocked = [1, 2, 3] when maxLevelPassed = 2; level 4 is still locked
+    const level4 = page.getByRole('button', { name: 'Bridge Builder' });
+    await expect(level4).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `again/` workspace (port 3004) — browser platformer game with Phaser 3 engine
- 10 hand-authored Tiled JSON levels of rising difficulty
- Proximity triggers: disappearing blocks (permanent) + movers (one-shot)
- Home screen with Play/Continue + Level Select (unlocked via cookie progress)
- Level complete popup with Next button; last level returns to Home

## Architecture

- **React shell** — routing, Home, LevelSelect, Game screens, overlays (DOM)
- **Phaser 3** — in-level gameplay only; Scale.FIT + CENTER_BOTH for 1920×1080 scale-to-fit
- **Pure TS engine** — `_engine/`, `_levels/`, `_progress/` (no Phaser/React, vitest-tested)
- **Tiled JSON levels** — `public/levels/level-NN.json`, object-layer only, no tileset image
- **Sprite-swap seam** — `_game/sprites.ts:textureFor()` colored rects today, swap to real sprites later without touching game logic

## Test plan

- [ ] `bun run --filter again test:unit` — 23 vitest tests pass (triggers, parse, validate, cookie)
- [ ] `bun run --filter again dev` → http://localhost:3004 — Home screen renders
- [ ] Play level 1: player moves, jumps over gap, reaches green exit → Congrats popup
- [ ] Play level 2: player rides moving blue platform across gap
- [ ] Level Select hidden on fresh start; appears after clearing level 1
- [ ] Shrink window below 1024px → "Screen Too Small" overlay appears
- [ ] CI: `bun run --filter again build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)